### PR TITLE
Small optimizations in preprocessing and small cleanup

### DIFF
--- a/src/api/MainSolver.C
+++ b/src/api/MainSolver.C
@@ -95,7 +95,6 @@ MainSolver::insertFormula(PTRef root, char** msg)
     lastFrame.units.clear();
     lastFrame.root = PTRef_Undef;
     lastFrame.substs = logic.getTerm_true();
-    lastFrame.nestedBoolRoots = logic.getNestedBoolRoots(root);
     // New formula has been added to the last frame. If the frame has been simplified before, we need to do it again
     frames.setSimplifiedUntil(std::min(frames.getSimplifiedUntil(), frames.size() - 1));
     return s_Undef;
@@ -158,8 +157,6 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
         // Stop if problem becomes unsatisfiable
         if ((status = giveToSolver(fc.getRoot(), frame.getId())) == s_False)
             break;
-        declareToSolver(frame.nestedBoolRoots, frame.getId());
-        ts.declareVars(logic.propFormulasAppearingInUF);
 #endif
     }
     return status;

--- a/src/api/MainSolver.C
+++ b/src/api/MainSolver.C
@@ -135,7 +135,7 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
                 logic.transferPartitionMembership(old, fla);
             }
             assert(logic.getPartitionIndex(fla) != -1);
-            logic.computePartitionMasks(fla);
+            logic.propagatePartitionMask(fla);
             if ((status = giveToSolver(fla, frame.getId())) == s_False) {
                 return s_False;
             }

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -122,10 +122,6 @@ class MainSolver
         PTRef getRoot   ()        const         { return root; }
     };
 
-    void declareToSolver(const vec<PTRef>& nestedBoolRoots, FrameId push_id) {
-        ts.declareToSolver(nestedBoolRoots, push_id);
-    }
-
     sstat giveToSolver(PTRef root, FrameId push_id) {
         if (ts.cnfizeAndGiveToSolver(root, push_id) == l_False) return s_False;
         return s_Undef; }

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -62,7 +62,6 @@ public:
     virtual ~Cnfizer( ) { }
 
     lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id); // Main routine
-    void  declareVars    (vec<PTRef>&); // Declare a set of Boolean atoms to the solver (without asserting them)
 
     lbool  getTermValue(PTRef) const;
 
@@ -77,7 +76,7 @@ protected:
     virtual bool cnfize                 ( PTRef ) = 0; // Cnfize and assert the top-level.  Calls declare.
     virtual bool declare                ( vec<PTRef>&, PTRef root ) = 0;  // Actual cnfization. To be implemented in derived classes
     bool     deMorganize                ( PTRef );                                    // Apply deMorgan rules whenever feasible
-
+    void     declareVars                (vec<PTRef>&); // Declare a set of Boolean atoms to the solver (without asserting them)
 
 public:
     bool     checkClause                ( PTRef ); // Check if a formula is a clause

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -62,7 +62,6 @@ public:
     virtual ~Cnfizer( ) { }
 
     lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id); // Main routine
-    void  declareToSolver(const vec<PTRef>& nestedBoolRoots, FrameId frame_id); // Entry point for declaring.
     void  declareVars    (vec<PTRef>&); // Declare a set of Boolean atoms to the solver (without asserting them)
 
     lbool  getTermValue(PTRef) const;
@@ -102,6 +101,7 @@ private:
 
 protected:
     inline Lit getOrCreateLiteralFor(PTRef ptr) {return this->tmap.getOrCreateLit(ptr);}
+    inline vec<PTRef> getNestedBoolRoots(PTRef ptr) { return logic.getNestedBoolRoots(ptr); }
 
     // PROOF version
     int currentPartition = -1;

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -163,6 +163,9 @@ public:
     virtual char *printTerm(PTRef tr) const override;
     virtual char *printTerm(PTRef tr, bool l, bool s) const override;
 
+    // MB: In pure LA, there are never nested boolean terms
+    virtual vec<PTRef> getNestedBoolRoots (PTRef tr)  const override { return vec<PTRef>(); }
+
 };
 // Determine for two multiplicative terms (* k1 v1) and (* k2 v2), v1 !=
 // v2 which one is smaller, based on the PTRef of v1 and v2.  (i.e.

