### PR TITLE
Fixing method Logic::getNestedBoolRoots to traverse the PTerm structure as a DAG and not as a tree.

### DIFF
--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -460,11 +460,13 @@ vec<PTRef> Logic::getNestedBoolRoots(PTRef root) const {
     vec<PTRef> nestedBoolRoots;
 
     vec<PTRef> queue;
+    std::unordered_set<PTRef, PTRefHash> processed;
     queue.push(root);
 
     while (queue.size() != 0) {
         PTRef tr = queue.last();
         queue.pop();
+        if (processed.find(tr) != processed.end()) { continue; } // already processed
         const Pterm& t = getPterm(tr);
         for (int i = 0; i < t.size(); i++) {
             queue.push(t[i]);
@@ -472,6 +474,7 @@ vec<PTRef> Logic::getNestedBoolRoots(PTRef root) const {
                 nestedBoolRoots.push(t[i]);
             }
         }
+        processed.insert(tr);
     }
     return std::move(nestedBoolRoots);
 }

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -476,7 +476,7 @@ vec<PTRef> Logic::getNestedBoolRoots(PTRef root) const {
         }
         processed.insert(tr);
     }
-    return std::move(nestedBoolRoots);
+    return nestedBoolRoots;
 }
 
 


### PR DESCRIPTION
I used std::unordered_set as a cache. Would you prefer the Map from minisat?

Also, returning using move in this case is not a good idea, it prevents Return Value Optimization.