### PR TITLE
Fixing issue #43 - proper cleanup of TSolver after interpolating at theory clause nodes in the proof

### DIFF
--- a/regression_itp/dec-far1.smt2
+++ b/regression_itp/dec-far1.smt2
@@ -1,0 +1,19 @@
+(set-logic QF_LRA)
+(set-option :produce-interpolants true)
+(set-option :interpolation-lra-algorithm 4) ; decomposed Farkas
+(declare-fun x1 () Real)
+(declare-fun x2 () Real)
+(declare-fun x3 () Real)
+
+(assert (!(<= 0 (+ x1  x2 ) ) :named A))
+(assert (!(<= 0  (+ x1 x3)) :named B))
+(assert (!(<= 0 ( * (- 1) x1 ) ) :named C))
+(assert (!(<= 1 (+ (* (- 1) x2 ) ( * (- 1) x3 ))) :named D))
+(check-sat)
+(get-interpolants (and A B C) D)
+(get-interpolants A (and B C D))
+(get-interpolants B (and A C D))
+(get-interpolants C (and A B D))
+
+
+

--- a/src/api/Interpret.C
+++ b/src/api/Interpret.C
@@ -1327,6 +1327,7 @@ void Interpret::getInterpolants(const ASTNode& n)
         else{
             smt_solver.getSingleInterpolant(itps, partitionings[0]);
         }
+        smt_solver.deleteProofGraph();
 
         for (int j = 0; j < itps.size(); j++) {
             char* itp = logic->pp(itps[j]);

--- a/src/proof/PGInterpolator.C
+++ b/src/proof/PGInterpolator.C
@@ -574,6 +574,7 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
                 }
 
                 partial_interp = thandler->getInterpolant (A_mask, &ptref2label);
+                clearTSolver();
             }
 
             assert ( partial_interp != PTRef_Undef );


### PR DESCRIPTION
Fixes #43 
The theory solver was cleaned before interpolating in a theory clause node, but not after.
This caused problems with respect to recent changes (#40 ) as the invariant were not preserved by the subsequent call to interpolation engine.

The fix is to clean the TSolver after interpolant computation in every theory leave of the proof.
It is a good practice to clean up after one-self.