### PR TITLE
Polarity suggestion

### DIFF
--- a/src/options/SMTConfig.C
+++ b/src/options/SMTConfig.C
@@ -604,6 +604,7 @@ SMTConfig::initializeConfig( )
 //  proof_certify_inter           = 0;
   proof_random_seed	        = 0;
   simplify_interpolant           = 0;
+  sat_theory_polarity_suggestion = 1;
 
 }
 

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -787,6 +787,9 @@ public:
         optionTable[o_do_substitutions]->getValue().numval : 1; }
 
 
+   bool use_theory_polarity_suggestion() const
+   { return sat_theory_polarity_suggestion != 0; }
+
 //  int          produce_stats;                // Should print statistics ?
   int          print_stats;                  // Should print statistics ?
   int          produce_proofs;               // Should produce proofs ?
@@ -815,6 +818,7 @@ public:
   // SAT-Solver related parameters
   int          sat_theory_propagation;       // Enables theory propagation from the sat-solver
   int          sat_polarity_mode;            // Polarity mode
+  int          sat_theory_polarity_suggestion;  // Should the SAT solver ask the theory solver for var polarity when making a decision
   double       sat_initial_skip_step;        // Initial skip step for tsolver calls
   double       sat_skip_step_factor;         // Increment for skip step
   int          sat_use_luby_restart;         // Use luby restart mechanism

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -821,6 +821,14 @@ Lit CoreSMTSolver::pickBranchLit()
 #endif
 
     bool sign = false;
+    bool use_theory_suggested_polarity = config.use_theory_polarity_suggestion();
+    if (use_theory_suggested_polarity && next != var_Undef && theory_handler.isTheoryTerm(next)) {
+        lbool suggestion = this->theory_handler.getSolverHandler().getPolaritySuggestion(this->theory_handler.varToTerm(next));
+        if (suggestion != l_Undef) {
+            sign = (suggestion != l_True);
+            return mkLit(next, sign);
+        }
+    }
     switch ( polarity_mode )
     {
     case polarity_true:

--- a/src/tsolvers/LASolver.h
+++ b/src/tsolvers/LASolver.h
@@ -132,6 +132,8 @@ protected:
 
     LVRef getLAVar_single(PTRef term);                      // Initialize a new LA var if needed, otherwise return the old var
     bool hasVar(PTRef expr);
+    LVRef getVarForLeq(PTRef ref) const { return lavarStore.getVarByLeqId(logic.getPterm(ref).getId()); }
+    LVRef getVarForTerm(PTRef ref) const { return lavarStore.getVarByPTId(logic.getPterm(ref).getId()); }
     virtual void doGaussianElimination( ) = 0;                     // Performs Gaussian elimination of all redundant terms in the Tableau if applicable
     virtual void notifyVar(LVRef v) {}                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
     void changeValueBy( LVRef, const Delta & );                    // Updates the bounds after constraint pushing

--- a/src/tsolvers/LRATHandler.C
+++ b/src/tsolvers/LRATHandler.C
@@ -24,6 +24,10 @@ const Logic &LRATHandler::getLogic() const
     return logic;
 }
 
+lbool LRATHandler::getPolaritySuggestion(PTRef p) const {
+    return lrasolver->getPolaritySuggestion(p);
+}
+
 
 void LRATHandler::fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs)
 {

--- a/src/tsolvers/LRATHandler.h
+++ b/src/tsolvers/LRATHandler.h
@@ -39,13 +39,14 @@ class LRATHandler : public TSolverHandler
   public:
     LRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap);
     virtual ~LRATHandler();
-    virtual void fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs);
-    virtual bool assertLit_special(PtAsgn);
-    virtual Logic& getLogic();
-    virtual const Logic& getLogic() const;
+    virtual void fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs) override;
+    virtual bool assertLit_special(PtAsgn) override;
+    virtual Logic& getLogic() override;
+    virtual const Logic& getLogic() const override;
+    virtual lbool getPolaritySuggestion(PTRef) const override;
 
 #ifdef PRODUCE_PROOF
-    virtual PTRef getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels);
+    virtual PTRef getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels) override;
 #endif
 };
 

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -183,7 +183,7 @@ public:
     bool         isKnown(PTRef tr);
 
 protected:
-    bool                        isInformed(PTRef tr) { return informed_PTRefs.has(tr); }
+    bool                        isInformed(PTRef tr) const { return informed_PTRefs.has(tr); }
     void                        setInformed(PTRef tr) { informed_PTRefs.insert(tr, true); }
     std::vector<PTRef>          getInformed() {std::vector<PTRef> res; vec<PTRef> tmp; informed_PTRefs.getKeys(tmp);
                                                 for(int i = 0; i < tmp.size(); ++i) {res.push_back(tmp[i]);} return res; }

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -85,6 +85,7 @@ public:
     void    declareAtom(PTRef tr);                     // Declare atom to the appropriate solver
 //    virtual SolverId getId() const { return my_id; }
     virtual void fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs) = 0;
+    virtual lbool getPolaritySuggestion(PTRef) const { return l_Undef; }
     TRes    check(bool);
 };
 #endif

--- a/src/tsolvers/UFTHandler.C
+++ b/src/tsolvers/UFTHandler.C
@@ -66,6 +66,11 @@ void UFTHandler::fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs)
     }
 }
 
+lbool UFTHandler::getPolaritySuggestion(PTRef p) const {
+    if (egraph) { return egraph->getPolaritySuggestion(p); }
+    return l_Undef;
+}
+
 #ifdef PRODUCE_PROOF
 PTRef UFTHandler::getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels)
 {
@@ -73,6 +78,7 @@ PTRef UFTHandler::getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t>
     assert(iegraph);
     return iegraph->getInterpolant(mask, labels);
 }
+
 #endif
 
 

--- a/src/tsolvers/UFTHandler.h
+++ b/src/tsolvers/UFTHandler.h
@@ -45,15 +45,16 @@ class UFTHandler : public TSolverHandler
   public:
     UFTHandler(SMTConfig& c, Logic& l, vec<DedElem>& d, TermMapper& tmap);
     virtual ~UFTHandler();
-    virtual bool assertLit_special(PtAsgn a);
+    virtual bool assertLit_special(PtAsgn a) override;
     // This is for simplification, needed to run the theory solver code
     // as if it were running inside a SAT solver.
-    void fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs);
-    virtual       Logic& getLogic();
-    virtual const Logic& getLogic() const;
+    void fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs) override;
+    virtual       Logic& getLogic() override;
+    virtual const Logic& getLogic() const override;
+    virtual lbool getPolaritySuggestion(PTRef) const override;
 
 #ifdef PRODUCE_PROOF
-    virtual PTRef getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels);
+    virtual PTRef getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels) override;
 #endif // PRODUCE_PROOF
 };
 

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -271,6 +271,7 @@ public:
   void                popBacktrackPoint       ( );                          // Backtrack to last saved point
   PtAsgn_reason       getDeduction            ( );                          // Return an implied node based on the current state
   PTRef               getSuggestion           ( );                          // Return a suggested literal based on the current state
+  lbool               getPolaritySuggestion   (PTRef);                      // Return a suggested polarity for a given literal
   void                getConflict             ( bool, vec<PtAsgn>& );       // Get explanation
   TRes                check                   ( bool ) { return TRes::SAT; }// Check satisfiability
   virtual ValPair     getValue                (PTRef tr);
@@ -362,7 +363,7 @@ private:
   //
   // Congruence closure main routines
   //
-  bool    unmergeable     ( ERef, ERef, PtAsgn& );              // Can two nodes be merged ?
+  bool    unmergeable     ( ERef, ERef, PtAsgn& ) const;        // Can two nodes be merged ?
   void    merge           ( ERef, ERef, PtAsgn );               // Merge two nodes
   bool    mergeLoop       ( PtAsgn reason );                    // Merge loop
   void    deduce          ( ERef, ERef, PtAsgn );               // Deduce from merging of two nodes (record the reason)

--- a/src/tsolvers/egraph/EnodeStore.h
+++ b/src/tsolvers/egraph/EnodeStore.h
@@ -84,7 +84,7 @@ class EnodeStore {
         return dist_classes[tr_d];
     }
 