--- a/src/logics/LRATheory.C
+++ b/src/logics/LRATheory.C
@@ -9,7 +9,7 @@ bool LRATheory::simplify(const vec<PFRef>& formulas, int curr)
 {
 #ifdef PRODUCE_PROOF
     vec<PTRef> & flas = pfstore[formulas[curr]].formulas;
-    for(int i = 0; i <flas.size(); ++i) {
+    for(int i = 0; i < flas.size(); ++i) {
         PTRef & fla = flas[i];
         lralogic.simplifyAndSplitEq(fla, fla);
     }

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -566,17 +566,17 @@ bool Logic::simplifyEquality(PtChild& ptc, bool simplify) {
 void Logic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
 {
     Pterm& p = getPterm(tr);
-    vec<PTRef> newargs;
+    vec<PTRef> newargs(p.size());
     char *msg;
     bool changed = false;
     for (int i = 0; i < p.size(); ++i) {
         PTRef tr = p[i];
         if (tr_map.has(tr)) {
             changed |= (tr_map[tr] != tr);
-            newargs.push(tr_map[tr]);
+            newargs[i] = tr_map[tr];
         }
         else
-            newargs.push(tr);
+            newargs[i] = tr;
     }
     if (!changed) {return;}
     PTRef trp = insertTerm(p.symb(), newargs, &msg);
@@ -626,8 +626,9 @@ void Logic::simplifyTree(PTRef tr, PTRef& root_out)
                 }
             }
             queue[i].done = true;
+            if (unprocessed_children) continue;
         }
-        if (unprocessed_children) continue;
+        assert(!unprocessed_children);
 #ifdef SIMPLIFY_DEBUG
         cerr << "Found a node " << queue[i].x.x << endl;
         cerr << "Before simplification it looks like " << this->printTerm(queue[i].x) << endl;

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -1154,10 +1154,8 @@ PTRef Logic::insertTerm(SymRef sym, vec<PTRef>& terms, char** msg)
 }
 
 PTRef
-Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms_in)
+Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms)
 {
-    vec<PTRef> terms;
-    terms_in.copyTo(terms);
     PTRef res = PTRef_Undef;
     char *msg;
     if (terms.size() == 0) {
@@ -1169,9 +1167,6 @@ Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms_in)
         }
     }
     else if (!isBooleanOperator(sym)) {
-        if (sym_store[sym].commutes()) {
-            termSort(terms);
-        }
         if (!sym_store[sym].left_assoc() &&
             !sym_store[sym].right_assoc() &&
             !sym_store[sym].chainable() &&
@@ -1185,10 +1180,13 @@ Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms_in)
         PTLKey k;
         k.sym = sym;
         terms.copyTo(k.args);
+        if (sym_store[sym].commutes()) {
+            termSort(k.args);
+        }
         if (term_store.hasCplxKey(k))
             res = term_store.getFromCplxMap(k);
         else {
-            res = term_store.newTerm(sym, terms);
+            res = term_store.newTerm(sym, k.args);
             term_store.addToCplxMap(k, res);
         }
     }

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -2154,22 +2154,24 @@ void Logic::conjoinItes(PTRef root, PTRef& new_root)
 
 #ifdef PRODUCE_PROOF
 
