### PR TITLE
Reserving more memory in advance in important operation of LRA solver

### DIFF
--- a/src/tsolvers/lrasolver/Polynomial.cpp
+++ b/src/tsolvers/lrasolver/Polynomial.cpp
@@ -100,7 +100,7 @@ void
 Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, std::function<void(LVRef)> informAdded,
                   std::function<void(LVRef)> informRemoved) {
     decltype(poly) merged;
-    merged.reserve(std::max(this->poly.size(),other.poly.size()));
+    merged.reserve(this->poly.size() + other.poly.size());
     auto myIt = std::make_move_iterator(poly.begin());
     auto otherIt = other.poly.cbegin();
     auto myEnd = std::make_move_iterator(poly.end());


### PR DESCRIPTION
Attached is the comparison of performance on latest SMT-LIB QF_LRA. It is not always better, but overall, there is a tiny performance gain and one more problem solved.
[comparison.pdf](https://github.com/usi-verification-and-security/opensmt/files/3201830/comparison.pdf)