-    PTRef getDistTerm(dist_t idx) { return index_to_dist[idx]; }
+    PTRef getDistTerm(dist_t idx) const { return index_to_dist[idx]; }
 
     void addDistClass(PTRef tr_d) {
         assert(!dist_classes.has(tr_d));

--- a/src/tsolvers/lrasolver/LABounds.C
+++ b/src/tsolvers/lrasolver/LABounds.C
@@ -69,15 +69,14 @@ void LABoundListAllocator::reloc(LABoundListRef& tr, LABoundListAllocator& to)
 LABoundStore::BoundInfo LABoundStore::addBound(PTRef leq_ref)
 {
 //    printf(" -> bound store gets %s\n", logic.pp(leq_ref));
-    Pterm& leq = logic.getPterm(leq_ref);
+    const Pterm& leq = logic.getPterm(leq_ref);
     PTRef const_tr = leq[0];
     PTRef sum_tr = leq[1];
 
     bool sum_term_is_negated = logic.isNegated(sum_tr);
 
-    PTRef pos_sum_tr = sum_term_is_negated ? logic.mkNumNeg(sum_tr) : sum_tr;
-
-    LVRef v = lavarStore.getVarByPTId(logic.getPterm(pos_sum_tr).getId());
+    LVRef v = lavarStore.getVarByLeqId(logic.getPterm(leq_ref).getId());
+    assert(v == lavarStore.getVarByPTId(logic.getPterm(sum_tr).getId()));
 
     LABoundRef br_pos;
     LABoundRef br_neg;

--- a/src/tsolvers/lrasolver/LABounds.C
+++ b/src/tsolvers/lrasolver/LABounds.C
@@ -280,7 +280,7 @@ char* LABoundStore::printBounds(LVRef v) const
     return bounds_str;
 }
 
-LABoundRefPair LABoundStore::getBoundRefPair(const PTRef leq)
+LABoundRefPair LABoundStore::getBoundRefPair(const PTRef leq) const
 { return ptermToLABoundsRef[Idx(logic.getPterm(leq).getId())]; }
 
 

--- a/src/tsolvers/lrasolver/LABounds.h
+++ b/src/tsolvers/lrasolver/LABounds.h
@@ -134,8 +134,8 @@ public:
     void updateBound(PTRef leq_tr); // Update a single bound.
 //    inline LABoundRef getLowerBound(const LVRef v) const { return bla[lva[v].getBounds()][lva[v].lbound()]; }
 //    inline LABoundRef getUpperBound(const LVRef v) const { return bla[lva[v].getBounds()][lva[v].ubound()]; }
-    LABoundRefPair getBoundRefPair(const PTRef leq);
-    inline LABound& operator[] (LABoundRef br) { return ba[br]; }
+    LABoundRefPair getBoundRefPair(const PTRef leq) const;
+    inline LABound& operator[] (LABoundRef br) const { return ba[br]; }
     // Debug
     char* printBound(LABoundRef br) const; // Print the bound br
     char* printBounds(LVRef v) const; // Print all bounds of v

--- a/src/tsolvers/lrasolver/LAVar.C
+++ b/src/tsolvers/lrasolver/LAVar.C
@@ -65,7 +65,7 @@ bool LAVarStore::hasVar(PTRef tr) { return hasVar(logic.getPterm(tr).getId()); }
 
 LVRef  LAVarStore::getVarByPTId(PTId i) { return ptermToLavar[Idx(i)]; }
 
-LVRef  LAVarStore::getVarByLeqId(PTId i) { return leqToLavar[Idx(i)]; }
+LVRef  LAVarStore::getVarByLeqId(PTId i) const { return leqToLavar[Idx(i)]; }
 bool   LAVarStore::hasVar(PTId i) { return ptermToLavar.size() > Idx(i) && ptermToLavar[Idx(i)] != LVRef_Undef; }
 
 int    LAVarStore::numVars() const { return lavars.size(); }

--- a/src/tsolvers/lrasolver/LAVar.C
+++ b/src/tsolvers/lrasolver/LAVar.C
@@ -63,7 +63,7 @@ void LAVarStore::addLeqVar(PTRef leq_tr, LVRef v)
 bool LAVarStore::hasVar(PTRef tr) { return hasVar(logic.getPterm(tr).getId()); }
 
 
-LVRef  LAVarStore::getVarByPTId(PTId i) { return ptermToLavar[Idx(i)]; }
+LVRef  LAVarStore::getVarByPTId(PTId i) const { return ptermToLavar[Idx(i)]; }
 
 LVRef  LAVarStore::getVarByLeqId(PTId i) const { return leqToLavar[Idx(i)]; }
 bool   LAVarStore::hasVar(PTId i) { return ptermToLavar.size() > Idx(i) && ptermToLavar[Idx(i)] != LVRef_Undef; }

--- a/src/tsolvers/lrasolver/LAVar.h
+++ b/src/tsolvers/lrasolver/LAVar.h
@@ -51,7 +51,7 @@ public:
     LVRef  getNewVar(PTRef e_orig);
     LVRef  getVarByPTId(PTId i);
     void   addLeqVar(PTRef leq_tr, LVRef v); // Adds a binding from leq_tr to the "slack var" v
-    LVRef  getVarByLeqId(PTId i);
+    LVRef  getVarByLeqId(PTId i) const;
     bool   hasVar(PTId i) ;
     bool   hasVar(PTRef tr);
     int    numVars() const ;

--- a/src/tsolvers/lrasolver/LAVar.h
+++ b/src/tsolvers/lrasolver/LAVar.h
@@ -49,9 +49,10 @@ public:
     LAVarStore(LALogic & logic) : logic(logic) {}
     inline void   clear() {};
     LVRef  getNewVar(PTRef e_orig);
-    LVRef  getVarByPTId(PTId i);
+    LVRef  getVarByPTId(PTId i) const;
     void   addLeqVar(PTRef leq_tr, LVRef v); // Adds a binding from leq_tr to the "slack var" v
     LVRef  getVarByLeqId(PTId i) const;
+
     bool   hasVar(PTId i) ;
     bool   hasVar(PTRef tr);
     int    numVars() const ;

--- a/src/tsolvers/lrasolver/LRASolver.C
+++ b/src/tsolvers/lrasolver/LRASolver.C
@@ -194,7 +194,7 @@ LRALogic&  LRASolver::getLogic() { return logic; }
 
 lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
     if (!this->isInformed(ptref)) { return l_Undef; }
-    LVRef var = this->lavarStore.getVarByLeqId(logic.getPterm(ptref).getId());
+    LVRef var = this->getVarForLeq(ptref);
     if (!model.hasModel(var)) { return l_Undef; }
     LABoundRefPair bounds = this->boundStore.getBoundRefPair(ptref);
     assert( bounds.pos != LABoundRef_Undef && bounds.neg != LABoundRef_Undef );

--- a/src/tsolvers/lrasolver/LRASolver.C
+++ b/src/tsolvers/lrasolver/LRASolver.C
@@ -196,6 +196,7 @@ lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
     LVRef var = this->lavarStore.getVarByLeqId(logic.getPterm(ptref).getId());
     if (!model.hasModel(var)) { return l_Undef; }
     LABoundRefPair bounds = this->boundStore.getBoundRefPair(ptref);
+    assert( bounds.pos != LABoundRef_Undef && bounds.neg != LABoundRef_Undef );
     auto const& val = model.read(var);
     bool positive = false;
     auto const& positive_bound = this->boundStore[bounds.pos];

--- a/src/tsolvers/lrasolver/LRASolver.C
+++ b/src/tsolvers/lrasolver/LRASolver.C
@@ -191,6 +191,7 @@ LRASolver::~LRASolver( )
 
 LRALogic&  LRASolver::getLogic() { return logic; }
 
+
 lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
     if (!this->isInformed(ptref)) { return l_Undef; }
     LVRef var = this->lavarStore.getVarByLeqId(logic.getPterm(ptref).getId());
@@ -202,17 +203,21 @@ lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
     auto const& positive_bound = this->boundStore[bounds.pos];
     if ((positive_bound.getType() == bound_l && positive_bound.getValue() <= val)
         || (positive_bound.getType() == bound_u && positive_bound.getValue() >= val)) {
+        // The current value of the variable is consistent with the positive bound
         positive = true;
     }
     bool negative = false;
     auto const& negative_bound = this->boundStore[bounds.neg];
     if ((negative_bound.getType() == bound_l && negative_bound.getValue() <= val)
         || (negative_bound.getType() == bound_u && negative_bound.getValue() >= val)) {
+        // The current value of the variable is consistent with the negative bound
         negative = true;
     }
-    // MB: Maybe we will not get any suggestion, if the value is <0|-1/2>, but the bounds are <0|0> and <0|-1>
-//    assert(positive || negative);
+    // The value cannot be consistent with bound positive and negative bound at the same time
     assert(!positive || !negative);
+    // It can happen that neither bound is consistent with the current assignment. Consider the current value
+    // of variable "x" as <0,-1/2> with term "x >= 0". The positive bound is lower with value <0,0> and the negative
+    // bound is upper with value <0, -1>. Then both "positive" and "negative" will be false
     if (positive) { return l_True; }
     if (negative) { return l_False; }
     return l_Undef;

--- a/src/tsolvers/lrasolver/LRASolver.h
+++ b/src/tsolvers/lrasolver/LRASolver.h
@@ -55,6 +55,7 @@ public:
     void computeModel() override;
 
     LRALogic&  getLogic() override;
+    lbool getPolaritySuggestion(PTRef) const;
 
 
 #ifdef PRODUCE_PROOF


### PR DESCRIPTION
This adds the possibility for the SAT solver to ask theory solver for suggested polarity once SAT solver has picked new decision variable.

New interface method is provided with implementations for LRA solver and UF solver.
The measured impact in LRA is huge, in UF is small but still positive.