### PR TITLE
Small updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #message(${CMAKE_C_COMPILER_ID})
 #message(${CMAKE_CXX_COMPILER_ID})
 
+#Set the default build type if this is the first time cmake is run and nothing has been set
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
+  if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+  endif()
+endif()
+
 set(INSTALL_HEADERS_DIR include/opensmt)
 
 option(PRODUCE_PROOF "Produce proof" OFF)

--- a/src/logics/LIATheory.C
+++ b/src/logics/LIATheory.C
@@ -11,7 +11,9 @@ bool LIATheory::simplify(const vec<PFRef>& formulas, int curr)
     vec<PTRef> & flas = pfstore[formulas[curr]].formulas;
     for(int i = 0; i <flas.size(); ++i) {
         PTRef & fla = flas[i];
-        lialogic.simplifyAndSplitEq(fla, fla);
+        PTRef old = flas[i];
+        lialogic.simplifyAndSplitEq(old, fla);
+        lialogic.transferPartitionMembership(old, fla);
     }
     pfstore[formulas[curr]].root = getLogic().mkAnd(flas);
 #else // PRODUCE_PROOF

--- a/src/logics/LRATheory.C
+++ b/src/logics/LRATheory.C
@@ -11,7 +11,9 @@ bool LRATheory::simplify(const vec<PFRef>& formulas, int curr)
     vec<PTRef> & flas = pfstore[formulas[curr]].formulas;
     for(int i = 0; i < flas.size(); ++i) {
         PTRef & fla = flas[i];
-        lralogic.simplifyAndSplitEq(fla, fla);
+        PTRef old = flas[i];
+        lralogic.simplifyAndSplitEq(old, fla);
+        lralogic.transferPartitionMembership(old, fla);
     }
     pfstore[formulas[curr]].root = getLogic().mkAnd(flas);
 #else

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -581,9 +581,6 @@ void Logic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
     if (!changed) {return;}
     PTRef trp = insertTerm(p.symb(), newargs, &msg);
     if (trp != tr) {
-#ifdef PRODUCE_PROOF
-    transferPartitionMembership(tr, trp);
-#endif
         if (tr_map.has(tr))
             assert(tr_map[tr] == trp);
         else


### PR DESCRIPTION
Changed caching for traversing PTerm DAG in Logic::propagatePartitionMask and Logic::simplifyTree.

Removed PRODUCE_PROOF macro from one place in Logic.

Set the default build type to Release, so users of OpenSMT library do not have to thing about that.