### PR TITLE
Optimizing pre-solving phase

### DIFF
--- a/src/api/Interpret.C
+++ b/src/api/Interpret.C
@@ -560,7 +560,7 @@ PTRef Interpret::parseTerm(const ASTNode& term, vec<LetFrame>& let_branch) {
 
     else if ( t == LQID_T ) {
         // Multi-argument term
-        list<ASTNode*>::iterator node_iter = term.children->begin();
+        auto node_iter = term.children->begin();
         vec<PTRef> args;
         const char* name = (**node_iter).getValue(); node_iter++;
         // Parse the arguments
@@ -609,8 +609,8 @@ PTRef Interpret::parseTerm(const ASTNode& term, vec<LetFrame>& let_branch) {
     }
 
     else if (t == LET_T) {
-        std::list<ASTNode*>::iterator ch = term.children->begin();
-        std::list<ASTNode*>::iterator vbl = (**ch).children->begin();
+        auto ch = term.children->begin();
+        auto vbl = (**ch).children->begin();
         let_branch.push(); // The next scope, where my vars will be defined
         vec<PTRef> tmp_args;
         vec<char*> names;
@@ -650,7 +650,7 @@ PTRef Interpret::parseTerm(const ASTNode& term, vec<LetFrame>& let_branch) {
 
     else if (t == BANG_T) {
         assert(term.children->size() == 2);
-        std::list<ASTNode*>::iterator ch = term.children->begin();
+        auto ch = term.children->begin();
         ASTNode& named_term = **ch;
         ASTNode& attr_l = **(++ ch);
         assert(attr_l.getType() == GATTRL_T);
@@ -773,10 +773,10 @@ bool Interpret::getAssignment() {
     return true;
 }
 
-void Interpret::getValue(const list<ASTNode*>* terms)
+void Interpret::getValue(const std::vector<ASTNode*>* terms)
 {
     vec<ValPair> values;
-    for (list<ASTNode*>::const_iterator term_it = terms->begin(); term_it != terms->end(); ++term_it) {
+    for (auto term_it = terms->begin(); term_it != terms->end(); ++term_it) {
         const ASTNode& term = **term_it;
         vec<LetFrame> tmp;
         PTRef tr = parseTerm(term, tmp);
@@ -817,7 +817,7 @@ void Interpret::writeSplits_smtlib2(const char* filename)
 
 bool Interpret::declareFun(ASTNode& n) // (const char* fname, const vec<SRef>& args)
 {
-    list<ASTNode*>::iterator it = n.children->begin();
+    auto it = n.children->begin();
     ASTNode& name_node = **(it++);
     ASTNode& args_node = **(it++);
     ASTNode& ret_node  = **(it++);
@@ -838,7 +838,7 @@ bool Interpret::declareFun(ASTNode& n) // (const char* fname, const vec<SRef>& a
         free(name);
         return false;
     }
-    for (list<ASTNode*>::iterator it2 = args_node.children->begin(); it2 != args_node.children->end(); it2++) {
+    for (auto it2 = args_node.children->begin(); it2 != args_node.children->end(); it2++) {
         char* name = buildSortName(**it2);
         if (logic->containsSort(name)) {
             args.push(logic->getSortRef(name));
@@ -868,7 +868,7 @@ bool Interpret::declareFun(ASTNode& n) // (const char* fname, const vec<SRef>& a
 
 bool Interpret::declareConst(ASTNode& n) //(const char* fname, const SRef ret_sort)
 {
-    list<ASTNode*>::iterator it = n.children->begin();
+    auto it = n.children->begin();
     ASTNode& name_node = **(it++);
     ASTNode& args_node = **(it++);
     ASTNode& ret_node = **(it++);
@@ -895,7 +895,7 @@ bool Interpret::declareConst(ASTNode& n) //(const char* fname, const SRef ret_so
 
 bool Interpret::defineFun(const ASTNode& n)
 {
-    list<ASTNode*>::iterator it = n.children->begin();
+    auto it = n.children->begin();
     ASTNode& name_node = **(it++);
     ASTNode& args_node = **(it++);
     ASTNode& ret_node  = **(it++);
@@ -907,10 +907,10 @@ bool Interpret::defineFun(const ASTNode& n)
     // Get the argument sorts
     vec<SRef> arg_sorts;
     vec<PTRef> arg_trs;
-    for (list<ASTNode*>::iterator it2 = args_node.children->begin(); it2 != args_node.children->end(); it2++) {
+    for (auto it2 = args_node.children->begin(); it2 != args_node.children->end(); it2++) {
         string varName = (**it2).getValue();
-        list<ASTNode*>::iterator varC = (**it2).children->begin();
-        list<ASTNode*>::iterator varCC = (**varC).children->begin();
+        auto varC = (**it2).children->begin();
+        auto varCC = (**varC).children->begin();
         string sortName = (**varCC).getValue();
 
         if (logic->containsSort(sortName.c_str())) {
@@ -1036,7 +1036,7 @@ void Interpret::notify_success() {
 }
 
 void Interpret::execute(const ASTNode* r) {
-    list<ASTNode*>::iterator i = r->children->begin();
+    auto i = r->children->begin();
     for (; i != r->children->end() && !f_exit; i++) {
         interp(**i);
     }
@@ -1058,7 +1058,6 @@ int Interpret::interpFile(char *content){
     int rval = smt2newparse(&context);
 
     if (rval != 0) return rval;
-
     const ASTNode* r = context.getRoot();
     execute(r);
     return rval;
@@ -1213,7 +1212,7 @@ int Interpret::interpInteractive(FILE*) {
 // Code can possibly be reused when define-sort is implemented
 char* Interpret::buildSortName(ASTNode& sn)
 {
-    list<ASTNode*>::iterator it = sn.children->begin();
+    auto it = sn.children->begin();
     char* canon_name;
     int written = asprintf(&canon_name, "%s", (**it).getValue());
     assert(written >= 0); (void)written;

--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -85,7 +85,7 @@ class Interpret {
     bool                        declareConst(ASTNode& n); //(const char* fname, const SRef ret_sort);
     bool                        defineFun(const ASTNode& n);
     bool                        checkSat();
-    void                        getValue(const list<ASTNode*>* term);
+    void                        getValue(const std::vector<ASTNode*>* term);
     bool                        push();
     bool                        pop();
     PTRef                       parseTerm(const ASTNode& term, vec<LetFrame>& let_branch);

--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -109,7 +109,7 @@ class Interpret {
     // Named terms for getting variable values
     Map<const char*,PTRef,StringHash,Equal<const char*>> nameToTerm;
     VecMap<PTRef,const char*,PTRefHash,Equal<PTRef> > termToNames;
-    vec<const char*>            term_names; // For (! <t> :named <n>) constructs.  if Itp is enabled, this maps a
+    vec<char*>                  term_names; // For (! <t> :named <n>) constructs.  if Itp is enabled, this maps a
                                             // partition to it name.
     vec<SRef>                   vec_sr_empty; // For faster comparison with empty vec
     vec<PTRef>                  vec_ptr_empty;

--- a/src/common/StringMap.h
+++ b/src/common/StringMap.h
@@ -35,9 +35,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct StringHash {
     uint32_t operator () (const char* s) const {
-        uint32_t v = 0;
-        for (int i = 0; s[i] != '\0'; i++) v += (uint32_t)s[i];
-    return v; }
+        // http://www.cse.yorku.ca/~oz/hash.html
+        size_t h = 5381;
+        int c;
+        while ((c = *s++))
+            h = ((h << 5) + h) + c;
+        return h;
+    }
 };
 
 template <>

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -1127,15 +1127,16 @@ bool Logic::defineFun(const char* fname, const vec<PTRef>& args, SRef rsort, PTR
     if (defined_functions.has(fname))
         return false; // already there
     TFun tpl_fun(fname, args, rsort, tr);
-    defined_functions.insert(fname, tpl_fun);
     // This part is a bit silly..
     Tterm tmp;
     defined_functions_vec.push(tmp);
     Tterm& t = defined_functions_vec.last();
     t.setName(tpl_fun.getName());
     t.setBody(tpl_fun.getBody());
-    for (int i = 0; i < args.size(); i++)
+    for (int i = 0; i < args.size(); i++) {
         t.addArg(args[i]);
+    }
+    defined_functions.insert(t.getName(), tpl_fun);
     return true;
 }
 

--- a/src/options/SMTConfig.C
+++ b/src/options/SMTConfig.C
@@ -31,7 +31,7 @@ void ASTNode::print(std::ostream& o, int indent) {
             printf(" ");
         o << "<type: " << typeToStr() << ", value: " << (val != NULL ?  val : "NULL") << ">" << std::endl;
         if (children == NULL) return;
-        for (std::list<ASTNode*>::iterator i = children->begin(); i != children->end(); i++)
+        for (auto i = children->begin(); i != children->end(); i++)
             (*i)->print(o, indent+1);
 }
 
@@ -87,7 +87,7 @@ ConfValue::ConfValue(const ASTNode& s_expr_n) {
     if (s_expr_n.getType() == SEXPRL_T) {
         type = O_LIST;
         configs = new list<ConfValue*>;
-        for (list<ASTNode*>::iterator i = s_expr_n.children->begin(); i != s_expr_n.children->end(); i++)
+        for (auto i = s_expr_n.children->begin(); i != s_expr_n.children->end(); i++)
             configs->push_back(new ConfValue(**i));
     }
     else if (s_expr_n.getType() == SYM_T) {

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -80,12 +80,12 @@ class ASTNode {
     char*               val;
     static const char*  typestr[];
   public:
-    std::list< ASTNode* >*children;
+    std::vector< ASTNode* >*children;
     ASTNode(ASTType t, smt2token tok) : type(t), tok(tok), val(NULL), children(NULL) {}
     ASTNode(ASTType t, char* v) : type(t), tok({t_none}), val(v), children(NULL) {}
     ~ASTNode() {
         if (children) {
-            for (std::list<ASTNode*>::const_iterator ci = children->begin(); ci != children->end(); ci++) {
+            for (auto ci = children->begin(); ci != children->end(); ci++) {
                 delete *ci;
             };
             delete children;

--- a/src/parsers/smt2new/smt2newparser.yy
+++ b/src/parsers/smt2new/smt2newparser.yy
@@ -67,7 +67,7 @@ void smt2newerror( YYLTYPE* locp, Smt2newContext* context, const char * s )
   char  *                      str;
   std::vector< std::string > * str_list;
   ASTNode *                    snode;
-  std::list< ASTNode * > *     snode_list;
+  std::vector< ASTNode * > *   snode_list;
   smt2token                    tok;
 }
 
@@ -94,7 +94,7 @@ script: command_list { ASTNode *n = new ASTNode(CMDL_T, strdup("main-script")); 
 
 
 command_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | command_list command
         { (*$1).push_back($2); $$ = $1; }
     ;
@@ -102,32 +102,32 @@ command_list:
 command: '(' TK_SETLOGIC TK_SYM ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(SYM_T, $3));
         }
     | '(' TK_SETOPTION option ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
         }
     | '(' TK_SETINFO attribute ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
         }
     | '(' TK_DECLARESORT TK_SYM TK_NUM ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(SYM_T, $3));
             $$->children->push_back(new ASTNode(NUM_T, $4));
         }
     | '(' TK_DEFINESORT TK_SYM '(' symbol_list ')' sort ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(SYM_T, $3));
 
             ASTNode* syml = new ASTNode(SYML_T, NULL);
@@ -140,7 +140,7 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_DECLAREFUN TK_SYM '(' sort_list ')' sort ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(SYM_T, $3));
 
             ASTNode* sortl = new ASTNode(SORTL_T, NULL);
@@ -152,11 +152,11 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_DECLARECONST const_val '(' ')' sort ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
 
             ASTNode* sortl = new ASTNode(SORTL_T, NULL);
-            sortl->children = new std::list<ASTNode*>();
+            sortl->children = new std::vector<ASTNode*>();
             $$->children->push_back(sortl);
 
             $$->children->push_back($6);
@@ -164,7 +164,7 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_DEFINEFUN TK_SYM '(' sorted_var_list ')' sort term ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(SYM_T, $3));
 
             ASTNode* svl = new ASTNode(SVL_T, NULL);
@@ -177,19 +177,19 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_PUSH TK_NUM ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(NUM_T, $3));
         }
     | '(' TK_POP TK_NUM ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(NUM_T, $3));
         }
     | '(' TK_ASSERT term ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
         }
     | '(' TK_CHECKSAT ')'
@@ -212,19 +212,19 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_WRSTATE TK_STR ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(UATTR_T, $3));
         }
     | '(' TK_RDSTATE TK_STR ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(UATTR_T, $3));
         }
     | '(' TK_WRFUNS TK_STR ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(UATTR_T, $3));
         }
     | '(' TK_GETUNSATCORE ')'
@@ -235,7 +235,7 @@ command: '(' TK_SETLOGIC TK_SYM ')'
         {
             $$ = new ASTNode(CMD_T, $2);
             $$->children = $5;
-            $$->children->push_front($4);
+            $$->children->insert($$->children->begin(), $4);
         }
     | '(' TK_GETASSIGNMENT ')'
         {
@@ -244,19 +244,19 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_GETOPTION TK_KEY ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(UATTR_T, $3));
         }
     | '(' TK_GETOPTION predef_key ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(PATTR_T, $3));
         }
     | '(' TK_GETINFO info_flag ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
         }
     | '(' TK_SIMPLIFY ')'
@@ -268,13 +268,13 @@ command: '(' TK_SETLOGIC TK_SYM ')'
     | '(' TK_ECHO TK_STR ')'
         {
             $$ = new ASTNode(CMD_T, $2);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(UATTR_T, $3));
         }
     ;
 
 attribute_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | attribute_list attribute
         { $1->push_back($2); $$ = $1; }
     ;
@@ -282,15 +282,15 @@ attribute_list:
 attribute: TK_KEY
         { $$ = new ASTNode(UATTR_T, $1); }
     | TK_KEY attribute_value
-        { $$ = new ASTNode(UATTR_T, $1); $$->children = new std::list<ASTNode*>(); $$->children->push_back($2); }
+        { $$ = new ASTNode(UATTR_T, $1); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($2); }
     | predef_key
         { $$ = new ASTNode(PATTR_T, $1); }
     | predef_key attribute_value
-        { $$ = new ASTNode(PATTR_T, $1); $$->children = new std::list<ASTNode*>(); $$->children->push_back($2); }
+        { $$ = new ASTNode(PATTR_T, $1); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($2); }
     ;
 
 attribute_value: spec_const
-        { $$ = new ASTNode(SPECC_T, NULL); $$->children = new std::list<ASTNode*>(); $$->children->push_back($1); }
+        { $$ = new ASTNode(SPECC_T, NULL); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($1); }
     | TK_SYM
         {
             $$ = new ASTNode(SYM_T, $1);
@@ -309,25 +309,25 @@ identifier: TK_SYM
     ;
 
 sort: identifier
-      { $$ = new ASTNode(ID_T, NULL); $$->children = new std::list<ASTNode*>(); $$->children->push_back($1); }
+      { $$ = new ASTNode(ID_T, NULL); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($1); }
     | '(' identifier sort sort_list ')'
       {
         $$ = new ASTNode(LID_T, NULL);
         $$->children = $4;
-        $$->children->push_front($3);
+        $$->children->insert($$->children->begin(), $3);
       }
     ;
 
 sort_list: sort_list sort
         { $1->push_back($2); $$ = $1; }
     |
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     ;
 
 s_expr: spec_const
         {
             $$ = new ASTNode(SPECC_T, NULL);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($1);
         }
     | TK_SYM
@@ -347,7 +347,7 @@ s_expr: spec_const
 
 s_expr_list:
         {
-            $$ = new std::list<ASTNode*>();
+            $$ = new std::vector<ASTNode*>();
         }
     | s_expr_list s_expr
         {
@@ -378,7 +378,7 @@ const_val: TK_SYM
 numeral_list: numeral_list TK_NUM
         { $1->push_back(new ASTNode(NUM_T, $2)); $$ = $1; }
     | TK_NUM
-        { $$ = new std::list<ASTNode*>(); $$->push_back(new ASTNode(NUM_T, $1)); }
+        { $$ = new std::vector<ASTNode*>(); $$->push_back(new ASTNode(NUM_T, $1)); }
     ;
 
 qual_identifier: identifier
@@ -386,53 +386,53 @@ qual_identifier: identifier
     | '(' TK_AS identifier sort ')'
         {
             $$ = new ASTNode(AS_T, NULL);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($3);
             $$->children->push_back($4);
         }
     ;
 
 var_binding_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | var_binding_list var_binding
         { $1->push_back($2); $$ = $1; }
     ;
 
 var_binding: '(' TK_SYM term ')'
-        { $$ = new ASTNode(VARB_T, $2); $$->children = new std::list<ASTNode*>(); $$->children->push_back($3); }
+        { $$ = new ASTNode(VARB_T, $2); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($3); }
     ;
 
 sorted_var_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | sorted_var_list sorted_var
         { $1->push_back($2); $$ = $1; }
     ;
 
 sorted_var: '(' TK_SYM sort ')'
-        { $$ = new ASTNode(SV_T, $2);  $$->children = new std::list<ASTNode*>(); $$->children->push_back($3); }
+        { $$ = new ASTNode(SV_T, $2);  $$->children = new std::vector<ASTNode*>(); $$->children->push_back($3); }
 
 term_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | term_list term
         { $1->push_back($2); $$ = $1; }
     ;
 
 term: spec_const
-        { $$ = new ASTNode(TERM_T, NULL); $$->children = new std::list<ASTNode*>(); $$->children->push_back($1); }
+        { $$ = new ASTNode(TERM_T, NULL); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($1); }
     | qual_identifier
-        { $$ = new ASTNode(QID_T, NULL); $$->children = new std::list<ASTNode*>(); $$->children->push_back($1); }
+        { $$ = new ASTNode(QID_T, NULL); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($1); }
     | '(' qual_identifier term term_list ')'
         {
             $$ = new ASTNode(LQID_T, NULL);
             $$->children = $4;
-            $$->children->push_front($3);
-            $$->children->push_front($2);
+            $$->children->insert($$->children->begin(), $3);
+            $$->children->insert($$->children->begin(), $2);
         }
     | '(' TK_LET '(' var_binding var_binding_list ')' term ')'
         {
             $$ = new ASTNode(LET_T, NULL);
-            $$->children = new std::list<ASTNode*>();
-            $5->push_front($4);
+            $$->children = new std::vector<ASTNode*>();
+            $5->insert($5->begin(), $4);
             ASTNode* vbl = new ASTNode(VARBL_T, NULL);
             vbl->children = $5;
             $$->children->push_back(vbl);
@@ -441,8 +441,8 @@ term: spec_const
     | '(' TK_FORALL '(' sorted_var sorted_var_list ')' term ')'
         {
             $$ = new ASTNode(FORALL_T, NULL);
-            $$->children = new std::list<ASTNode*>();
-            $5->push_front($4);
+            $$->children = new std::vector<ASTNode*>();
+            $5->insert($5->begin(), $4);
             ASTNode* svl = new ASTNode(SVL_T, NULL);
             svl->children = $5;
             $$->children->push_back(svl);
@@ -451,8 +451,8 @@ term: spec_const
     | '(' TK_EXISTS '(' sorted_var sorted_var_list ')' term ')'
         {
             $$ = new ASTNode(EXISTS_T, NULL);
-            $$->children = new std::list<ASTNode*>();
-            $5->push_front($4);
+            $$->children = new std::vector<ASTNode*>();
+            $5->insert($5->begin(), $4);
             ASTNode* svl = new ASTNode(SVL_T, NULL);
             svl->children = $5;
             $$->children->push_back(svl);
@@ -461,17 +461,17 @@ term: spec_const
     | '(' '!' term attribute attribute_list ')'
         {
             $$ = new ASTNode(BANG_T, NULL);
-            $$->children = new std::list<ASTNode*>();
-            $$->children->push_front($3);
+            $$->children = new std::vector<ASTNode*>();
+            $$->children->push_back($3);
             ASTNode *atrs = new ASTNode(GATTRL_T, NULL);
-            $5->push_front($4);
+            $5->insert($5->begin(), $4);
             atrs->children = $5;
             $$->children->push_back(atrs);
         }
     ;
 
 symbol_list:
-        { $$ = new std::list<ASTNode*>(); }
+        { $$ = new std::vector<ASTNode*>(); }
     | symbol_list TK_SYM
         { $1->push_back(new ASTNode(SYM_T, $2)); $$ = $1; }
     ;
@@ -492,73 +492,73 @@ b_value: TK_SYM
 option: KW_PRINTSUCCESS b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_EXPANDDEFINITIONS b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_INTERACTIVEMODE b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_PRODUCEPROOFS b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_PRODUCEUNSATCORES b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_PRODUCEMODELS b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_PRODUCEASSIGNMENTS b_value
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($2);
         }
     | KW_REGULAROUTPUTCHANNEL TK_STR
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(STR_T, $2));
         }
     | KW_DIAGNOSTICOUTPUTCHANNEL TK_STR
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(STR_T, $2));
         }
     | KW_RANDOMSEED TK_NUM
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(NUM_T, $2));
         }
     | KW_VERBOSITY TK_NUM
         {
             $$ = new ASTNode(OPTION_T, $1);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(NUM_T, $2));
         }
     | attribute
         {
             $$ = new ASTNode(OPTION_T, NULL);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back($1);
         }
     ;
