### PR TITLE
Small improvement by re-using memory in important loop

### DIFF
--- a/src/tsolvers/lrasolver/Polynomial.cpp
+++ b/src/tsolvers/lrasolver/Polynomial.cpp
@@ -145,6 +145,56 @@ Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, std::func
     poly.shrink_to_fit();
 }
 
+void
+Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, std::function<void(LVRef)> informAdded,
+                  std::function<void(LVRef)> informRemoved, std::vector<Term>& storage) {
+    storage.reserve(this->poly.size() + other.poly.size());
+    auto myIt = std::make_move_iterator(poly.begin());
+    auto otherIt = other.poly.cbegin();
+    auto myEnd = std::make_move_iterator(poly.end());
+    auto otherEnd = other.poly.cend();
+    TermCmp cmp;
+    while(true) {
+        if (myIt == myEnd) {
+            for (auto it = otherIt; it != otherEnd; ++it) {
+                storage.emplace_back(it->var, it->coeff * coeff);
+                informAdded(it->var);
+            }
+            break;
+        }
+        if (otherIt == otherEnd) {
+            storage.insert(storage.end(), myIt, myEnd);
+            break;
+        }
+        if(cmp(*myIt, *otherIt)) {
+            storage.emplace_back(*myIt);
+            ++myIt;
+        }
+        else if (cmp(*otherIt, *myIt)) {
+            storage.emplace_back(otherIt->var, otherIt->coeff * coeff);
+            informAdded(otherIt->var);
+            ++otherIt;
+        }
+        else {
+            assert(myIt->var == otherIt->var);
+            auto mergedCoeff = otherIt->coeff * coeff;
+            mergedCoeff += myIt->coeff;
+            if (mergedCoeff.isZero()) {
+                informRemoved(myIt->var);
+            }
+            else {
+                storage.emplace_back(myIt->var, std::move(mergedCoeff));
+            }
+            ++myIt;
+            ++otherIt;
+        }
+    }
+    std::vector<Term>(std::make_move_iterator(storage.begin()), std::make_move_iterator(storage.end())).swap(poly);
+    storage.clear();
+}
+
+
+
 void Polynomial::print() const {
     for (auto & term : poly) {
         std::cout << term.coeff << " * " << term.var.x << "v + ";

--- a/src/tsolvers/lrasolver/Polynomial.cpp
+++ b/src/tsolvers/lrasolver/Polynomial.cpp
@@ -68,7 +68,7 @@ Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff) {
             merged.insert(merged.end(), myIt, myEnd);
             break;
         }
-        if(cmp(*myIt, *otherIt)) {
+        if (cmp(*myIt, *otherIt)) {
             merged.emplace_back(*myIt);
             ++myIt;
         }
@@ -118,7 +118,7 @@ Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, std::func
             merged.insert(merged.end(), myIt, myEnd);
             break;
         }
-        if(cmp(*myIt, *otherIt)) {
+        if (cmp(*myIt, *otherIt)) {
             merged.emplace_back(*myIt);
             ++myIt;
         }
@@ -166,7 +166,7 @@ Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, std::func
             storage.insert(storage.end(), myIt, myEnd);
             break;
         }
-        if(cmp(*myIt, *otherIt)) {
+        if (cmp(*myIt, *otherIt)) {
             storage.emplace_back(*myIt);
             ++myIt;
         }

--- a/src/tsolvers/lrasolver/Polynomial.h
+++ b/src/tsolvers/lrasolver/Polynomial.h
@@ -23,6 +23,7 @@ struct MergeResult{
 };
 
 class Polynomial{
+    friend class Tableau;
 private:
     struct Term {
         LVRef var;
@@ -43,9 +44,14 @@ public:
     opensmt::Real removeVar(LVRef var);
     void negate();
     void divideBy(const opensmt::Real& r);
+
     MergeResult merge(const Polynomial & other, const opensmt::Real & coeff);
+
     void merge(const Polynomial & other, const opensmt::Real & coeff, std::function<void(LVRef)> informAdded,
                std::function<void(LVRef)> informRemoved);
+
+    void merge(const Polynomial & other, const opensmt::Real & coeff, std::function<void(LVRef)> informAdded,
+               std::function<void(LVRef)> informRemoved, std::vector<Term>& storage);
 
     using iterator = poly_t::iterator;
     using const_iterator = poly_t::const_iterator;

--- a/src/tsolvers/lrasolver/Tableau.cpp
+++ b/src/tsolvers/lrasolver/Tableau.cpp
@@ -156,6 +156,7 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
         removeRowFromColumn(bv, var);
         addRowToColumn(nv, var);
     }
+    std::vector<Polynomial::Term> storage;
     // for all (active) rows containing nv, substitute
     for (auto rowVar : getColumn(bv)) {
         if(rowVar == nv || !isActive(rowVar)) {
@@ -178,6 +179,7 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
                        assert(contains(getColumn(removedVar), rowVar));
                        removeRowFromColumn(rowVar, removedVar);
                    }
+                   , storage
         );
     }
     assert(!cols[nv.x]);


### PR DESCRIPTION
After pivot operation, tableau representation needs to be updated.
Instead of allocating and deallocating helper vector in each iteration, allocate once at the before the loop and reuse.

See the attached comparison.
[comparison_reuse.pdf](https://github.com/usi-verification-and-security/opensmt/files/3211800/comparison_reuse.pdf)
