### PR TITLE
Fixing issue #19

### DIFF
--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -333,8 +333,8 @@ private:
   // Asserting literals
   //
 public:
-  lbool       addDisequality      ( PtAsgn );
-  lbool       addEquality         ( PtAsgn );
+  bool       addDisequality      ( PtAsgn );
+  bool       addEquality         ( PtAsgn );
   bool       addTrue             ( PTRef );
   bool       addFalse            ( PTRef );
 


### PR DESCRIPTION
Fixed possible assertion of equality to Egraph solver when its state is already unsatisfiable.
Also, the information about the state after assertion is stored as bool, no need for l_bool, since only l_False (conflict) and l_Undef (no conflict) were used.