-// Given a vector roots of ptrefs, compute the partitions for each term rooted at roots
-// so that a term has the partitions of its ancestors.
-void Logic::computePartitionMasks(const vec<PTRef> &roots) {
+void Logic::propagatePartitionMask(PTRef root) {
+    ipartitions_t& p = getIPartitions(root);
+    Map<PTRef, bool, PTRefHash> seen;
+    std::vector<PTRef> queue {root};
 
-    vec<PtChild> list_out;
-    getTermsList(roots, list_out, *this);
-    for (int i = list_out.size()-1; i >= 0; i--)
-    {
-        PTRef tr = list_out[i].tr;
-        Pterm& t = getPterm(tr);
-        ipartitions_t& p = getIPartitions(tr);
-        for (int j = 0; j < t.size(); j++) {
-            addIPartitions(t[j], p);
-        }
-        if (isUF(tr) || isUP(tr)) {
-            addIPartitions(t.symb(), p);
+    while (!queue.empty()) {
+        PTRef current = queue.back();
+        queue.pop_back();
+        if (!seen.has(current)) {
+            const Pterm& c_term = this->getPterm(current);
+            for (int j = 0; j < c_term.size(); ++j) {
+                addIPartitions(c_term[j], p);
+                queue.push_back(c_term[j]);
+            }
+            if (isUF(current) || isUP(current)) {
+                addIPartitions(c_term.symb(), p);
+            }
+            seen.insert(current, false);
         }
     }
 }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -320,8 +320,8 @@ class Logic {
     ipartitions_t& getIPartitions(SymRef _s) { return term_store.getIPartitions(_s); }
     void setIPartitions(SymRef _s, const ipartitions_t& _p) { term_store.setIPartitions(_s, _p); }
     void addIPartitions(SymRef _s, const ipartitions_t& _p) { term_store.addIPartitions(_s, _p); }
-    void computePartitionMasks(const vec<PTRef> & roots);
-    void computePartitionMasks(PTRef tr) { vec<PTRef> trs = {tr}; computePartitionMasks(trs); }
+    void propagatePartitionMask(PTRef tr);
+
 #endif
 
     // The Boolean connectives

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -372,7 +372,7 @@ class Logic {
 
     bool         appearsInUF        (PTRef tr)        const;
     void         setAppearsInUF     (PTRef tr);
-    vec<PTRef>   getNestedBoolRoots (PTRef tr)        const;
+    virtual vec<PTRef> getNestedBoolRoots (PTRef tr)  const;
 
     bool        isVar              (SymRef sr)     const ;//{ return sym_store[sr].nargs() == 0 && !isConstant(sr); }
     bool        isVar              (PTRef tr)      const;// { return isVar(getPterm(tr).symb()); }

--- a/src/logics/Theory.h
+++ b/src/logics/Theory.h
@@ -99,7 +99,6 @@ public:
     PushFrame(PushFrame& pf);
     PushFrame() : id(FrameId_Undef), root(PTRef_Undef) {} // For pushing into vecs we need a default.
     PushFrame operator= (PushFrame& other);
-    vec<PTRef> nestedBoolRoots;
  private:
     PushFrame(uint32_t id) : id({id}), root(PTRef_Undef) {}
 };

--- a/src/simplifiers/BoolRewriting.cpp
+++ b/src/simplifiers/BoolRewriting.cpp
@@ -112,8 +112,10 @@ PTRef mergePTRefArgs(Logic & logic, PTRef tr, Map<PTRef,PTRef,PTRefHash>& cache,
     Pterm& t = logic.getPterm(tr);
     SymRef sr = t.symb();
     vec<PTRef> new_args;
+    bool changed = false;
     for (int i = 0; i < t.size(); i++) {
         PTRef subst = cache[t[i]];
+        changed |= subst != t[i];
         if (logic.getSymRef(t[i]) != sr) {
             new_args.push(subst);
             continue;
@@ -125,6 +127,7 @@ PTRef mergePTRefArgs(Logic & logic, PTRef tr, Map<PTRef,PTRef,PTRefHash>& cache,
             continue;
         }
         if (logic.getSymRef(subst) == sr) {
+            changed = true;
             const Pterm& substs_t = logic.getPterm(subst);
             for (int j = 0; j < substs_t.size(); j++)
                 new_args.push(substs_t[j]);
@@ -132,6 +135,7 @@ PTRef mergePTRefArgs(Logic & logic, PTRef tr, Map<PTRef,PTRef,PTRefHash>& cache,
         } else
             new_args.push(subst);
     }
+    if (!changed) { return tr; }
     PTRef new_tr;
     if (sr == logic.getSym_and()) {
         new_tr = logic.mkAnd(new_args);

--- a/src/simplifiers/BoolRewriting.cpp
+++ b/src/simplifiers/BoolRewriting.cpp
@@ -115,7 +115,7 @@ PTRef mergePTRefArgs(Logic & logic, PTRef tr, Map<PTRef,PTRef,PTRefHash>& cache,
     bool changed = false;
     for (int i = 0; i < t.size(); i++) {
         PTRef subst = cache[t[i]];
-        changed |= subst != t[i];
+        changed |= (subst != t[i]);
         if (logic.getSymRef(t[i]) != sr) {
             new_args.push(subst);
             continue;


### PR DESCRIPTION
Various small changes to prevent unnecessary work. Please review carefully and report anything suspicious.

Moved dealing with nested booleans to Cnfizer, the MainSolver no longer knows about that.
LALogic avoids this altogether.