@@ -638,7 +638,7 @@ info_flag: KW_ERRORBEHAVIOR
     | TK_KEY
         {
             $$ = new ASTNode(INFO_T, NULL);
-            $$->children = new std::list<ASTNode*>();
+            $$->children = new std::vector<ASTNode*>();
             $$->children->push_back(new ASTNode(GATTR_T, $1));
         }
     ;

--- a/src/symbols/SymStore.C
+++ b/src/symbols/SymStore.C
@@ -70,9 +70,12 @@ SymRef SymStore::newSymb(const char * fname, const vec<SRef> & args) {
     ta[tr].id = id;                     // Tell the term its id, used in error reporting, and checking whether two terms could be equal in future?
     if (newsym) {
         vec<SymRef> trs;
+        trs.push(tr);
         symbolTable.insert(tmp_name, trs);
     }
-    symbolTable[tmp_name].push(tr);           // Map the name to term reference (why not id?), used in parsing
+    else {
+        symbolTable[tmp_name].push(tr);           // Map the name to term reference (why not id?), used in parsing
+    }
     return tr;
 }
 


### PR DESCRIPTION
This PR contains two main changes.

1. New hash function for strings that works much better for similar names (like var12 vs var21).
2. Deleting AST nodes after processing so that the memory is released and not kept throughout the whole solving process.
2b. In addition vector is used to store children in AST node instead of list, as vector has lower memory footprint.