### PR TITLE
Fixing memory leak introduced in recent changes to LRA solver

### DIFF
--- a/src/api/Interpret.C
+++ b/src/api/Interpret.C
@@ -850,6 +850,7 @@ bool Interpret::declareFun(ASTNode& n) // (const char* fname, const vec<SRef>& a
         }
         else {
             notify_formatted(true, "Undefined sort %s in function %s", name, fname);
+            free(name);
             return false;
         }
     }
@@ -881,13 +882,13 @@ bool Interpret::declareConst(ASTNode& n) //(const char* fname, const SRef ret_so
     SRef ret_sort;
     if (logic->containsSort(name)) {
         ret_sort = newSort(ret_node);
+        free(name);
     } else {
         notify_formatted(true, "Failed to declare constant %s", fname);
         notify_formatted(true, "Unknown return sort %s of %s", name, fname);
         free(name);
         return false;
     }
-
     PTRef rval = logic->mkConst(ret_sort, fname);
     if (rval == PTRef_Undef) {
         comment_formatted("While declare-const %s: %s", fname, "error");

--- a/src/tsolvers/lrasolver/LRAModel.cpp
+++ b/src/tsolvers/lrasolver/LRAModel.cpp
@@ -77,7 +77,7 @@ void LRAModel::clear() {
     this->current_assignment.clear();
     this->last_consistent_assignment.clear();
     this->changed_vars_set.reset();
-    this->changed_vars_vec.reset();
+    this->changed_vars_vec.clear();
     this->int_lbounds.clear();
     this->bound_trace.clear();
     this->has_model.clear();

--- a/src/tsolvers/lrasolver/LRAModel.h
+++ b/src/tsolvers/lrasolver/LRAModel.h
@@ -72,7 +72,7 @@ public:
             LVRef v = changed_vars_vec[i];
             last_consistent_assignment[getVarId(v)] = current_assignment[getVarId(v)];
         }
-        changed_vars_vec.reset();
+        changed_vars_vec.clear();
         changed_vars_set.reset();
     }
 
@@ -81,7 +81,7 @@ public:
             LVRef v = changed_vars_vec[i];
             current_assignment[getVarId(v)] = last_consistent_assignment[getVarId(v)];
         }
-        changed_vars_vec.reset();
+        changed_vars_vec.clear();
         changed_vars_set.reset();
     }
 


### PR DESCRIPTION
This PR contains a fix for a relatively big memory leak introduced by me in bb2e8bbd.
The problem is that one Vec was not cleaned properly.

In addition, this PR contains a fix for an old minor leak from pre-solving phase where char* was not freed on all program paths.