### PR TITLE
Checking larger amount of compiler warnings in CI; fixing warnings in current code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ before_script:
     - mkdir build && mkdir ${INSTALL}
 
 script:
+  - set -e
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS="$FLAGS" -DPRODUCE_PROOF=${PRODUCE_PROOF} -DCMAKE_INSTALL_PREFIX=${INSTALL} ..
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ addons:
 install: true
 
 before_script:
-    - if [[ "${TRAVIS_COMPILER}" == "clang" ]]; then FLAGS="-Wpessimizing-move -Werror=pessimizing-move"; fi
+    - FLAGS="-Wall -Werror"
     - INSTALL=${TRAVIS_BUILD_DIR}/install
     - mkdir build && mkdir ${INSTALL}
 

--- a/examples/test-bv.cc
+++ b/examples/test-bv.cc
@@ -21,7 +21,7 @@ main(int argc, char** argv)
 
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c, bw);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -89,11 +89,11 @@ main(int argc, char** argv)
 
     PTRef eq3 = logic.mkBVEq(op_tr, d);
 
-    SolverId id = { 5 };
     vec<PtAsgn> asgns;
     vec<DedElem> deds;
     vec<PTRef> foo;
 
+    SolverId id = {42};
     BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
     BVRef output;
 

--- a/examples/test-cuf.cc
+++ b/examples/test-cuf.cc
@@ -16,7 +16,7 @@ main(int argc, char** argv)
     int c2_int = atoi(argv[2]);
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c, 8);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -36,11 +36,11 @@ main(int argc, char** argv)
     char* msg;
     mainSolver.insertFormula(eq3, &msg);
 
-    SolverId id = { 5 };
     vec<PtAsgn> asgns;
     vec<DedElem> deds;
     vec<PTRef> foo;
 
+    SolverId id = {42};
     BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
     BVRef output;
 

--- a/examples/test-cuf3.cc
+++ b/examples/test-cuf3.cc
@@ -7,7 +7,7 @@ main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -26,11 +26,11 @@ main(int argc, char** argv)
     PTRef eq = logic.mkBVEq(ab,ba);
     PTRef eq_neg = logic.mkBVNot(eq);
 
-    SolverId id = { 5 };
     vec<PtAsgn> asgns;
     vec<DedElem> deds;
     vec<PTRef> foo;
 
+    SolverId id = {42};
     BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
     BVRef output;
 

--- a/examples/test1.cc
+++ b/examples/test1.cc
@@ -6,7 +6,7 @@ main(int argc, char** argv)
 {
     SMTConfig c;
     UFTheory* uftheory = new UFTheory(c);
-    THandler* thandler = new THandler(c, *uftheory);
+    THandler* thandler = new THandler(*uftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver = new MainSolver(*thandler, c, solver, "test solver");
 

--- a/examples/test10_BV.cc
+++ b/examples/test10_BV.cc
@@ -11,7 +11,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -28,11 +28,11 @@ int main(int argc, char** argv)
     PTRef eq1_neg = logic.mkBVNot(eq1);
     PTRef LOr = logic.mkBVLor(eq1_neg, eq2);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test11_BV.cc
+++ b/examples/test11_BV.cc
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -36,11 +36,11 @@ int main(int argc, char** argv)
     PTRef LOr = logic.mkBVLor(a_neg, eq4);
     //PTRef eq4 = logic.mkBVEq(eq3, LOr);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test13_BV.cc
+++ b/examples/test13_BV.cc
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -36,11 +36,11 @@ int main(int argc, char** argv)
     PTRef eq5 = logic.mkBVLor(a_neg, eq4);
     //PTRef eq4 = logic.mkBVEq(eq3, LOr);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test15_ex1CADE.cc
+++ b/examples/test15_ex1CADE.cc
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -46,11 +46,11 @@ int main(int argc, char** argv)
 
     PTRef assert = logic.mkBVEq(constOne, eq_not);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test16_ex2CADE_BV.cc
+++ b/examples/test16_ex2CADE_BV.cc
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c, 8);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -72,11 +72,11 @@ int main(int argc, char** argv)
     PTRef assert = logic.mkBVEq(constOne , NotEq);
 
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+	SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test17_ex2CADE_CUF.cc
+++ b/examples/test17_ex2CADE_CUF.cc
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c, 8);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;

--- a/examples/test18_ex2CADE_glue_BV-CUF.cc
+++ b/examples/test18_ex2CADE_glue_BV-CUF.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c, 8);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -112,10 +112,10 @@ int main(int argc, char** argv)
     PTRef eq2_bv = logic.mkBVEq(mod4_bv, c2_bv);
 
 //***** BItBlasting of C1_bv and C2_bv and two******
-    SolverId id = { 5 };
     vec<PtAsgn> asgns;
     vec<DedElem> deds;
     vec<PTRef> foo;
+    SolverId id = {42};
     BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
     BVRef output1;

--- a/examples/test2.cc
+++ b/examples/test2.cc
@@ -6,7 +6,7 @@ main(int argc, char** argv)
 {
     SMTConfig c;
     UFTheory* uftheory = new UFTheory(c);
-    THandler* thandler = new THandler(c, *uftheory);
+    THandler* thandler = new THandler(*uftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;

--- a/examples/test3_BV.cc
+++ b/examples/test3_BV.cc
@@ -14,7 +14,7 @@ main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver = new MainSolver(*thandler, c, solver, "test solver");
     CUFLogic& logic = cuftheory->getLogic();

--- a/examples/test4_BV.cc
+++ b/examples/test4_BV.cc
@@ -14,7 +14,7 @@ main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver = new MainSolver(*thandler, c, solver, "test solver");
     BVLogic& logic = cuftheory->getLogic();
@@ -44,12 +44,11 @@ main(int argc, char** argv)
 
     PTRef eq = logic.mkAnd(args);*/
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
-	BitBlaster bbb(id, c, *mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb({42}, c, *mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test5_BV.cc
+++ b/examples/test5_BV.cc
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -45,11 +45,11 @@ int main(int argc, char** argv)
     PTRef d2 = logic.mkBVTimes(a, b);
     PTRef eq4 = logic.mkBVEq(d, d2);
 /******************************************************/
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test7_BV.cc
+++ b/examples/test7_BV.cc
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -38,11 +38,11 @@ int main(int argc, char** argv)
     PTRef LOr = logic.mkBVLor(a_neg, b);
     PTRef eq4 = logic.mkBVEq(d, LOr);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test8_BV.cc
+++ b/examples/test8_BV.cc
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -37,11 +37,11 @@ int main(int argc, char** argv)
     PTRef one = logic.mkBVConst(1);
     PTRef eq3 = logic.mkBVEq(GT, one);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/examples/test9_BV.cc
+++ b/examples/test9_BV.cc
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
 {
     SMTConfig c;
     CUFTheory* cuftheory = new CUFTheory(c);
-    THandler* thandler = new THandler(c, *cuftheory);
+    THandler* thandler = new THandler(*cuftheory);
     SimpSMTSolver* solver = new SimpSMTSolver(c, *thandler);
     MainSolver* mainSolver_ = new MainSolver(*thandler, c, solver, "test solver");
     MainSolver& mainSolver = *mainSolver_;
@@ -45,11 +45,11 @@ int main(int argc, char** argv)
 
     PTRef eq5 = logic.mkBVLor(a_neg, eq4);
 
-    SolverId id = { 5 };
 	vec<PtAsgn> asgns;
 	vec<DedElem> deds;
 	vec<PTRef> foo;
 
+    SolverId id = {42};
 	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
 
 	BVRef output1;

--- a/src/api/Interpret.C
+++ b/src/api/Interpret.C
@@ -208,7 +208,7 @@ void Interpret::interp(ASTNode& n) {
                     {
                         UFTheory *uftheory = new UFTheory(config);
                         theory = uftheory;
-                        thandler = new THandler(config, *uftheory);
+                        thandler = new THandler(*uftheory);
                         logic = &(theory->getLogic());
                         new_solver();
 
@@ -220,7 +220,7 @@ void Interpret::interp(ASTNode& n) {
                     {
                         CUFTheory *cuftheory = new CUFTheory(config);
                         theory = cuftheory;
-                        thandler = new THandler(config, *cuftheory);
+                        thandler = new THandler(*cuftheory);
                         logic = &(theory->getLogic());
                         new_solver();
 
@@ -233,7 +233,7 @@ void Interpret::interp(ASTNode& n) {
                     {
                         LRATheory *lratheory = new LRATheory(config);
                         theory = lratheory;
-                        thandler = new THandler(config, *lratheory);
+                        thandler = new THandler(*lratheory);
                         logic = &(theory->getLogic());
 
                         new_solver();
@@ -246,7 +246,7 @@ void Interpret::interp(ASTNode& n) {
                     {
                         LIATheory *liatheory = new LIATheory(config);
                         theory = liatheory;
-                        thandler = new THandler(config, *liatheory);
+                        thandler = new THandler(*liatheory);
                         logic = &(theory->getLogic());
 
                         new_solver();
@@ -258,7 +258,7 @@ void Interpret::interp(ASTNode& n) {
                     {
                         UFLRATheory* uflratheory = new UFLRATheory(config);
                         theory = uflratheory;
-                        thandler = new THandler(config, *uflratheory);
+                        thandler = new THandler(*uflratheory);
                         logic = &(theory->getLogic());
                         new_solver();
                         main_solver = new MainSolver(*thandler, config, solver, "qf_uflra solver");

--- a/src/api/MainSolver.C
+++ b/src/api/MainSolver.C
@@ -382,7 +382,7 @@ sstat MainSolver::solve()
     vec<PTRef> query;
 
     vec<FrameId> en_frames;
-    for (int i = 0; i < frames.size(); i++) {
+    for (std::size_t i = 0; i < frames.size(); i++) {
         const PushFrame& frame = pfstore[frames.getFrameReference(i)];
         en_frames.push(frame.getId());
         query.push(frame.root);

--- a/src/api/Opensmt.C
+++ b/src/api/Opensmt.C
@@ -25,7 +25,7 @@ Opensmt::Opensmt(opensmt_logic _logic, const char* name, int bw)
     default:
         opensmt_error("Theory not supported");
     }
-    thandler = new THandler(*config, *theory);
+    thandler = new THandler(*theory);
     solver = new SimpSMTSolver(*config, *thandler);
     mainSolver = new MainSolver(*thandler, *config, solver, name);
     mainSolver->initialize();

--- a/src/cnfizers/Cnfizer.C
+++ b/src/cnfizers/Cnfizer.C
@@ -115,7 +115,7 @@ bool Cnfizer::isNPAtom (PTRef r, PTRef &p) const
 
 void Cnfizer::setFrameTerm(FrameId frame_id)
 {
-    while (frame_terms.size() <= frame_id.id) {
+    while (static_cast<unsigned int>(frame_terms.size()) <= frame_id.id) {
         frame_terms.push(logic.getTerm_true());
     }
     // frame_id == {0} is for the bottom frame and we don't want to add
@@ -217,7 +217,7 @@ lbool Cnfizer::cnfizeAndGiveToSolver(PTRef formula, FrameId frame_id)
 
 void Cnfizer::declareVars(vec<PTRef>& vars)
 {
-    for (size_t i = 0; i < vars.size(); i++) {
+    for (int i = 0; i < vars.size(); i++) {
         Lit l = tmap.getOrCreateLit(vars[i]);
         solver.addVar(var(l));
     }

--- a/src/logics/BVLogic.C
+++ b/src/logics/BVLogic.C
@@ -221,8 +221,7 @@ BVLogic::mkBVEq(PTRef a1, PTRef a2)
     vec<PTRef> tmp;
     tmp.push(a1);
     tmp.push(a2);
-    char* msg;
-    return mkFun(sym_BV_EQ, tmp, &msg);
+    return mkFun(sym_BV_EQ, tmp);
 }
 
 PTRef
@@ -271,7 +270,7 @@ BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> sum_args;
     sum_args.push(arg1);
     sum_args.push(arg2);
-    PTRef tr = mkFun(sym_BV_PLUS, sum_args, msg);
+    PTRef tr = mkFun(sym_BV_PLUS, sum_args);
 //    sum_args[0] = arg2;
 //    sum_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_PLUS, sum_args, msg);
@@ -292,7 +291,7 @@ BVLogic::mkBVTimes(const PTRef arg1, const PTRef arg2, char** msg)
     times_args.push(arg1);
     times_args.push(arg2);
 
-    PTRef tr = mkFun(sym_BV_TIMES, times_args, msg);
+    PTRef tr = mkFun(sym_BV_TIMES, times_args);
 //    times_args[0] = arg2;
 //    times_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_TIMES, times_args, msg);
@@ -312,7 +311,7 @@ BVLogic::mkBVDiv(const PTRef arg1, const PTRef arg2)
     div_args.push(arg1);
     div_args.push(arg2);
     char* msg;
-    PTRef tr = mkFun(sym_BV_DIV, div_args, &msg);
+    PTRef tr = mkFun(sym_BV_DIV, div_args);
     return tr;
 }
 
@@ -384,7 +383,7 @@ BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    PTRef tr = mkFun(sym_BV_ULEQ, args, msg);
+    PTRef tr = mkFun(sym_BV_ULEQ, args);
     return tr;
 }
 
@@ -413,7 +412,7 @@ BVLogic::mkBVSlt(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    PTRef tr = mkFun(sym_BV_SLT, args, msg);
+    PTRef tr = mkFun(sym_BV_SLT, args);
     return tr;
 }
 
@@ -427,8 +426,7 @@ PTRef BVLogic::mkBVLshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_BV_LSHIFT, args, &msg);
+    return mkFun(sym_BV_LSHIFT, args);
 }
 
 PTRef BVLogic::mkBVLRshift(const PTRef arg1, const PTRef arg2)
@@ -438,8 +436,7 @@ PTRef BVLogic::mkBVLRshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_BV_LRSHIFT, args, &msg);
+    return mkFun(sym_BV_LRSHIFT, args);
 }
 
 PTRef BVLogic::mkBVARshift(const PTRef arg1, const PTRef arg2)
@@ -449,8 +446,7 @@ PTRef BVLogic::mkBVARshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_BV_ARSHIFT, args, &msg);
+    return mkFun(sym_BV_ARSHIFT, args);
 }
 
 
@@ -466,9 +462,7 @@ PTRef BVLogic::mkBVMod(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-
-    return mkFun(sym_BV_MOD, args, &msg);
+    return mkFun(sym_BV_MOD, args);
 }
 
 PTRef BVLogic::mkBVBwAnd(const PTRef arg1, const PTRef arg2)
@@ -478,8 +472,7 @@ PTRef BVLogic::mkBVBwAnd(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_BV_BWAND, args, &msg);
+    return mkFun(sym_BV_BWAND, args);
 }
 
 PTRef BVLogic::mkBVBwOr(const PTRef arg1, const PTRef arg2)
@@ -489,8 +482,7 @@ PTRef BVLogic::mkBVBwOr(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_BV_BWOR, args, &msg);
+    return mkFun(sym_BV_BWOR, args);
 }
 
 /*PTRef BVLogic::mkBVInc(const PTRef arg1)
@@ -526,8 +518,7 @@ PTRef BVLogic::mkBVLand(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_BV_LAND, args, &msg);
+    PTRef tr = mkFun(sym_BV_LAND, args);
     return tr;
 }
 
@@ -538,8 +529,7 @@ PTRef BVLogic::mkBVLor(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_BV_LOR, args, &msg);
+    PTRef tr = mkFun(sym_BV_LOR, args);
     return tr;
 }
 
@@ -554,8 +544,7 @@ PTRef BVLogic::mkBVNot(const PTRef arg)
         return term_BV_ONE;
     vec<PTRef> tmp;
     tmp.push(arg);
-    char* msg;
-    PTRef tr = mkFun(sym_BV_NOT, tmp, &msg);
+    PTRef tr = mkFun(sym_BV_NOT, tmp);
     return tr;
 }
 
@@ -563,11 +552,10 @@ PTRef BVLogic::mkBVBwXor(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    char* msg;
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    return mkFun(sym_BV_BWXOR, args, &msg);
+    return mkFun(sym_BV_BWXOR, args);
 }
 
 PTRef BVLogic::mkBVCompl(const PTRef arg1)
@@ -575,8 +563,7 @@ PTRef BVLogic::mkBVCompl(const PTRef arg1)
     assert(hasSortBVNUM(arg1));
     vec<PTRef> args;
     args.push(arg1);
-    char* msg;
-    PTRef tr = mkFun(sym_BV_COMPL, args, &msg);
+    PTRef tr = mkFun(sym_BV_COMPL, args);
 //    PTRef neq = mkBVNeq(tr, arg1);
 //    if (!compl_diseqs.has(neq))
 //        compl_diseqs.insert(neq, true);

--- a/src/logics/BVLogic.C
+++ b/src/logics/BVLogic.C
@@ -225,7 +225,7 @@ BVLogic::mkBVEq(PTRef a1, PTRef a2)
 }
 
 PTRef
-BVLogic::mkBVNeg(PTRef tr, char** msg)
+BVLogic::mkBVNeg(PTRef tr)
 {
     assert(hasSortBVNUM(tr));
     if (isBVNeg(tr)) return getPterm(tr)[0];
@@ -242,7 +242,7 @@ BVLogic::mkBVNeg(PTRef tr, char** msg)
 }
 
 PTRef
-BVLogic::mkBVMinus(const vec<PTRef>& args_in, char** msg)
+BVLogic::mkBVMinus(const vec<PTRef>& args_in)
 {
     for (int i = 0; i < args_in.size(); i++)
         assert(hasSortBVNUM(args_in[i]));
@@ -250,18 +250,18 @@ BVLogic::mkBVMinus(const vec<PTRef>& args_in, char** msg)
     vec<PTRef> args;
     args_in.copyTo(args);
     if (args.size() == 1)
-        return mkBVNeg(args[0], msg);
+        return mkBVNeg(args[0]);
 
     assert(args.size() == 2);
     PTRef mo = mkBVConst(-1);
     vec<PTRef> tmp;
-    PTRef fact = mkBVTimes(mo, args[1], msg);
+    PTRef fact = mkBVTimes(mo, args[1]);
     args[1] = fact;
     return mkBVPlus(args[0], args[1]);
 }
 
 PTRef
-BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2)
 {
 
     assert(hasSortBVNUM(arg1));
@@ -282,7 +282,7 @@ BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2, char** msg)
 
 
 PTRef
-BVLogic::mkBVTimes(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVTimes(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -310,13 +310,12 @@ BVLogic::mkBVDiv(const PTRef arg1, const PTRef arg2)
     vec<PTRef> div_args;
     div_args.push(arg1);
     div_args.push(arg2);
-    char* msg;
     PTRef tr = mkFun(sym_BV_DIV, div_args);
     return tr;
 }
 
 PTRef
-BVLogic::mkBVUgeq(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVUgeq(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -325,7 +324,7 @@ BVLogic::mkBVUgeq(const PTRef arg1, const PTRef arg2, char** msg)
 
 
 PTRef
-BVLogic::mkBVSgeq(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVSgeq(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -333,7 +332,7 @@ BVLogic::mkBVSgeq(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-BVLogic::mkBVUgt(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVUgt(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -342,7 +341,7 @@ BVLogic::mkBVUgt(const PTRef arg1, const PTRef arg2, char** msg)
 
 
 PTRef
-BVLogic::mkBVSgt(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVSgt(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -350,7 +349,7 @@ BVLogic::mkBVSgt(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-BVLogic::mkBVSleq(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVSleq(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -367,7 +366,7 @@ BVLogic::mkBVSleq(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -388,7 +387,7 @@ BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-BVLogic::mkBVUlt(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVUlt(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
@@ -396,7 +395,7 @@ BVLogic::mkBVUlt(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-BVLogic::mkBVSlt(const PTRef arg1, const PTRef arg2, char** msg)
+BVLogic::mkBVSlt(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -194,54 +194,42 @@ class BVLogic: public CUFLogic
 
 
     PTRef mkBVNeg(const vec<PTRef>& args) { assert(args.size() == 1); return mkBVNeg(args[0]); }
-    PTRef mkBVNeg(PTRef, char**);
-    PTRef mkBVNeg(PTRef tr) {char* msg; PTRef trn = mkBVNeg(tr, &msg); assert(trn != PTRef_Undef); return trn; }
+    PTRef mkBVNeg(PTRef);
 
-    PTRef mkBVMinus(const vec<PTRef>&, char**);
-    PTRef mkBVMinus(const vec<PTRef>& args) { char *msg; PTRef tr = mkBVMinus(args, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkBVMinus(const vec<PTRef>&);
     PTRef mkBVMinus(const PTRef a1, const PTRef a2) { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkBVMinus(tmp); }
 
     PTRef mkBVPlus(const vec<PTRef>& args) { assert(args.size() == 2); return mkBVPlus(args[0], args[1]); }
-    PTRef mkBVPlus(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVPlus(const PTRef arg1, const PTRef arg2) { char *msg; PTRef tr = mkBVPlus(arg1, arg2, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkBVPlus(const PTRef arg1, const PTRef arg2);
 
     PTRef mkBVTimes(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVTimes(args[0], args[1]);}
-    PTRef mkBVTimes(const PTRef, const PTRef, char**);
-    PTRef mkBVTimes(const PTRef arg1, const PTRef arg2) { char *msg; PTRef tr = mkBVTimes(arg1, arg2, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkBVTimes(const PTRef, const PTRef);
 
     PTRef mkBVDiv(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVDiv(args[0], args[1]);}
     PTRef mkBVDiv(const PTRef nom, const PTRef den);
 
-    PTRef mkBVSleq(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVSleq(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVSleq(arg1, arg2, &msg); }
+    PTRef mkBVSleq(const PTRef arg1, const PTRef arg2);
     PTRef mkBVSleq(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVSleq(args[0], args[1]);}
 
-    PTRef mkBVUleq(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVUleq(const PTRef arg1, const PTRef arg2) { char *msg; return mkBVUleq(arg1, arg2, &msg); }
+    PTRef mkBVUleq(const PTRef arg1, const PTRef arg2);
     PTRef mkBVUleq(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVUleq(args[0], args[1]);}
 
-    PTRef mkBVSlt(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVSlt(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVSlt(arg1, arg2, &msg); }
+    PTRef mkBVSlt(const PTRef arg1, const PTRef arg2);
     PTRef mkBVSlt(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVSlt(args[0], args[1]);}
 
-    PTRef mkBVUlt(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVUlt(const PTRef arg1, const PTRef arg2) { char *msg; return mkBVUlt(arg1, arg2, &msg); }
+    PTRef mkBVUlt(const PTRef arg1, const PTRef arg2);
     PTRef mkBVUlt(const vec<PTRef>& args) {assert(args.size() == 2); return mkBVUlt(args[0], args[1]);}
 
-    PTRef mkBVSgeq(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVSgeq(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVSgeq(arg1, arg2, &msg); }
+    PTRef mkBVSgeq(const PTRef arg1, const PTRef arg2);
     PTRef mkBVSgeq(const vec<PTRef>& args) { assert(args.size() == 2); return mkBVSgeq(args[0], args[1]); }
 
-    PTRef mkBVUgeq(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkBVUgeq(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVUgeq(arg1, arg2, &msg); }
+    PTRef mkBVUgeq(const PTRef arg1, const PTRef arg2);
     PTRef mkBVUgeq(const vec<PTRef>& args) { assert(args.size() == 2); return mkBVUgeq(args[0], args[1]); }
 
-    PTRef mkBVSgt(const PTRef arg1, const PTRef arg2, char** tmp);
-    PTRef mkBVSgt(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVSgt(arg1, arg2, &msg); }
+    PTRef mkBVSgt(const PTRef arg1, const PTRef arg2);
     PTRef mkBVSgt(const vec<PTRef>& args) { assert(args.size() == 2); return mkBVSgt(args[0], args[1]); }
 
-    PTRef mkBVUgt(const PTRef arg1, const PTRef arg2, char** tmp);
-    PTRef mkBVUgt(const PTRef arg1, const PTRef arg2) { char* msg; return mkBVUgt(arg1, arg2, &msg); }
+    PTRef mkBVUgt(const PTRef arg1, const PTRef arg2);
     PTRef mkBVUgt(const vec<PTRef>& args) { assert(args.size() == 2); return mkBVUgt(args[0], args[1]); }
 
 

--- a/src/logics/CUFLogic.C
+++ b/src/logics/CUFLogic.C
@@ -209,7 +209,7 @@ CUFLogic::mkCUFNeg(PTRef tr, char** msg)
         PTRef nterm = mkCUFConst(v);
         SymRef s = getPterm(nterm).symb();
         vec<PTRef> args;
-        return mkFun(s, args, msg);
+        return mkFun(s, args);
     }
     PTRef mo = mkCUFConst(-1);
     return mkCUFTimes(mo, tr);
@@ -240,10 +240,10 @@ CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> sum_args;
     sum_args.push(arg1);
     sum_args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_PLUS, sum_args, msg);
+    PTRef tr = mkFun(sym_CUF_PLUS, sum_args);
     sum_args[0] = arg2;
     sum_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_PLUS, sum_args, msg);
+    PTRef tr_comm = mkFun(sym_CUF_PLUS, sum_args);
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -321,10 +321,10 @@ CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
     times_args.push(arg1);
     times_args.push(arg2);
 
-    PTRef tr = mkFun(sym_CUF_TIMES, times_args, msg);
+    PTRef tr = mkFun(sym_CUF_TIMES, times_args);
     times_args[0] = arg2;
     times_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_TIMES, times_args, msg);
+    PTRef tr_comm = mkFun(sym_CUF_TIMES, times_args);
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -337,8 +337,7 @@ CUFLogic::mkCUFDiv(const PTRef arg1, const PTRef arg2)
     vec<PTRef> div_args;
     div_args.push(arg1);
     div_args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_DIV, div_args, &msg);
+    PTRef tr = mkFun(sym_CUF_DIV, div_args);
     return tr;
 }
 
@@ -362,7 +361,7 @@ CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    PTRef leq_tr = mkFun(sym_CUF_LEQ, args, msg);
+    PTRef leq_tr = mkFun(sym_CUF_LEQ, args);
     return mkOr(leq_tr, mkEq(arg1, arg2));
 }
 
@@ -380,7 +379,7 @@ CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2, char** msg)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_GT, args, msg);
+    PTRef tr = mkFun(sym_CUF_GT, args);
     // a>b -> a != b
     PTRef tr_eq = mkEq(arg1, arg2);
     PTRef n_tr_eq = mkCUFNot(tr_eq);
@@ -402,8 +401,7 @@ PTRef CUFLogic::mkCUFLshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_CUF_LSHIFT, args, &msg);
+    return mkFun(sym_CUF_LSHIFT, args);
 }
 
 PTRef CUFLogic::mkCUFLRshift(const PTRef arg1, const PTRef arg2)
@@ -413,8 +411,7 @@ PTRef CUFLogic::mkCUFLRshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_CUF_LRSHIFT, args, &msg);
+    return mkFun(sym_CUF_LRSHIFT, args);
 }
 
 PTRef CUFLogic::mkCUFARshift(const PTRef arg1, const PTRef arg2)
@@ -424,8 +421,7 @@ PTRef CUFLogic::mkCUFARshift(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    return mkFun(sym_CUF_ARSHIFT, args, &msg);
+    return mkFun(sym_CUF_ARSHIFT, args);
 }
 
 PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
@@ -437,9 +433,7 @@ PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-
-    return mkFun(sym_CUF_MOD, args, &msg);
+    return mkFun(sym_CUF_MOD, args);
 }
 
 PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
@@ -447,11 +441,10 @@ PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_BWAND, args, &msg);
+    PTRef tr = mkFun(sym_CUF_BWAND, args);
     args[0] = arg2;
     args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWAND, args, &msg);
+    PTRef tr_comm = mkFun(sym_CUF_BWAND, args);
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -463,11 +456,10 @@ PTRef CUFLogic::mkCUFBwOr(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_BWOR, args, &msg);
+    PTRef tr = mkFun(sym_CUF_BWOR, args);
     args[0] = arg2;
     args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWOR, args, &msg);
+    PTRef tr_comm = mkFun(sym_CUF_BWOR, args);
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -478,8 +470,7 @@ PTRef CUFLogic::mkCUFInc(const PTRef arg1)
 {
     vec<PTRef> args;
     args.push(arg1);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_INC, args, &msg);
+    PTRef tr = mkFun(sym_CUF_INC, args);
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -490,8 +481,7 @@ PTRef CUFLogic::mkCUFDec(const PTRef arg1)
 {
     vec<PTRef> args;
     args.push(arg1);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_DEC, args, &msg);
+    PTRef tr = mkFun(sym_CUF_DEC, args);
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -503,8 +493,7 @@ PTRef CUFLogic::mkCUFLand(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_LAND, args, &msg);
+    PTRef tr = mkFun(sym_CUF_LAND, args);
     return tr;
 }
 
@@ -513,8 +502,7 @@ PTRef CUFLogic::mkCUFLor(const PTRef arg1, const PTRef arg2)
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_LOR, args, &msg);
+    PTRef tr = mkFun(sym_CUF_LOR, args);
     return tr;
 }
 
@@ -525,14 +513,13 @@ PTRef CUFLogic::mkCUFNot(const PTRef arg)
 
 PTRef CUFLogic::mkCUFBwXor(const PTRef arg1, const PTRef arg2)
 {
-    char* msg;
     vec<PTRef> args;
     args.push(arg1);
     args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWXOR, args, &msg);
+    PTRef tr = mkFun(sym_CUF_BWXOR, args);
     args[0] = arg2;
     args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWXOR, args, &msg);
+    PTRef tr_comm = mkFun(sym_CUF_BWXOR, args);
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -543,8 +530,7 @@ PTRef CUFLogic::mkCUFCompl(const PTRef arg1)
 {
     vec<PTRef> args;
     args.push(arg1);
-    char* msg;
-    PTRef tr = mkFun(sym_CUF_COMPL, args, &msg);
+    PTRef tr = mkFun(sym_CUF_COMPL, args);
     PTRef neq = mkCUFNeq(tr, arg1);
     if (!compl_diseqs.has(neq))
         compl_diseqs.insert(neq, true);
@@ -555,16 +541,14 @@ PTRef CUFLogic::mkCUFSizeof(const PTRef arg)
 {
     vec<PTRef> args;
     args.push(arg);
-    char* msg;
-    return mkFun(sym_CUF_SIZEOF, args, &msg);
+    return mkFun(sym_CUF_SIZEOF, args);
 }
 
 PTRef CUFLogic::mkCUFAddrof(const PTRef arg)
 {
     vec<PTRef> args;
     args.push(arg);
-    char* msg;
-    return mkFun(sym_CUF_SIZEOF, args, &msg);
+    return mkFun(sym_CUF_SIZEOF, args);
 }
 
 
@@ -572,8 +556,7 @@ PTRef CUFLogic::mkCUFPtr(const PTRef arg)
 {
     vec<PTRef> args;
     args.push(arg);
-    char* msg;
-    return mkFun(sym_CUF_PTR, args, &msg);
+    return mkFun(sym_CUF_PTR, args);
 }
 
 PTRef CUFLogic::mkCUFCond(const PTRef cond, PTRef i_arg, PTRef e_arg)

--- a/src/logics/LALogic.C
+++ b/src/logics/LALogic.C
@@ -244,14 +244,13 @@ bool LALogic::okToPartition(PTRef tr) const
 void LALogic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
 {
     if (split_eq && isNumEq(tr)) {
-        char *msg;
         Pterm& p = getPterm(tr);
         PTRef a1 = p[0];
         PTRef a2 = p[1];
         vec<PTRef> args;
         args.push(a1); args.push(a2);
-        PTRef i1 = mkNumLeq(args, &msg);
-        PTRef i2 = mkNumGeq(args, &msg);
+        PTRef i1 = mkNumLeq(args);
+        PTRef i2 = mkNumGeq(args);
         args.clear();
         args.push(i1); args.push(i2);
         PTRef andr = mkAnd(args);
@@ -438,29 +437,10 @@ PTRef LALogic::mkNumLeq(const vec<PTRef> &args) {
     return tr;
 }
 
-PTRef LALogic::mkNumLeq(const vec<PTRef> &args, char** msg) {
-    assert(args.size() == 2);
-    PTRef tr = mkNumLeq(args[0], args[1]);
-    assert(tr != PTRef_Undef);
-    return tr;
-}
-
-PTRef LALogic::mkNumGeq(const vec<PTRef> &args) {
-    char *msg;
-    PTRef tr = mkNumGeq(args, &msg);
-    assert(tr != PTRef_Undef);
-    return tr;
-}
 PTRef LALogic::mkNumGeq(const PTRef arg1, const PTRef arg2) {
     return mkNumLeq(arg2, arg1);
 }
 
-PTRef LALogic::mkNumLt(const vec<PTRef> &args) {
-    char *msg;
-    PTRef tr = mkNumLt(args, &msg);
-    assert(tr != PTRef_Undef);
-    return tr;
-}
 PTRef LALogic::mkNumLt(const PTRef arg1, const PTRef arg2) {
     vec<PTRef> tmp;
     tmp.push(arg1);
@@ -468,12 +448,6 @@ PTRef LALogic::mkNumLt(const PTRef arg1, const PTRef arg2) {
     return mkNumLt(tmp);
 }
 
-PTRef LALogic::mkNumGt(const vec<PTRef> &args) {
-    char *msg;
-    PTRef tr = mkNumGt(args, &msg);
-    assert(tr != PTRef_Undef);
-    return tr;
-}
 PTRef LALogic::mkNumGt(const PTRef arg1, const PTRef arg2) {
     vec<PTRef> tmp;
     tmp.push(arg1);
@@ -683,12 +657,12 @@ PTRef LALogic::mkNumLeq(PTRef lhs, PTRef rhs)
     return r;
 
 }
-PTRef LALogic::mkNumGeq(const vec<PTRef>& args, char** msg)
+PTRef LALogic::mkNumGeq(const vec<PTRef> & args)
 {
     assert(args.size() == 2);
     return mkNumLeq(args[1], args[0]);
 }
-PTRef LALogic::mkNumLt(const vec<PTRef>& args, char** msg)
+PTRef LALogic::mkNumLt(const vec<PTRef> & args)
 {
     if (isConstant(args[0]) && isConstant(args[1])) {
         opensmt::Number const& v1 = this->getNumConst(args[0]);
@@ -706,11 +680,10 @@ PTRef LALogic::mkNumLt(const vec<PTRef>& args, char** msg)
     }
     return mkNot(tr);
 }
-PTRef LALogic::mkNumGt(const vec<PTRef>& args, char** msg)
+PTRef LALogic::mkNumGt(const vec<PTRef> & args)
 {
-    PTRef tr = mkNumLeq(args, msg);
+    PTRef tr = mkNumLeq(args);
     if (tr == PTRef_Undef) {
-        printf("%s\n", *msg);
         assert(false);
     }
     return mkNot(tr);
@@ -729,13 +702,13 @@ PTRef LALogic::insertTerm(SymRef sym, vec<PTRef>& terms, char **msg)
     if (sym == get_sym_Num_DIV())
         return mkNumDiv(terms, msg);
     if (sym == get_sym_Num_LEQ())
-        return mkNumLeq(terms, msg);
+        return mkNumLeq(terms);
     if (sym == get_sym_Num_LT())
-        return mkNumLt(terms, msg);
+        return mkNumLt(terms);
     if (sym == get_sym_Num_GEQ())
-        return mkNumGeq(terms, msg);
+        return mkNumGeq(terms);
     if (sym == get_sym_Num_GT())
-        return mkNumGt(terms, msg);
+        return mkNumGt(terms);
     if (sym == get_sym_Num_ITE())
         return mkIte(terms);
     return Logic::insertTerm(sym, terms, msg);

--- a/src/logics/LALogic.C
+++ b/src/logics/LALogic.C
@@ -27,7 +27,7 @@ const opensmt::Number&
 LALogic::getNumConst(PTRef tr) const
 {
     SymId id = sym_store[getPterm(tr).symb()].getId();
-    assert(id < numbers.size() && numbers[id] != NULL);
+    assert(id < static_cast<unsigned int>(numbers.size()) && numbers[id] != nullptr);
     return *numbers[id];
 }
 void LALogic::splitTermToVarAndConst(const PTRef& term, PTRef& var, PTRef& fac) const
@@ -155,7 +155,7 @@ lbool LALogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Map<PTR
         // FORWARD substitution
         // We put the matrix equalities into upper triangular form
         //
-        for (uint32_t i = 0; i < equalities.size()-1; i++) {
+        for (int i = 0; i < equalities.size()-1; i++) {
             LAExpression &s = *equalities[i];
             // Solve w.r.t. first variable
             if (s.solve( ) == PTRef_Undef) {
@@ -165,7 +165,7 @@ lbool LALogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Map<PTR
             }
             // Use the first variable x in s to generate a
             // substitution and replace x in lac
-            for ( unsigned j = i + 1 ; j < equalities.size( ) ; j ++ ) {
+            for ( int j = i + 1 ; j < equalities.size( ) ; j ++ ) {
                 LAExpression & lac = *equalities[ j ];
                 combine( s, lac );
             }
@@ -193,7 +193,7 @@ lbool LALogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Map<PTR
         //
         // Now, for each row we get a substitution
         //
-        for (unsigned i = 0 ;i < equalities.size(); i++) {
+        for (int i = 0 ;i < equalities.size(); i++) {
             LAExpression& lae = *equalities[i];
             pair<PTRef, PTRef> sub = lae.getSubst();
             if (sub.first == PTRef_Undef) continue;
@@ -318,7 +318,7 @@ PTRef  LALogic::mkConst(const opensmt::Number& c)
     ptr = mkVar(getSort_num(), val);
     // Store the value of the number as a real
     SymId id = sym_store[getPterm(ptr).symb()].getId();
-    for (int i = numbers.size(); i <= id; i++) { numbers.push(nullptr); }
+    for (int i = numbers.size(); static_cast<unsigned int>(i) <= id; i++) { numbers.push(nullptr); }
     if (numbers[id] == nullptr) { numbers[id] = new opensmt::Number(val); }
     assert(c == *numbers[id]);
     markConstant(id);
@@ -727,7 +727,7 @@ PTRef LALogic::mkConst(SRef s, const char* name)
         ptr = mkVar(s, rat);
         // Store the value of the number as a real
         SymId id = sym_store[getPterm(ptr).symb()].getId();
-        for (int i = numbers.size(); i <= id; i++)
+        for (int i = numbers.size(); static_cast<unsigned>(i) <= id; i++)
             numbers.push(nullptr);
         if (numbers[id] != nullptr) { delete numbers[id]; }
         numbers[id] = new opensmt::Number(rat);

--- a/src/logics/LALogic.C
+++ b/src/logics/LALogic.C
@@ -295,7 +295,7 @@ PTRef LALogic::mkNumNeg(PTRef tr, char** msg)
             assert(tr_arg != PTRef_Undef);
             args.push(tr_arg);
         }
-        PTRef tr_n = mkFun(get_sym_Num_PLUS(), args, msg);
+        PTRef tr_n = mkFun(get_sym_Num_PLUS(), args);
         assert(tr_n == mkNumPlus(args, msg));
         assert(tr_n != PTRef_Undef);
         return tr_n;
@@ -489,8 +489,6 @@ PTRef LALogic::mkNumMinus(const vec<PTRef>& args_in, char** msg)
     args_in.copyTo(args);
     if (args.size() == 1) {
         return mkNumNeg(args[0], msg);
-//        s = sym_Real_NEG;
-//        return mkFun(s, args, msg);
     }
     assert (args.size() == 2);
     PTRef mo = mkConst(getSort_num(), "-1");
@@ -533,7 +531,7 @@ PTRef LALogic::mkNumPlus(const vec<PTRef>& args, char** msg)
     if (args_new.size() == 1)
         return args_new[0];
     if(s_new != get_sym_Num_PLUS()) {
-        return mkFun(s_new, args_new, msg);
+        return mkFun(s_new, args_new);
     }
     // This code takes polynomials (+ (* v c1) (* v c2)) and converts them to the form (* v c3) where c3 = c1+c2
     VecMap<PTRef,PTRef,PTRefHash> s2t;
@@ -574,7 +572,7 @@ PTRef LALogic::mkNumPlus(const vec<PTRef>& args, char** msg)
     }
     if (sum_args.size() == 0) return getTerm_NumZero();
     if (sum_args.size() == 1) return sum_args[0];
-    PTRef tr = mkFun(s_new, sum_args, msg);
+    PTRef tr = mkFun(s_new, sum_args);
     return tr;
 }
 PTRef LALogic::mkNumTimes(const vec<PTRef>& tmp_args, char** msg)
@@ -594,7 +592,7 @@ PTRef LALogic::mkNumTimes(const vec<PTRef>& tmp_args, char** msg)
     vec<PTRef> args_new;
     SymRef s_new;
     simp.simplify(get_sym_Num_TIMES(), args, s_new, args_new, msg);
-    PTRef tr = mkFun(s_new, args_new, msg);
+    PTRef tr = mkFun(s_new, args_new);
     // Either a real term or, if we constructed a multiplication of a
     // constant and a sum, a real sum.
     if (isNumTerm(tr) || isNumPlus(tr) || isUF(tr))
@@ -618,7 +616,7 @@ PTRef LALogic::mkNumDiv(const vec<PTRef>& args, char** msg)
         args_new[1] = mkConst(FastRational_inverse(getNumConst(args_new[1]))); //mkConst(1/getRealConst(args_new[1]));
         return mkNumTimes(args_new);
     }
-    PTRef tr = mkFun(s_new, args_new, msg);
+    PTRef tr = mkFun(s_new, args_new);
     return tr;
 }
 

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -134,17 +134,13 @@ public:
     virtual PTRef mkNumDiv(const vec<PTRef> &, char **);
     virtual  PTRef mkNumDiv(const vec<PTRef> &args);
     virtual  PTRef mkNumDiv(const PTRef nom, const PTRef den);
-    virtual PTRef mkNumLeq(const vec<PTRef> &, char **);
     virtual PTRef mkNumLeq(const vec<PTRef> &args);
     virtual PTRef mkNumLeq(const PTRef arg1, const PTRef arg2);
-    virtual PTRef mkNumGeq(const vec<PTRef> &, char **);
-    virtual PTRef mkNumGeq(const vec<PTRef> &args);
+    virtual PTRef mkNumGeq(const vec<PTRef> & args);
     virtual PTRef mkNumGeq(const PTRef arg1, const PTRef arg2);
-    virtual  PTRef mkNumLt(const vec<PTRef> &, char **);
-    virtual PTRef mkNumLt(const vec<PTRef> &args);
+    virtual PTRef mkNumLt(const vec<PTRef> & args);
     virtual  PTRef mkNumLt(const PTRef arg1, const PTRef arg2);
-    virtual PTRef mkNumGt(const vec<PTRef> &, char **);
-    virtual PTRef mkNumGt(const vec<PTRef> &args);
+    virtual PTRef mkNumGt(const vec<PTRef> & args);
     virtual PTRef mkNumGt(const PTRef arg1, const PTRef arg2);
 
     virtual bool isNegated(PTRef tr) const;

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -164,7 +164,7 @@ public:
     virtual char *printTerm(PTRef tr, bool l, bool s) const override;
 
     // MB: In pure LA, there are never nested boolean terms
-    virtual vec<PTRef> getNestedBoolRoots (PTRef tr)  const override { return vec<PTRef>(); }
+    virtual vec<PTRef> getNestedBoolRoots (PTRef)  const override { return vec<PTRef>(); }
 
 };
 // Determine for two multiplicative terms (* k1 v1) and (* k2 v2), v1 !=

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -431,7 +431,7 @@ bool Logic::isTheorySymbol(SymRef tr) const {
 }
 
 void Logic::setAppearsInUF(PTRef tr) {
-    uint32_t id = Idx(getPterm(tr).getId());
+    int id = static_cast<int>(Idx(getPterm(tr).getId()));
 
     if (appears_in_uf.size() <= id || appears_in_uf[id] == false)
         propFormulasAppearingInUF.push(tr);
@@ -444,7 +444,7 @@ void Logic::setAppearsInUF(PTRef tr) {
 
 bool Logic::appearsInUF(PTRef tr) const {
     uint32_t id = Idx(getPterm(tr).getId());
-    if (id < appears_in_uf.size())
+    if (id < static_cast<unsigned int>(appears_in_uf.size()))
         return appears_in_uf[id];
     else
         return false;
@@ -1022,7 +1022,7 @@ void Logic::markConstant(PTRef ptr) {
 
 void Logic::markConstant(SymId id) {
     // Code to allow efficient constant detection.
-    while (id >= constants.size())
+    while (id >= static_cast<unsigned int>(constants.size()))
         constants.push(false);
     constants[id] = true;
 }
@@ -1769,7 +1769,7 @@ Logic::dumpHeaderToFile(ostream& dump_out)
         free(sym);
         Symbol& symb = sym_store[s];
         dump_out << "(";
-        for(int j = 0; j < symb.nargs(); ++j)
+        for(unsigned int j = 0; j < symb.nargs(); ++j)
         {
             dump_out << sort_store.getName(symb[j]) << " ";
         }

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -984,16 +984,14 @@ PTRef Logic::mkConst(const char* name, const char** msg)
 PTRef Logic::mkVar(SRef s, const char* name) {
     vec<SRef> sort_args;
     sort_args.push(s);
-    char* msg;
-    SymRef sr = newSymb(name, sort_args, &msg);
+    SymRef sr = newSymb(name, sort_args);
     if (sr == SymRef_Undef) {
-        cerr << "Warning: while mkVar " << name << ": " << msg << endl;
-        free(msg);
+        std::cerr << "Warning: while mkVar " << name << ": " << std::endl;
         assert(symNameToRef(name).size() == 1);
         sr = symNameToRef(name)[0];
     }
     vec<PTRef> tmp;
-    PTRef ptr = mkFun(sr, tmp, &msg);
+    PTRef ptr = mkFun(sr, tmp);
     assert (ptr != PTRef_Undef);
 
     return ptr;
@@ -1043,7 +1041,7 @@ PTRef Logic::mkUninterpFun(SymRef f, const vec<PTRef> & args) {
     return tr;
 }
 
-PTRef Logic::mkFun(SymRef f, const vec<PTRef>& args, char** msg)
+PTRef Logic::mkFun(SymRef f, const vec<PTRef>& args)
 {
     PTRef tr;
     if (f == SymRef_Undef)
@@ -1061,7 +1059,7 @@ PTRef Logic::mkBoolVar(const char* name)
     SymRef sr = declareFun(name, sort_BOOL, tmp, &msg);
     assert(sr != SymRef_Undef);
     vec<PTRef> tmp2;
-    PTRef tr = mkFun(sr, tmp2, &msg);
+    PTRef tr = mkFun(sr, tmp2);
     return tr;
 }
 

--- a/src/logics/Logic.C
+++ b/src/logics/Logic.C
@@ -985,8 +985,9 @@ PTRef Logic::mkVar(SRef s, const char* name) {
     vec<SRef> sort_args;
     sort_args.push(s);
     SymRef sr = newSymb(name, sort_args);
+    assert(sr != SymRef_Undef);
     if (sr == SymRef_Undef) {
-        std::cerr << "Warning: while mkVar " << name << ": " << std::endl;
+        std::cerr << "Unexpected situation in  Logic::mkVar for " << name << std::endl;
         assert(symNameToRef(name).size() == 1);
         sr = symNameToRef(name)[0];
     }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -218,8 +218,7 @@ class Logic {
     bool        containsSort  (const char* name)      const;// { return sort_store.containsSort(name); }
   protected:
     SRef        newSort       (IdRef idr, const char* name, vec<SRef>& tmp);// { return sort_store.newSort(idr, name, tmp); }
-    PTRef       mkFun         (SymRef f, const vec<PTRef>& args, char** msg);
-    PTRef       mkFun         (SymRef f, const vec<PTRef>& args) { char* msg; return mkFun(f, args, &msg); };
+    PTRef       mkFun         (SymRef f, const vec<PTRef>& args);
     void        markConstant  (PTRef ptr);
     void        markConstant  (SymId sid);
 
@@ -231,7 +230,7 @@ class Logic {
     const char* getSortName   (const SRef s)  ;//              { return sort_store.getName(s); }
 
     // Symbols
-    SymRef      newSymb       (const char* name, vec<SRef>& sort_args, char** msg)
+    SymRef      newSymb       (const char* name, vec<SRef>& sort_args)
                                                             { return sym_store.newSymb(name, sort_args); }
     Symbol& getSym              (const SymRef s)        { return sym_store[s]; }
     const Symbol& getSym        (const SymRef s)        const { return sym_store[s]; }

--- a/src/logics/Theory.C
+++ b/src/logics/Theory.C
@@ -58,13 +58,13 @@ namespace{
     }
 }
 
-//
-// Given coll_f = (R_1 /\ ... /\ R_{curr-1}) /\ (U_1 /\ ... /\ U_{curr-1}) /\
-// P_{curr}, compute U_{curr}.  Place U_{curr} to frame and simplify
+/*
+// Given coll_f = (R_1 /\ ... /\ R_{curr-1}) /\ (U_1 /\ ... /\ U_{curr-1}) /\ P_{curr},
+// compute U_{curr}.  Place U_{curr} to frame and simplify
 // the problem P_{curr} using (U_1 /\ ... /\ U_{curr}) resulting in
 // R_{curr}.
 // If x = f(Y) is a newly found substitution and there is a lower frame F containing x, add x = f(Y) to R_{curr}.
-//
+*/
 bool Theory::computeSubstitutions(const PTRef coll_f, const vec<PFRef>& frames, const int curr)
 {
     if (!config.do_substitutions() || config.produce_inter()) {

--- a/src/logics/Theory.C
+++ b/src/logics/Theory.C
@@ -58,13 +58,13 @@ namespace{
     }
 }
 
-/*
+
 // Given coll_f = (R_1 /\ ... /\ R_{curr-1}) /\ (U_1 /\ ... /\ U_{curr-1}) /\ P_{curr},
 // compute U_{curr}.  Place U_{curr} to frame and simplify
 // the problem P_{curr} using (U_1 /\ ... /\ U_{curr}) resulting in
 // R_{curr}.
 // If x = f(Y) is a newly found substitution and there is a lower frame F containing x, add x = f(Y) to R_{curr}.
-*/
+//
 bool Theory::computeSubstitutions(const PTRef coll_f, const vec<PFRef>& frames, const int curr)
 {
     if (!config.do_substitutions() || config.produce_inter()) {

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -154,7 +154,7 @@ class Clause {
         header.reloced   = 0;
         header.size      = ps.size();
 
-        for (int i = 0; i < ps.size(); i++)
+        for (unsigned i = 0; i < (unsigned)ps.size(); i++)
             data[i].lit = ps[i];
 
         if (header.has_extra){
@@ -168,12 +168,12 @@ public:
     void calcAbstraction() {
         assert(header.has_extra);
         uint32_t abstraction = 0;
-        for (int i = 0; i < size(); i++)
+        for (unsigned i = 0; i < size(); i++)
             abstraction |= 1 << (var(data[i].lit) & 31);
         data[header.size].abs = abstraction;  }
 
 
-    int          size        ()      const   { return header.size; }
+    unsigned int size        ()      const   { return header.size; }
     void         shrink      (int i)         { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
     void         pop         ()              { shrink(1); }
     bool         learnt      ()      const   { return header.learnt; }

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -174,7 +174,7 @@ public:
 
 
     unsigned int size        ()      const   { return header.size; }
-    void         shrink      (unsigned int i)         { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
+    void         shrink      (unsigned i)    { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
     void         pop         ()              { shrink(1); }
     bool         learnt      ()      const   { return header.learnt; }
     bool         has_extra   ()      const   { return header.has_extra; }

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -174,7 +174,7 @@ public:
 
 
     unsigned int size        ()      const   { return header.size; }
-    void         shrink      (int i)         { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
+    void         shrink      (unsigned int i)         { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
     void         pop         ()              { shrink(1); }
     bool         learnt      ()      const   { return header.learnt; }
     bool         has_extra   ()      const   { return header.has_extra; }

--- a/src/minisat/mtl/Alg.h
+++ b/src/minisat/mtl/Alg.h
@@ -35,9 +35,9 @@ template<class V, class T>
 static inline void remove(V& ts, const T& t)
 {
     int j = 0;
-    for (; j < ts.size() && ts[j] != t; j++);
-    assert(j < ts.size());
-    for (; j < ts.size()-1; j++) ts[j] = ts[j+1];
+    for (; j < static_cast<int>(ts.size()) && ts[j] != t; j++);
+    assert(j < static_cast<int>(ts.size()));
+    for (; j < static_cast<int>(ts.size())-1; j++) ts[j] = ts[j+1];
     ts.pop();
 }
 
@@ -46,8 +46,8 @@ template<class V, class T>
 static inline bool find(V& ts, const T& t)
 {
     int j = 0;
-    for (; j < ts.size() && ts[j] != t; j++);
-    return j < ts.size();
+    for (; j < static_cast<int>(ts.size()) && ts[j] != t; j++);
+    return j < static_cast<int>(ts.size());
 }
 
 

--- a/src/minisat/mtl/Map.h
+++ b/src/minisat/mtl/Map.h
@@ -275,8 +275,8 @@ class VecMap {
     int        size;
 
     // Don't allow copying (error prone):
-    VecMap<K,D,H,E>&  operator = (VecMap<K,D,H,E>& ) { assert(0); }
-                   VecMap        (VecMap<K,D,H,E>& ) { assert(0); }
+    VecMap<K,D,H,E>&  operator = (VecMap<K,D,H,E>& ) = delete;
+                   VecMap        (VecMap<K,D,H,E>& ) = delete;
 
     bool    checkCap(int new_size) const { return new_size > cap; }
 
@@ -430,8 +430,8 @@ class VecKeyMap {
     int        size;
 
     // Don't allow copying (error prone):
-    VecKeyMap<K,D,H,E>&  operator = (VecKeyMap<K,D,H,E>& other) { assert(0); }
-                   VecKeyMap        (VecKeyMap<K,D,H,E>& other) { assert(0); }
+    VecKeyMap<K,D,H,E>&  operator = (VecKeyMap<K,D,H,E>& other) = delete;
+                   VecKeyMap        (VecKeyMap<K,D,H,E>& other) = delete;
 
     bool    checkCap(int new_size) const { return new_size > cap; }
 
@@ -560,8 +560,8 @@ class MapVec
     int cap;
 
     // Don't allow copying (error prone):
-    MapVec<K,D,H>&  operator = (MapVec<K,D,H>& other) { assert(0); return *this; }
-    MapVec<K,D,H,E>            (MapVec<K,D,H,E>& other) { assert(0); }
+    MapVec<K,D,H>&  operator = (MapVec<K,D,H>& other) = delete;
+    MapVec<K,D,H,E>            (MapVec<K,D,H,E>& other) = delete;
 
     // Helpers for calculating next capacity:
     static inline int  imax   (int x, int y) { int mask = (y-x) >> (sizeof(int)*8-1); return (x&mask) + (y&(~mask)); }

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -106,8 +106,8 @@ class vec<vec<T> > {
     int cap;
 
     // Don't allow copying (error prone):
-    vec<vec<T> >&  operator = (vec<vec<T> >& other) { assert(0); return *this; }
-                   vec        (vec<vec<T> >& other) { assert(0); }
+    vec<vec<T> >&  operator = (vec<vec<T> >& other) = delete;
+                   vec        (vec<vec<T> >& other) = delete;
 
 
     // Helpers for calculating next capacity:

--- a/src/parsers/smt2new/CMakeLists.txt
+++ b/src/parsers/smt2new/CMakeLists.txt
@@ -22,5 +22,7 @@ target_sources(parsers
     PRIVATE ${FLEX_smt2newScanner_OUTPUTS}
 )
 
+target_compile_options(parsers PRIVATE -Wno-error)
+
 install(FILES smt2newcontext.h
 DESTINATION ${INSTALL_HEADERS_DIR})

--- a/src/parsers/smt2new/smt2newlexer.ll
+++ b/src/parsers/smt2new/smt2newlexer.ll
@@ -31,6 +31,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 %option noyywrap
 %option yylineno
 %option stack
+%option nounput
+%option noinput
+%option noyy_top_state
 
 %{
 

--- a/src/parsers/smt2new/smt2newparser.yy
+++ b/src/parsers/smt2new/smt2newparser.yy
@@ -24,11 +24,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *********************************************************************/
 
 
-%pure-parser
+%define api.pure
+%define parse.error verbose
 %name-prefix "smt2new"
 %locations
 %defines
-%error-verbose
 %parse-param { Smt2newContext* context }
 %lex-param { void* scanner }
 

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -321,6 +321,7 @@ public:
     bool verifyTreeInterpolantsFromLeaves   ( opensmt::InterpolationTree*, vec<PTRef> &);
 
     void produceMultipleInterpolants        ( const vec< ipartitions_t >&, vec<PTRef> &);
+    void produceMultipleInterpolants        ( const std::vector< ipartitions_t >&, vec<PTRef> &);
     void produceSingleInterpolant           (vec<PTRef>& interpolants);
     void produceSingleInterpolant           (vec<PTRef>& interpolants, const ipartitions_t& A_mask);
     void printProofAsDotty                  ( ostream &, ipartitions_t ip = 0);

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -281,7 +281,7 @@ public:
 , theory ( th )
 , proof	   ( t )
 , logic_ ( th.getLogic() )
-, thandler {new THandler(c, th)}
+, thandler {new THandler(th)}
 , graph_   ( new vector<ProofNode*> )
 , graph    ( *graph_ )
 #ifdef FULL_LABELING

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -38,7 +38,7 @@ using namespace opensmt;
 class CoreSMTSolver;
 class Proof;
 class Logic;
-class SMTConfig;
+struct SMTConfig;
 
 typedef unsigned clauseid_t;
 
@@ -135,18 +135,15 @@ struct InterpolData
 struct ProofNode
 {
     ProofNode            (Logic& _logic)
-    : clause     (NULL)
-    , pivot      (-1)
-    , ant1       (NULL)
-    , ant2       (NULL)
-    , resolvents ()
-    , i_data     (NULL)
-    , logic   (_logic)
+    : logic   (_logic)
+    , clause     (nullptr)
     , clause_ref (CRef_Undef)
-    {
-        clause = NULL;
-        i_data = NULL;
-    }
+    , pivot      (-1)
+    , ant1       (nullptr)
+    , ant2       (nullptr)
+    , resolvents ()
+    , i_data     (nullptr)
+    { }
 
     ~ProofNode ( )
     {
@@ -266,7 +263,7 @@ private:
     ProofNode *        ant2;               // Edges to antecedents
     set< clauseid_t  > resolvents;         // Resolvents
     clause_type        type;               // Node type
-    InterpolData*       i_data;               // Data for interpolants computation
+    InterpolData*      i_data;             // Data for interpolants computation
 };
 
 
@@ -282,11 +279,11 @@ public:
 : config   ( c )
 , solver   ( s )
 , theory ( th )
-, thandler {new THandler(c, th)}
+, proof	   ( t )
 , logic_ ( th.getLogic() )
+, thandler {new THandler(c, th)}
 , graph_   ( new vector<ProofNode*> )
 , graph    ( *graph_ )
-, proof	   ( t )
 #ifdef FULL_LABELING
 , vars_suggested_color_map ( NULL )
 #endif

--- a/src/proof/PGBuild.C
+++ b/src/proof/PGBuild.C
@@ -396,8 +396,7 @@ void ProofGraph::buildProofGraph( int nVars )
                             // else replace node with existing one
                             else
                             {
-                                ProofNode* replacing = getNode( it->second );
-                                assert( replacing );
+                                assert( getNode( it->second ) );
                                 last_seen_id = it->second;
                                 // Skip the new node construction and move to the next clause in the chain
                                 continue;
@@ -445,8 +444,7 @@ void ProofGraph::buildProofGraph( int nVars )
                                 // else replace node with existing one
                                 else
                                 {
-                                    ProofNode* replacing = getNode( it->second );
-                                    assert( replacing );
+                                    assert( getNode( it->second ) );
                                     last_seen_id = it->second;
                                     // Skip the new node construction and move to the next clause in the chain
                                     continue;
@@ -527,7 +525,7 @@ void ProofGraph::buildProofGraph( int nVars )
         // Check whether there are any remaining pieces
         checkProof( false );
         unsigned rem = cleanProofGraph( );
-        assert( rem == 0 );
+        assert( rem == 0 ); (void)rem;
     }
 
     if( verbose() > 0 )
@@ -805,11 +803,11 @@ clauseid_t ProofGraph::dupliNode( RuleContext& ra )
 	clauseid_t v_id = ra.getV();
 	ProofNode* w = getNode( ra.getW() );
 	assert(w);
-	unsigned num_old_res = w->getNumResolvents();
+    unsigned num_old_res = w->getNumResolvents(); (void)num_old_res;
 	assert( num_old_res > 1);
 	for( set<clauseid_t>::iterator it = w->getResolvents().begin(); it!=w->getResolvents().end(); it++)
 	{
-		ProofNode* res = getNode( (*it) ); assert(res);
+		ProofNode* res = getNode( (*it) ); assert(res); (void)res;
 		assert(res->getAnt1()==w || res->getAnt2()==w);
 	}
 

--- a/src/proof/PGBuild.C
+++ b/src/proof/PGBuild.C
@@ -477,14 +477,16 @@ void ProofGraph::buildProofGraph( int nVars )
                     // First internal node deduced from first clauses 0 and 1
                     // Other internal nodes deduced from last internal node and clause i
                     n->setPivot(chainvar[i-1]); proof_variables.insert(chainvar[i-1]);
-                    if(chainvar[i-1] > max_id_variable) max_id_variable = chainvar[i-1];
+                    if (static_cast<unsigned>(chainvar[i-1]) > max_id_variable) {
+                        max_id_variable = static_cast<unsigned>(chainvar[i-1]);
+                    }
                     assert(last_seen_id>=0); assert(currId>=0);
 
                     bool pos_piv = true;
                     bool found_piv = false;
                     // Make sure ant1 has the pivot positive (and ant2 negated)
                     Clause& clausei = proof.getClause(clause_i);
-                    for(int k=0;k<clausei.size();k++)
+                    for(unsigned k = 0; k < clausei.size(); k++)
                     {
                         if( var( clausei[k] ) == n->getPivot() )
                         {

--- a/src/proof/PGBuild.C
+++ b/src/proof/PGBuild.C
@@ -495,7 +495,7 @@ void ProofGraph::buildProofGraph( int nVars )
                             break;
                         }
                     }
-                    assert( found_piv );
+                    assert( found_piv );(void)found_piv;
                     int id_i=clauseToIDMap[clause_i];
                     if(pos_piv)
                     {

--- a/src/proof/PGBuild.C
+++ b/src/proof/PGBuild.C
@@ -41,10 +41,10 @@ ProofNode::setInterpPartitionMask( const ipartitions_t& mask)
 
 ostream& operator<< (ostream &out, RuleContext &ra)
 {
-	out << "Context: v1(" << ra.getV1() << ") v2(" << ra.getV2() << ") w("
-			<< ra.getW() << ") v3(" << ra.getV3() << ") v("
-			<< ra.getV() << ")";
-	return out;
+    out << "Context: v1(" << ra.getV1() << ") v2(" << ra.getV2() << ") w("
+        << ra.getW() << ") v3(" << ra.getV3() << ") v("
+        << ra.getV() << ")";
+    return out;
 }
 
 void ProofGraph::initTSolver() {
@@ -171,8 +171,8 @@ void ProofGraph::buildProofGraph( int nVars )
                 n->initClause(false_clause);
                 // We should set the partition_mask here, but how is that
                 // done?
-//                ipartitions_t mask = 0x10; // This is arbitrary, we should somehow know in which partition the false is so we could get this right.
-//                n->setInterpPartitionMask(mask);
+                // ipartitions_t mask = 0x10; // This is arbitrary, we should somehow know in which partition the false is so we could get this right.
+                // n->setInterpPartitionMask(mask);
                 graph.push_back(n);
                 assert(getNode(currId)==n);
                 root=currId;
@@ -244,7 +244,7 @@ void ProofGraph::buildProofGraph( int nVars )
                     if (ctype == clause_type::CLA_ORIG)
                     {
                         if ( n->getClauseSize() >= max_leaf_size ) max_leaf_size = n->getClauseSize();
-                            avg_leaf_size += n->getClauseSize();
+                        avg_leaf_size += n->getClauseSize();
                     }
                 }
                 // NB: internal derived clauses not considered here
@@ -572,281 +572,281 @@ void ProofGraph::buildProofGraph( int nVars )
 
 void ProofGraph::fillProofGraph()
 {
-	if ( verbose() > 1 )
-	{
-		uint64_t mem_used = memUsed();
-		reportf( "# Memory used before filling the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-	}
+    if ( verbose() > 1 )
+    {
+        uint64_t mem_used = memUsed();
+        reportf( "# Memory used before filling the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+    }
 
-	vector<clauseid_t>q;
-	clauseid_t id;
-	ProofNode* n=NULL;
-	q.push_back(getRoot()->getId());
-	do
-	{
-		id=q.back();
-		n=getNode(id);
-		//Node not visited yet
-		if(!isSetVisited1(id))
-		{
-			// Enqueue antecedents if not visited
-			if(n->getAnt1()!=NULL && !isSetVisited1(n->getAnt1()->getId()))
-				q.push_back(n->getAnt1()->getId());
-			else if(n->getAnt2()!=NULL && !isSetVisited1(n->getAnt2()->getId()))
-				q.push_back(n->getAnt2()->getId());
-			// Mark node as visited if both antecedents visited
-			else
-			{
-				setVisited1(id);
-				q.pop_back();
-				assert(n);
-				//Non leaf node
-				if(!n->isLeaf())
-				{
-					n->initClause();
-					mergeClauses(n->getAnt1()->getClause(), n->getAnt2()->getClause(), n->getClause(), n->getPivot());
-				}
-			}
-		}
-		else q.pop_back();
-	}
-	while(!q.empty());
-	resetVisited1();
+    vector<clauseid_t>q;
+    clauseid_t id;
+    ProofNode* n=NULL;
+    q.push_back(getRoot()->getId());
+    do
+    {
+        id=q.back();
+        n=getNode(id);
+        //Node not visited yet
+        if(!isSetVisited1(id))
+        {
+            // Enqueue antecedents if not visited
+            if(n->getAnt1()!=NULL && !isSetVisited1(n->getAnt1()->getId()))
+                q.push_back(n->getAnt1()->getId());
+            else if(n->getAnt2()!=NULL && !isSetVisited1(n->getAnt2()->getId()))
+                q.push_back(n->getAnt2()->getId());
+                // Mark node as visited if both antecedents visited
+            else
+            {
+                setVisited1(id);
+                q.pop_back();
+                assert(n);
+                //Non leaf node
+                if(!n->isLeaf())
+                {
+                    n->initClause();
+                    mergeClauses(n->getAnt1()->getClause(), n->getAnt2()->getClause(), n->getClause(), n->getPivot());
+                }
+            }
+        }
+        else q.pop_back();
+    }
+    while(!q.empty());
+    resetVisited1();
 
-	if ( verbose() > 0 )
-	{
-		uint64_t mem_used = memUsed();
-		reportf( "# Memory used after filling the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-	}
+    if ( verbose() > 0 )
+    {
+        uint64_t mem_used = memUsed();
+        reportf( "# Memory used after filling the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+    }
 }
 
 void ProofGraph::emptyProofGraph()
 {
-	if ( verbose() > 1 )
-	{
-		uint64_t mem_used = memUsed();
-		reportf( "# Memory used before emptying the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-	}
-	ProofNode* n = NULL;
-	for(size_t i=0;i< getGraphSize() ;i++)
-	{
-		n=getNode(i);
-		if( n!=NULL && !n->isLeaf() ) { n->resetClause(); }
-	}
-	if ( verbose() > 0 )
-	{
-		uint64_t mem_used = memUsed();
-		reportf( "# Memory used after emptying the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-	}
+    if ( verbose() > 1 )
+    {
+        uint64_t mem_used = memUsed();
+        reportf( "# Memory used before emptying the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+    }
+    ProofNode* n = NULL;
+    for(size_t i=0;i< getGraphSize() ;i++)
+    {
+        n=getNode(i);
+        if( n!=NULL && !n->isLeaf() ) { n->resetClause(); }
+    }
+    if ( verbose() > 0 )
+    {
+        uint64_t mem_used = memUsed();
+        reportf( "# Memory used after emptying the proof: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+    }
 }
 
 void ProofGraph::normalizeAntecedentOrder()
 {
-	// Normalize proof for interpolation
-	std::deque<ProofNode*> q;
-	ProofNode* n;
-	q.push_back(getRoot());
-	do
-	{
-		n=q.front();
-		q.pop_front();
-		if(!isSetVisited1(n->getId()))
-		{
-			if(!n->isLeaf())
-			{
-				q.push_back(n->getAnt1());
-				q.push_back(n->getAnt2());
+    // Normalize proof for interpolation
+    std::deque<ProofNode*> q;
+    ProofNode* n;
+    q.push_back(getRoot());
+    do
+    {
+        n=q.front();
+        q.pop_front();
+        if(!isSetVisited1(n->getId()))
+        {
+            if(!n->isLeaf())
+            {
+                q.push_back(n->getAnt1());
+                q.push_back(n->getAnt2());
 
-				// Check pivot in antecedents
-				short f1 = n->getAnt1()->hasOccurrenceBin(n->getPivot());
-				short f2 = n->getAnt2()->hasOccurrenceBin(n->getPivot());
-				assert( f1!=-1 && f2!=-1 );
-				assert( !(f1==1 && f2==1) && !(f1==0 && f2==0) );
-				// Exchange antecedents if necessary
-				if( f1==1 && f2==0 )
-				{
-					ProofNode* aux = n->getAnt1();
-					n->setAnt1( n->getAnt2() );
-					n->setAnt2( aux );
-				}
-			}
-			setVisited1(n->getId());
-		}
-	}
-	while(!q.empty());
-	resetVisited1();
+                // Check pivot in antecedents
+                short f1 = n->getAnt1()->hasOccurrenceBin(n->getPivot());
+                short f2 = n->getAnt2()->hasOccurrenceBin(n->getPivot());
+                assert( f1!=-1 && f2!=-1 );
+                assert( !(f1==1 && f2==1) && !(f1==0 && f2==0) );
+                // Exchange antecedents if necessary
+                if( f1==1 && f2==0 )
+                {
+                    ProofNode* aux = n->getAnt1();
+                    n->setAnt1( n->getAnt2() );
+                    n->setAnt2( aux );
+                }
+            }
+            setVisited1(n->getId());
+        }
+    }
+    while(!q.empty());
+    resetVisited1();
 }
 
 int ProofGraph::cleanProofGraph()
 {
-	// Remove the unreachable part of the graph
-	// Ideally it will be made of subgraphs not connected to the main graph
-	unsigned removed=0;
-	bool done = false;
-	unsigned counter = 0;
-	while(!done)
-	{
-		done = true;
-		counter ++;
-		for(size_t i=0;i< getGraphSize() ;i++)
-		{
-			if(getNode(i)!=NULL && getNode(i)->getNumResolvents()==0 && getNode(i)!=getRoot())
-			{
-				done = false;
-				removed += removeTree(i);
-				//cerr << "Detached tree starting at " << i << endl;
-			}
-		}
-	}
-	return removed;
+    // Remove the unreachable part of the graph
+    // Ideally it will be made of subgraphs not connected to the main graph
+    unsigned removed=0;
+    bool done = false;
+    unsigned counter = 0;
+    while(!done)
+    {
+        done = true;
+        counter ++;
+        for(size_t i=0;i< getGraphSize() ;i++)
+        {
+            if(getNode(i)!=NULL && getNode(i)->getNumResolvents()==0 && getNode(i)!=getRoot())
+            {
+                done = false;
+                removed += removeTree(i);
+                //cerr << "Detached tree starting at " << i << endl;
+            }
+        }
+    }
+    return removed;
 }
 
 //Remove a node from the graph
 void ProofGraph::removeNode(clauseid_t vid)
 {
-	ProofNode* n=getNode(vid);
-	assert(n);
-	if(n->getAnt1()==NULL && n->getAnt2()==NULL) removeLeaf(vid);
-	n->setAnt1(NULL); n->setAnt2(NULL);
-	// Free memory
-	n->delIData();
-	delete n;
-	// Remove v from proof
-	graph[vid]=NULL;
+    ProofNode* n=getNode(vid);
+    assert(n);
+    if(n->getAnt1()==NULL && n->getAnt2()==NULL) removeLeaf(vid);
+    n->setAnt1(NULL); n->setAnt2(NULL);
+    // Free memory
+    n->delIData();
+    delete n;
+    // Remove v from proof
+    graph[vid]=NULL;
 }
 
 unsigned ProofGraph::removeTree( clauseid_t vid )
 {
-	assert(getNode(vid));
-	assert(getNode(vid)->getNumResolvents() == 0 );
-	unsigned removed=0;
+    assert(getNode(vid));
+    assert(getNode(vid)->getNumResolvents() == 0 );
+    unsigned removed=0;
 
-	//Go on removing nodes with 0 resolvents
-	//Visit graph from root keeping track of edges and nodes
-	std::deque< clauseid_t > q;
-	ProofNode * n;
-	clauseid_t c;
-	// Better a set than a boolean vector to avoid wasting memory
-	std::set<clauseid_t> visit;
+    //Go on removing nodes with 0 resolvents
+    //Visit graph from root keeping track of edges and nodes
+    std::deque< clauseid_t > q;
+    ProofNode * n;
+    clauseid_t c;
+    // Better a set than a boolean vector to avoid wasting memory
+    std::set<clauseid_t> visit;
 
 
-	/*
- 	// For some reason this code leaves some hanging nodes with RecyclePivots
- 	q.push_back( vid );
-	do
-	{
-		c = q.front( );
-		q.pop_front( );
-		assert( c < getGraphSize() );
+    /*
+     // For some reason this code leaves some hanging nodes with RecyclePivots
+     q.push_back( vid );
+    do
+    {
+        c = q.front( );
+        q.pop_front( );
+        assert( c < getGraphSize() );
 
-		//Node not visited yet
-		if(visit.find(c) == visit.end())
-		{
-			n = getNode(c);
-			assert( n );
-			//Mark node as visited
-			visit.insert(c);
-			//Remove node if no more resolvents present
-			if( n->getNumResolvents() == 0 )
-			{
-				if( n->getAnt1()!=NULL )
-				{
-					assert(getNode(n->getAnt1()->getId())==n->getAnt1());
-					q.push_back( n->getAnt1()->getId() );
-					n->getAnt1()->remRes( c );
-				}
-				if( n->getAnt2()!=NULL )
-				{
-					assert(getNode(n->getAnt2()->getId())==n->getAnt2());
-					q.push_back( n->getAnt2()->getId() );
-					n->getAnt2()->remRes( c );
-				}
-				removeNode( c );
-				removed++;
-			}
-		}
-	}
-	while( !q.empty( ) );*/
+        //Node not visited yet
+        if(visit.find(c) == visit.end())
+        {
+            n = getNode(c);
+            assert( n );
+            //Mark node as visited
+            visit.insert(c);
+            //Remove node if no more resolvents present
+            if( n->getNumResolvents() == 0 )
+            {
+                if( n->getAnt1()!=NULL )
+                {
+                    assert(getNode(n->getAnt1()->getId())==n->getAnt1());
+                    q.push_back( n->getAnt1()->getId() );
+                    n->getAnt1()->remRes( c );
+                }
+                if( n->getAnt2()!=NULL )
+                {
+                    assert(getNode(n->getAnt2()->getId())==n->getAnt2());
+                    q.push_back( n->getAnt2()->getId() );
+                    n->getAnt2()->remRes( c );
+                }
+                removeNode( c );
+                removed++;
+            }
+        }
+    }
+    while( !q.empty( ) );*/
 
-	q.push_back( vid );
-	do
-	{
-		c = q.front( );
-		q.pop_front( );
-		assert( c < getGraphSize() );
-		n = getNode(c);
-		//Remove node if no more resolvents present
-		if( n!= NULL && n->getNumResolvents() == 0 )
-		{
-			if( n->getAnt1()!=NULL )
-			{
-				assert(getNode(n->getAnt1()->getId())==n->getAnt1());
-				q.push_back( n->getAnt1()->getId() );
-				n->getAnt1()->remRes( c );
-			}
-			if( n->getAnt2()!=NULL )
-			{
-				assert(getNode(n->getAnt2()->getId())==n->getAnt2());
-				q.push_back( n->getAnt2()->getId() );
-				n->getAnt2()->remRes( c );
-			}
-			removeNode( c );
-			removed++;
-		}
-	}
-	while( !q.empty( ) );
+    q.push_back( vid );
+    do
+    {
+        c = q.front( );
+        q.pop_front( );
+        assert( c < getGraphSize() );
+        n = getNode(c);
+        //Remove node if no more resolvents present
+        if( n!= NULL && n->getNumResolvents() == 0 )
+        {
+            if( n->getAnt1()!=NULL )
+            {
+                assert(getNode(n->getAnt1()->getId())==n->getAnt1());
+                q.push_back( n->getAnt1()->getId() );
+                n->getAnt1()->remRes( c );
+            }
+            if( n->getAnt2()!=NULL )
+            {
+                assert(getNode(n->getAnt2()->getId())==n->getAnt2());
+                q.push_back( n->getAnt2()->getId() );
+                n->getAnt2()->remRes( c );
+            }
+            removeNode( c );
+            removed++;
+        }
+    }
+    while( !q.empty( ) );
 
-	return removed;
+    return removed;
 }
 
 clauseid_t ProofGraph::dupliNode( RuleContext& ra )
 {
-	//cerr << "Duplicating " << ra.getW() << " in rule " << ra.getType() << endl;
-	clauseid_t v_id = ra.getV();
-	ProofNode* w = getNode( ra.getW() );
-	assert(w);
+    //cerr << "Duplicating " << ra.getW() << " in rule " << ra.getType() << endl;
+    clauseid_t v_id = ra.getV();
+    ProofNode* w = getNode( ra.getW() );
+    assert(w);
     unsigned num_old_res = w->getNumResolvents(); (void)num_old_res;
-	assert( num_old_res > 1);
-	for( set<clauseid_t>::iterator it = w->getResolvents().begin(); it!=w->getResolvents().end(); it++)
-	{
-		ProofNode* res = getNode( (*it) ); assert(res); (void)res;
-		assert(res->getAnt1()==w || res->getAnt2()==w);
-	}
+    assert( num_old_res > 1);
+    for( set<clauseid_t>::iterator it = w->getResolvents().begin(); it!=w->getResolvents().end(); it++)
+    {
+        ProofNode* res = getNode( (*it) ); assert(res); (void)res;
+        assert(res->getAnt1()==w || res->getAnt2()==w);
+    }
 
-	ProofNode* n=new ProofNode(logic_);
-	n->initIData();
+    ProofNode* n=new ProofNode(logic_);
+    n->initIData();
 
-	// Create node and add to graph vector
-	clauseid_t currId=getGraphSize();
-	n->setId(currId);
-	graph.push_back(n);
-	assert(getNode(currId)==n);
-	n->setType(w->getType());
-	n->initClause(w->getClause());
+    // Create node and add to graph vector
+    clauseid_t currId=getGraphSize();
+    n->setId(currId);
+    graph.push_back(n);
+    assert(getNode(currId)==n);
+    n->setType(w->getType());
+    n->initClause(w->getClause());
     n->setInterpPartitionMask(w->getInterpPartitionMask());
 
-	// Set antecedents, pivot
-	n->setAnt1(w->getAnt1());
-	n->setAnt2(w->getAnt2());
-	n->getAnt1()->addRes(currId);
-	n->getAnt2()->addRes(currId);
-	n->setPivot(w->getPivot());
+    // Set antecedents, pivot
+    n->setAnt1(w->getAnt1());
+    n->setAnt2(w->getAnt2());
+    n->getAnt1()->addRes(currId);
+    n->getAnt2()->addRes(currId);
+    n->setPivot(w->getPivot());
 
-	// The new node replaces w in the context
-	// w loses v but keeps everything else
-	ProofNode* v = getNode(v_id);
-	w->remRes(v_id);
-	n->addRes(v_id);
-	if(v->getAnt1() == w) v->setAnt1(n);
-	else if(v->getAnt2() == w) v->setAnt2(n);
-	else opensmt_error_();
-	assert( w->getResolvents().find(v_id) == w->getResolvents().end());
-	assert( w->getNumResolvents() == num_old_res - 1);
-	// Remember to modify context
-	ra.cw = currId;
+    // The new node replaces w in the context
+    // w loses v but keeps everything else
+    ProofNode* v = getNode(v_id);
+    w->remRes(v_id);
+    n->addRes(v_id);
+    if(v->getAnt1() == w) v->setAnt1(n);
+    else if(v->getAnt2() == w) v->setAnt2(n);
+    else opensmt_error_();
+    assert( w->getResolvents().find(v_id) == w->getResolvents().end());
+    assert( w->getNumResolvents() == num_old_res - 1);
+    // Remember to modify context
+    ra.cw = currId;
 
-	duplications++;
-	return currId;
+    duplications++;
+    return currId;
 }
 
 #endif

--- a/src/proof/PGCheck.C
+++ b/src/proof/PGCheck.C
@@ -223,7 +223,7 @@ void ProofGraph::checkClause(clauseid_t nid)
 			// Checks whether both antecedents have the pivot
 			short f1 = n->getAnt1()->hasOccurrenceBin(n->getPivot());
 			short f2 = n->getAnt2()->hasOccurrenceBin(n->getPivot());
-			assert( f1 != -1 ); assert( f2 != -1 ); assert( f1 != f2 );
+			assert( f1 != -1 ); assert( f2 != -1 ); assert( f1 != f2 ); (void)f1; (void)f2;
 		}
 	}
 	// Check that every resolvent has this node as its antecedent

--- a/src/proof/PGCheck.C
+++ b/src/proof/PGCheck.C
@@ -67,7 +67,7 @@ void ProofGraph::verifyLeavesInconsistency( )
 	logic_.dumpHeaderToFile( dump_out );
 
 	unsigned added = 0;
-	for ( int i = 0 ; i < proofleaves.size( ) ; i ++ )
+	for ( unsigned i = 0 ; i < proofleaves.size( ) ; i ++ )
 	{
 		if(added == 0)
 		{

--- a/src/proof/PGHelp.C
+++ b/src/proof/PGHelp.C
@@ -289,7 +289,6 @@ void ProofGraph::getComplexityInterpolant( PTRef int_e )
     unsigned num_and_or_dag = 0;
 
     q.push_back(int_e);
-    Logic& logic = theory.getLogic();
     do
     {
         e_curr=q.back();

--- a/src/proof/PGHeuristics.C
+++ b/src/proof/PGHeuristics.C
@@ -68,9 +68,6 @@ bool ProofGraph::allowSwapRuleForPredicatePushingDown(RuleContext& ra, Var pred)
 	//cerr << "SWAP-Trying to push down " << thandler->varToEnode(pred) <<
 	//	" where w=" << ra.getW() << " and v=" << ra.getV() << endl;
 
-	rul_type t=ra.getType();
-	bool dupl=(getNode(ra.getW())->getNumResolvents()>1);
-
 	Var pred1 = ( getNode(ra.getW())->getPivot() );
 	Var pred2 = ( getNode(ra.getV())->getPivot() );
 	bool is1 = (pred1==pred);
@@ -99,7 +96,6 @@ bool ProofGraph::allowSwapRuleForPredicatePushingDown(RuleContext& ra, Var pred)
 //Output: true if rule application is allowed
 bool ProofGraph::allowCutRuleForPredicatePushing(RuleContext& ra, Var pred)
 {
-	rul_type t=ra.getType();
 	bool dupl=(getNode(ra.getW())->getNumResolvents()>1);
 
 	Var pred1 = ( getNode(ra.getW())->getPivot() );
@@ -134,11 +130,6 @@ short ProofGraph::handleRuleApplicationForPredicatePushing(RuleContext& ra1,Rule
 	// Cut application rule
 	bool(ProofGraph::*allowCut)(RuleContext& ra,Var v) = &ProofGraph::allowCutRuleForPredicatePushing;
 
-
-	// Duplication allowed?
-	const bool duplAllowedSwap = false;
-	const bool duplAllowedCut = false;
-
 	// Check need for duplication
 	bool dupl1, dupl2;
 	bool allowed1, allowed2;
@@ -146,7 +137,6 @@ short ProofGraph::handleRuleApplicationForPredicatePushing(RuleContext& ra1,Rule
 	short chosen=-1;
 	rul_type t1=ra1.getType();
 	rul_type t2=ra2.getType();
-	bool all1,all2;
 	bool is1cut=isCutRule(t1);
 	bool is2cut=isCutRule(t2);
 	bool is1swap=isSwapRule(t1);
@@ -304,7 +294,6 @@ short ProofGraph::handleRuleApplicationForUnitsPushingDown(RuleContext& ra1,Rule
 	short chosen=-1;
 	rul_type t1=ra1.getType();
 	rul_type t2=ra2.getType();
-	bool all1,all2;
 	bool is1cut=isCutRule(t1);
 	bool is2cut=isCutRule(t2);
 	bool is1swap=isSwapRule(t1);
@@ -449,7 +438,6 @@ short ProofGraph::handleRuleApplicationForReduction(RuleContext& ra1,RuleContext
 	short chosen=-1;
 	rul_type t1=ra1.getType();
 	rul_type t2=ra2.getType();
-	bool all1,all2;
 	bool is1cut=isCutRule(t1);
 	bool is2cut=isCutRule(t2);
 	bool is1swap=isSwapRule(t1);
@@ -618,7 +606,6 @@ short ProofGraph::handleRuleApplicationForStrongerWeakerInterpolant(RuleContext&
 	short chosen=-1;
 	rul_type t1=ra1.getType();
 	rul_type t2=ra2.getType();
-	bool all1,all2;
 	bool is1cut=isCutRule(t1);
 	bool is2cut=isCutRule(t2);
 	bool is1swap=isSwapRule(t1);
@@ -716,7 +703,6 @@ short ProofGraph::handleRuleApplicationForStrongerWeakerInterpolant(RuleContext&
 //Output: true if rule application is allowed
 bool ProofGraph::allowSwapRuleForCNFinterpolant(RuleContext& ra)
 {
-	rul_type t=ra.getType();
 	bool dupl=(getNode(ra.getW())->getNumResolvents()>1);
 
 	// McMillan should be used for generating an interpolant in CNF
@@ -762,7 +748,6 @@ short ProofGraph::handleRuleApplicationForCNFinterpolant(RuleContext& ra1,RuleCo
 	short chosen=-1;
 	rul_type t1=ra1.getType();
 	rul_type t2=ra2.getType();
-	bool all1,all2;
 	bool is1cut=isCutRule(t1);
 	bool is2cut=isCutRule(t2);
 	bool is1swap=isSwapRule(t1);

--- a/src/proof/PGInterAux.C
+++ b/src/proof/PGInterAux.C
@@ -237,8 +237,7 @@ ProofGraph::computePSFunction(vector< clauseid_t >& DFSv, const ipartitions_t& A
 		time(&before);
 		
 		map<Var, int> occ_a, occ_b;
-		int aclauses, bclauses;
-		aclauses = bclauses;
+
 		for(size_t i = 0; i < proof_size; ++i)
 		{
 			n = getNode(DFSv[i]); assert(n);
@@ -277,14 +276,12 @@ ProofGraph::computePSFunction(vector< clauseid_t >& DFSv, const ipartitions_t& A
 					if(vclass != I_AB) continue;
 					if(col == I_A)
 					{
-						++aclauses;
 						++occ_a[v];
 						if(occ_b.find(v) == occ_b.end())
 							occ_b[v] = 0;
 					}
 					else if(col == I_B)
 					{
-						++bclauses;
 						++occ_b[v];
 						if(occ_a.find(v) == occ_a.end())
 							occ_a[v] = 0;

--- a/src/proof/PGInterCheck.C
+++ b/src/proof/PGInterCheck.C
@@ -294,7 +294,7 @@ void ProofGraph::verifyPartialInterpolantFromLeaves( ProofNode* n, const ipartit
 	logic_.dumpHeaderToFile( dump_out );
 
 	string varsDecl("");
-	for(int i = 2; i <= getMaxIdVar(); ++i)
+	for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
 		{
 				varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
 			}
@@ -538,7 +538,7 @@ bool ProofGraph::verifyPathInterpolantsFromLeaves ( vec< PTRef > & interps)
 	assert( (no_part + 1) == interps.size() );
 
 	string varsDecl("");
-	for(int i = 2; i <= getMaxIdVar(); ++i)
+	for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
 	{
 		varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
 	}
@@ -635,8 +635,9 @@ bool ProofGraph::verifySimultaneousAbstraction( vec< PTRef > & interps)
 	logic_.dumpHeaderToFile( dump_out );
 
 	// Add conjunction interpolants
-	for( unsigned i = 0; i < interps.size(); i++ )
-		logic_.dumpFormulaToFile( dump_out, interps[i], false );
+	for( int i = 0; i < interps.size(); i++ ) {
+        logic_.dumpFormulaToFile(dump_out, interps[i], false);
+    }
 	dump_out << "(check-sat)" << endl;
 	dump_out << "(exit)" << endl;
 	dump_out.close( );
@@ -699,8 +700,9 @@ bool ProofGraph::verifyGenSimultaneousAbstraction( vec< PTRef > & interps)
 	logic_.dumpHeaderToFile( dump_out );
 
 	// Add conjunction interpolants
-	for( unsigned i = 0; i < interps.size()-1; i++ )
-		logic_.dumpFormulaToFile( dump_out, interps[i], false );
+	for( int i = 0; i < interps.size()-1; i++ ) {
+        logic_.dumpFormulaToFile(dump_out, interps[i], false);
+    }
 	// Add negation last interpolant
 	logic_.dumpFormulaToFile( dump_out, interps[interps.size()-1], true );
 	dump_out << "(check-sat)" << endl;

--- a/src/proof/PGInterCheck.C
+++ b/src/proof/PGInterCheck.C
@@ -535,7 +535,7 @@ bool ProofGraph::verifyPathInterpolantsFromLeaves ( vec< PTRef > & interps)
 	unsigned no_part = logic_.getNofPartitions();
 
 	// m partitions, m+1 interpolants
-	assert( (no_part + 1) == interps.size() );
+	assert( (no_part + 1) == static_cast<unsigned>(interps.size()) );
 
 	string varsDecl("");
 	for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
@@ -763,7 +763,7 @@ bool ProofGraph::verifyStateTransitionInterpolants ( vec< PTRef > & interps)
 
 	// m partitions, 2m+1 interpolants
 	unsigned no_part = logic_.getNofPartitions();
-	assert( (2*no_part + 1) == interps.size() );
+	assert( (2*no_part + 1) == static_cast<unsigned>(interps.size()) );
 
 	// Try ith constraint I_i /\ J_{i+1} -> I_{i+1}
 	bool property_holds = true;
@@ -955,7 +955,7 @@ bool ProofGraph::verifyTreeInterpolantsFromLeaves( opensmt::InterpolationTree* i
 	// m partitions, one for each node of the tree
 	// TODO m or less interpolants - not necessarily all nodes are approximated
 	// for nodes non approximated, interpolants are the original formulae
-	assert( logic_.getNofPartitions() == interps.size() );
+	assert( logic_.getNofPartitions() == static_cast<unsigned>(interps.size()) );
 
 	// NOTE partition ids start from 1, interpolants vector from 0
 	// interpolants[i] contains interpolant for node with partition id i+1

--- a/src/proof/PGInterCheck.C
+++ b/src/proof/PGInterCheck.C
@@ -169,28 +169,28 @@ ProofGraph::verifyPartialInterpolantA(ProofNode *n, const ipartitions_t& mask)
     vec<PTRef> restricted_clause;
 
     const size_t size = cl.size( );
-	for( size_t i = 0 ; i < size ; i ++ )
-	{
-		Var v = var(cl[i]);
-		var_class = getVarClass2( v );
-		assert( var_class == I_B || var_class == I_A || var_class == I_AB );
-		if( var_class == I_B || var_class == I_A ) var_color = var_class;
-		else
-		{
-			// Determine color of AB variable
-			if( isColoredA( n,v ) ) var_color = I_A;
-			else if ( isColoredB( n,v )  ) var_color = I_B;
-			else if ( isColoredAB( n,v ) ) var_color = I_AB;
-			else opensmt_error( "Variable " << v << " has no color in clause " << n->getId() );
-		}
-		if( var_color == I_A || var_color == I_AB )
+    for( size_t i = 0 ; i < size ; i ++ )
+    {
+        Var v = var(cl[i]);
+        var_class = getVarClass2( v );
+        assert( var_class == I_B || var_class == I_A || var_class == I_AB );
+        if( var_class == I_B || var_class == I_A ) var_color = var_class;
+        else
+        {
+            // Determine color of AB variable
+            if( isColoredA( n,v ) ) var_color = I_A;
+            else if ( isColoredB( n,v )  ) var_color = I_B;
+            else if ( isColoredAB( n,v ) ) var_color = I_AB;
+            else opensmt_error( "Variable " << v << " has no color in clause " << n->getId() );
+        }
+        if( var_color == I_A || var_color == I_AB )
         {
             PTRef ptaux = varToPTRef(var(cl[i]));
             if(sign(cl[i]))
                 ptaux = logic.mkNot(ptaux);
             restricted_clause.push(ptaux);
         }
-	}
+    }
 
     PTRef cl_ptref = logic.mkNot(logic.mkOr(restricted_clause));
     vec<PTRef> AC_args;
@@ -221,28 +221,28 @@ ProofGraph::verifyPartialInterpolantB(ProofNode *n, const ipartitions_t& mask)
     vec<PTRef> restricted_clause;
 
     const size_t size = cl.size( );
-	for( size_t i = 0 ; i < size ; i ++ )
-	{
-		Var v = var(cl[i]);
-		var_class = getVarClass2( v );
-		assert( var_class == I_B || var_class == I_A || var_class == I_AB );
-		if( var_class == I_B || var_class == I_A ) var_color = var_class;
-		else
-		{
-			// Determine color of AB variable
-			if( isColoredA( n,v ) ) var_color = I_A;
-			else if ( isColoredB( n,v )  ) var_color = I_B;
-			else if ( isColoredAB( n,v ) ) var_color = I_AB;
-			else opensmt_error( "Variable " << v << " has no color in clause " << n->getId() );
-		}
-		if( var_color == I_B || var_color == I_AB )
+    for( size_t i = 0 ; i < size ; i ++ )
+    {
+        Var v = var(cl[i]);
+        var_class = getVarClass2( v );
+        assert( var_class == I_B || var_class == I_A || var_class == I_AB );
+        if( var_class == I_B || var_class == I_A ) var_color = var_class;
+        else
+        {
+            // Determine color of AB variable
+            if( isColoredA( n,v ) ) var_color = I_A;
+            else if ( isColoredB( n,v )  ) var_color = I_B;
+            else if ( isColoredAB( n,v ) ) var_color = I_AB;
+            else opensmt_error( "Variable " << v << " has no color in clause " << n->getId() );
+        }
+        if( var_color == I_B || var_color == I_AB )
         {
             PTRef ptaux = varToPTRef(var(cl[i]));
             if(sign(cl[i]))
                 ptaux = logic.mkNot(ptaux);
             restricted_clause.push(ptaux);
         }
-	}
+    }
 
     PTRef cl_ptref = logic.mkNot(logic.mkOr(restricted_clause));
     vec<PTRef> BC_args;
@@ -266,261 +266,261 @@ ProofGraph::verifyPartialInterpolantB(ProofNode *n, const ipartitions_t& mask)
 
 void ProofGraph::verifyPartialInterpolantFromLeaves( ProofNode* n, const ipartitions_t& A_mask )
 {
-	if( verbose() > 0 ) { cerr << "# Checking soundness of the interpolant" << endl; }
-	// NOTE no reason at the moment to verify partial interpolants besides those
-	// at the leaves and the global one at the root
-	assert(n->isLeaf() || isRoot(n));
+    if( verbose() > 0 ) { cerr << "# Checking soundness of the interpolant" << endl; }
+    // NOTE no reason at the moment to verify partial interpolants besides those
+    // at the leaves and the global one at the root
+    assert(n->isLeaf() || isRoot(n));
 
-	PTRef partial_interp = n->getPartialInterpolant();
-	assert(partial_interp != PTRef_Undef);
+    PTRef partial_interp = n->getPartialInterpolant();
+    assert(partial_interp != PTRef_Undef);
 
-	// Check that the interpolant is on the shared signature
-	set<PTRef> pred_set;
-	getPredicatesSetFromInterpolantIterative( partial_interp, pred_set );
-	for( set<PTRef>::iterator it = pred_set.begin(); it != pred_set.end(); it++ )
-	{
-		// Skip true and false
-		if((*it) == logic_.getTerm_true() || (*it) == logic_.getTerm_false()) continue;
-		assert( getVarClass(PTRefToVar(*it), A_mask) == I_AB );
-	}
-	if( verbose() > 0 ) { cerr << "# The interpolant is on the shared signature" << endl; }
+    // Check that the interpolant is on the shared signature
+    set<PTRef> pred_set;
+    getPredicatesSetFromInterpolantIterative( partial_interp, pred_set );
+    for( set<PTRef>::iterator it = pred_set.begin(); it != pred_set.end(); it++ )
+    {
+        // Skip true and false
+        if((*it) == logic_.getTerm_true() || (*it) == logic_.getTerm_false()) continue;
+        assert( getVarClass(PTRefToVar(*it), A_mask) == I_AB );
+    }
+    if( verbose() > 0 ) { cerr << "# The interpolant is on the shared signature" << endl; }
 
 
-	// Check A /\ ~(C|a,ab) -> I, i.e., A /\ ~(C|a,ab) /\ ~I unsat
+    // Check A /\ ~(C|a,ab) -> I, i.e., A /\ ~(C|a,ab) /\ ~I unsat
 
-	// First stage: print declarations
-	const char * name = "verifyinterp_A.smt2";
-	ofstream dump_out( name );
-	logic_.dumpHeaderToFile( dump_out );
+    // First stage: print declarations
+    const char * name = "verifyinterp_A.smt2";
+    ofstream dump_out( name );
+    logic_.dumpHeaderToFile( dump_out );
 
-	string varsDecl("");
-	for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
-		{
-				varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
-			}
-	dump_out << varsDecl << endl;
+    string varsDecl("");
+    for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
+    {
+        varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
+    }
+    dump_out << varsDecl << endl;
 
-	// Print only A atoms
-	unsigned A_added = 0;
-	for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
-	{
-		ProofNode* n = getNode(*it);
-		icolor_t clause_color = getClauseColor( n->getInterpPartitionMask(), A_mask );
-		assert( clause_color == I_A || clause_color == I_B );
-		if ( clause_color == I_A )
-		{
-			if(A_added == 0)
-			{
-				dump_out << "(assert " << endl;
-				dump_out << "(and" << endl;
-				A_added++;
-			}
-			printClause( dump_out, n->getClause() );
-			dump_out << endl;
-		}
-	}
-	if(A_added > 0) dump_out << "))" << endl;
-
-#ifdef FULL_LABELING
-	if(n->isLeaf())
-	{
-		// Add negation of clause restriction
-		// In labeling, classes and colors are distinct
-		icolor_t var_class;
-		icolor_t var_color;
-		vector< Lit > & cl = n->getClause();
-		const size_t size = cl.size( );
-
-		if( cl.size() > 0 )
-		{
-			unsigned num_added=0;
-			for( size_t i = 0 ; i < size ; i ++ )
-			{
-				Var v = var(cl[i]);
-				var_class = getVarClass2( v );
-				assert( var_class == I_B || var_class == I_A || var_class == I_AB );
-				if( var_class == I_B || var_class == I_A ) var_color = var_class;
-				else
-				{
-					// Determine color of AB variable
-					if( isColoredA( n,v ) ) var_color = I_A;
-					else if ( isColoredB( n,v )  ) var_color = I_B;
-					else if ( isColoredAB( n,v ) ) var_color = I_AB;
-					else opensmt_error( "Variable has no color" );
-				}
-				if( var_color == I_A || var_color == I_AB )
-				{
-					if(num_added==0)
-					{
-						dump_out << "(assert" << endl;
-						dump_out << "(and" << endl;
-						num_added++;
-					}
-					// Add negated literal
-					if( sign(cl[i]) )
-						dump_out << logic_.printTerm(varToPTRef( v )) << endl;
-					else
-						dump_out << "(not " << logic_.printTerm(varToPTRef( v )) << " )" << endl;
-				}
-			}
-			if(num_added>0) dump_out << "))" << endl;
-		}
-	}
-#endif
-
-	// Add partial interpolant
-	//dump_out << "(assert (not " << partial_interp << ") )" << endl;
-	logic_.dumpFormulaToFile( dump_out, partial_interp, true );
-	dump_out << "(check-sat)" << endl;
-	dump_out << "(exit)" << endl;
-	dump_out.close( );
-
-	// Check !
-	bool tool_res;
-	if ( int pid = fork() )
-	{
-		int status;
-		waitpid(pid, &status, 0);
-		switch ( WEXITSTATUS( status ) )
-		{
-		case 0:
-			tool_res = false;
-			break;
-		case 1:
-			tool_res = true;
-			break;
-		default:
-			perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-			exit( EXIT_FAILURE );
-		}
-	}
-	else
-	{
-		//if( verbose() > 0 ) { cerr << "# Solving A /\\ ~(C|a,ab) /\\ ~I" << endl; }
-		if( verbose() > 0 ) { cerr << "# Checking A -> I" << endl; }
-		execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-		perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-		exit( EXIT_FAILURE );
-	}
-	if ( tool_res == true )
-		//opensmt_error( "External tool says A /\\ ~(C|a,ab) -> I does not hold" );
-		opensmt_error( "External tool says A -> I does not hold" );
-
-	// Check B /\ ~(C|b,ab) -> ~I, i.e., B /\ ~(C|b,ab) /\ I unsat
-
-	const char * name2 = "verifyinterp_B.smt2";
-	dump_out.open( name2 );
-	logic_.dumpHeaderToFile( dump_out );
-
-dump_out << varsDecl << endl;
-
-	// Print only B atoms
-	unsigned B_added = 0;
-	for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
-	{
-		ProofNode* n = getNode(*it);
-		icolor_t clause_color = getClauseColor( n->getInterpPartitionMask(), A_mask );
-		assert( clause_color == I_A || clause_color == I_B );
-		if ( clause_color == I_B )
-		{
-			if(B_added == 0)
-			{
-				dump_out << "(assert " << endl;
-				dump_out << "(and" << endl;
-				B_added++;
-			}
-			printClause( dump_out, n->getClause() );
-			dump_out << endl;
-		}
-	}
-	if(B_added > 0) dump_out << "))" << endl;
+    // Print only A atoms
+    unsigned A_added = 0;
+    for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
+    {
+        ProofNode* n = getNode(*it);
+        icolor_t clause_color = getClauseColor( n->getInterpPartitionMask(), A_mask );
+        assert( clause_color == I_A || clause_color == I_B );
+        if ( clause_color == I_A )
+        {
+            if(A_added == 0)
+            {
+                dump_out << "(assert " << endl;
+                dump_out << "(and" << endl;
+                A_added++;
+            }
+            printClause( dump_out, n->getClause() );
+            dump_out << endl;
+        }
+    }
+    if(A_added > 0) dump_out << "))" << endl;
 
 #ifdef FULL_LABELING
-	if(n->isLeaf())
-	{
-		icolor_t var_class;
-		icolor_t var_color;
-		vector< Lit > & cl = n->getClause();
-		const size_t size = cl.size( );
-		// Add negation of clause restriction
-		// In labeling, classes and colors are distinct
-		if( cl.size() > 0 )
-		{
-			unsigned num_added = 0;
-			for( size_t i = 0 ; i < size ; i ++ )
-			{
-				Var v = var(cl[i]);
-				var_class = getVarClass2( v );
-				assert( var_class == I_B || var_class == I_A || var_class == I_AB );
-				if( var_class == I_B || var_class == I_A ) var_color = var_class;
-				else
-				{
-					// Determine color of AB variable
-					if( isColoredA( n,v ) ) var_color = I_A;
-					else if ( isColoredB( n,v )  ) var_color = I_B;
-					else if ( isColoredAB( n,v ) ) var_color = I_AB;
-					else opensmt_error( "Variable has no color" );
-				}
-				if( var_color == I_B || var_color == I_AB )
-				{
-					if(num_added==0)
-					{
-						dump_out << "(assert" << endl;
-						dump_out << "(and" << endl;
-						num_added++;
-					}
-					// Add negated literal
-					if( sign(cl[i]) )
-						dump_out << logic_.printTerm(varToPTRef( v )) << endl;
-					else
-						dump_out << "(not " << logic_.printTerm(varToPTRef( v )) << " )" << endl;
-				}
-			}
-			if(num_added>0) dump_out << "))" << endl;
-		}
-	}
+    if(n->isLeaf())
+    {
+        // Add negation of clause restriction
+        // In labeling, classes and colors are distinct
+        icolor_t var_class;
+        icolor_t var_color;
+        vector< Lit > & cl = n->getClause();
+        const size_t size = cl.size( );
+
+        if( cl.size() > 0 )
+        {
+            unsigned num_added=0;
+            for( size_t i = 0 ; i < size ; i ++ )
+            {
+                Var v = var(cl[i]);
+                var_class = getVarClass2( v );
+                assert( var_class == I_B || var_class == I_A || var_class == I_AB );
+                if( var_class == I_B || var_class == I_A ) var_color = var_class;
+                else
+                {
+                    // Determine color of AB variable
+                    if( isColoredA( n,v ) ) var_color = I_A;
+                    else if ( isColoredB( n,v )  ) var_color = I_B;
+                    else if ( isColoredAB( n,v ) ) var_color = I_AB;
+                    else opensmt_error( "Variable has no color" );
+                }
+                if( var_color == I_A || var_color == I_AB )
+                {
+                    if(num_added==0)
+                    {
+                        dump_out << "(assert" << endl;
+                        dump_out << "(and" << endl;
+                        num_added++;
+                    }
+                    // Add negated literal
+                    if( sign(cl[i]) )
+                        dump_out << logic_.printTerm(varToPTRef( v )) << endl;
+                    else
+                        dump_out << "(not " << logic_.printTerm(varToPTRef( v )) << " )" << endl;
+                }
+            }
+            if(num_added>0) dump_out << "))" << endl;
+        }
+    }
 #endif
 
-	// Add partial interpolant
-	//dump_out << "(assert " << partial_interp << " )" << endl;
-	logic_.dumpFormulaToFile( dump_out, partial_interp, false );
-	dump_out << "(check-sat)" << endl;
-	dump_out << "(exit)" << endl;
-	dump_out.close( );
-	// Check !
-	if ( int pid = fork() )
-	{
-		int status;
-		waitpid(pid, &status, 0);
-		switch ( WEXITSTATUS( status ) )
-		{
-		case 0:
-			tool_res = false;
-			break;
-		case 1:
-			tool_res = true;
-			break;
-		default:
-			perror( "Error: Certifying solver returned weird answer (should be 0 or 1)" );
-			exit( EXIT_FAILURE );
-		}
-	}
-	else
-	{
-		//if ( verbose() > 0 ) { cerr << "# Solving B /\\ ~(C|b,ab) /\\ I" << endl; }
-		if ( verbose() > 0 ) { cerr << "# Checking B /\\ I -> false" << endl; }
-		execlp( config.certifying_solver, config.certifying_solver, name2, NULL );
-		perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-		exit( 1 );
-	}
-	if ( tool_res == true )
-		//opensmt_error( "External tool says B /\\ ~(C|b,ab) -> ~I does not hold" );
-		opensmt_error( "External tool says B /\\ I -> false does not hold" );
+    // Add partial interpolant
+    //dump_out << "(assert (not " << partial_interp << ") )" << endl;
+    logic_.dumpFormulaToFile( dump_out, partial_interp, true );
+    dump_out << "(check-sat)" << endl;
+    dump_out << "(exit)" << endl;
+    dump_out.close( );
 
-	remove(name);
-	remove(name2);
+    // Check !
+    bool tool_res;
+    if ( int pid = fork() )
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        switch ( WEXITSTATUS( status ) )
+        {
+            case 0:
+                tool_res = false;
+                break;
+            case 1:
+                tool_res = true;
+                break;
+            default:
+                perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                exit( EXIT_FAILURE );
+        }
+    }
+    else
+    {
+        //if( verbose() > 0 ) { cerr << "# Solving A /\\ ~(C|a,ab) /\\ ~I" << endl; }
+        if( verbose() > 0 ) { cerr << "# Checking A -> I" << endl; }
+        execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+        perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+        exit( EXIT_FAILURE );
+    }
+    if ( tool_res == true )
+        //opensmt_error( "External tool says A /\\ ~(C|a,ab) -> I does not hold" );
+    opensmt_error( "External tool says A -> I does not hold" );
 
-	if( verbose() > 0 ) { cerr << "# The interpolant is sound" << endl; }
+    // Check B /\ ~(C|b,ab) -> ~I, i.e., B /\ ~(C|b,ab) /\ I unsat
+
+    const char * name2 = "verifyinterp_B.smt2";
+    dump_out.open( name2 );
+    logic_.dumpHeaderToFile( dump_out );
+
+    dump_out << varsDecl << endl;
+
+    // Print only B atoms
+    unsigned B_added = 0;
+    for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
+    {
+        ProofNode* n = getNode(*it);
+        icolor_t clause_color = getClauseColor( n->getInterpPartitionMask(), A_mask );
+        assert( clause_color == I_A || clause_color == I_B );
+        if ( clause_color == I_B )
+        {
+            if(B_added == 0)
+            {
+                dump_out << "(assert " << endl;
+                dump_out << "(and" << endl;
+                B_added++;
+            }
+            printClause( dump_out, n->getClause() );
+            dump_out << endl;
+        }
+    }
+    if(B_added > 0) dump_out << "))" << endl;
+
+#ifdef FULL_LABELING
+    if(n->isLeaf())
+    {
+        icolor_t var_class;
+        icolor_t var_color;
+        vector< Lit > & cl = n->getClause();
+        const size_t size = cl.size( );
+        // Add negation of clause restriction
+        // In labeling, classes and colors are distinct
+        if( cl.size() > 0 )
+        {
+            unsigned num_added = 0;
+            for( size_t i = 0 ; i < size ; i ++ )
+            {
+                Var v = var(cl[i]);
+                var_class = getVarClass2( v );
+                assert( var_class == I_B || var_class == I_A || var_class == I_AB );
+                if( var_class == I_B || var_class == I_A ) var_color = var_class;
+                else
+                {
+                    // Determine color of AB variable
+                    if( isColoredA( n,v ) ) var_color = I_A;
+                    else if ( isColoredB( n,v )  ) var_color = I_B;
+                    else if ( isColoredAB( n,v ) ) var_color = I_AB;
+                    else opensmt_error( "Variable has no color" );
+                }
+                if( var_color == I_B || var_color == I_AB )
+                {
+                    if(num_added==0)
+                    {
+                        dump_out << "(assert" << endl;
+                        dump_out << "(and" << endl;
+                        num_added++;
+                    }
+                    // Add negated literal
+                    if( sign(cl[i]) )
+                        dump_out << logic_.printTerm(varToPTRef( v )) << endl;
+                    else
+                        dump_out << "(not " << logic_.printTerm(varToPTRef( v )) << " )" << endl;
+                }
+            }
+            if(num_added>0) dump_out << "))" << endl;
+        }
+    }
+#endif
+
+    // Add partial interpolant
+    //dump_out << "(assert " << partial_interp << " )" << endl;
+    logic_.dumpFormulaToFile( dump_out, partial_interp, false );
+    dump_out << "(check-sat)" << endl;
+    dump_out << "(exit)" << endl;
+    dump_out.close( );
+    // Check !
+    if ( int pid = fork() )
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        switch ( WEXITSTATUS( status ) )
+        {
+            case 0:
+                tool_res = false;
+                break;
+            case 1:
+                tool_res = true;
+                break;
+            default:
+                perror( "Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                exit( EXIT_FAILURE );
+        }
+    }
+    else
+    {
+        //if ( verbose() > 0 ) { cerr << "# Solving B /\\ ~(C|b,ab) /\\ I" << endl; }
+        if ( verbose() > 0 ) { cerr << "# Checking B /\\ I -> false" << endl; }
+        execlp( config.certifying_solver, config.certifying_solver, name2, NULL );
+        perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+        exit( 1 );
+    }
+    if ( tool_res == true )
+        //opensmt_error( "External tool says B /\\ ~(C|b,ab) -> ~I does not hold" );
+    opensmt_error( "External tool says B /\\ I -> false does not hold" );
+
+    remove(name);
+    remove(name2);
+
+    if( verbose() > 0 ) { cerr << "# The interpolant is sound" << endl; }
 }
 
 
@@ -531,93 +531,93 @@ dump_out << varsDecl << endl;
 // Requirement  I_i /\ phi_{i+1} -> I_{i+1}
 bool ProofGraph::verifyPathInterpolantsFromLeaves ( vec< PTRef > & interps)
 {
-	if( verbose() ) cerr << "# Verifying the path interpolation property " << endl;
-	unsigned no_part = logic_.getNofPartitions();
+    if( verbose() ) cerr << "# Verifying the path interpolation property " << endl;
+    unsigned no_part = logic_.getNofPartitions();
 
-	// m partitions, m+1 interpolants
-	assert( (no_part + 1) == static_cast<unsigned>(interps.size()) );
+    // m partitions, m+1 interpolants
+    assert( (no_part + 1) == static_cast<unsigned>(interps.size()) );
 
-	string varsDecl("");
-	for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
-	{
-		varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
-	}
+    string varsDecl("");
+    for(int i = 2; i <= static_cast<int>(getMaxIdVar()); ++i)
+    {
+        varsDecl += "(declare-fun " + string(logic_.printTerm(varToPTRef(i))) + " () Bool)\n";
+    }
 
-	// Try ith constraint I_i /\ phi_i -> I_{i+1}
-	bool property_holds = true;
-	for( unsigned j = 0; j < no_part && property_holds; j++ )
-	{
-		// First stage: print declarations
-		const char * name = "interpolationproperty.smt2";
-		ofstream dump_out( name );
-		logic_.dumpHeaderToFile( dump_out );
+    // Try ith constraint I_i /\ phi_i -> I_{i+1}
+    bool property_holds = true;
+    for( unsigned j = 0; j < no_part && property_holds; j++ )
+    {
+        // First stage: print declarations
+        const char * name = "interpolationproperty.smt2";
+        ofstream dump_out( name );
+        logic_.dumpHeaderToFile( dump_out );
 
-		dump_out << varsDecl << endl;
+        dump_out << varsDecl << endl;
 
-		// Print I_i /\ ~I_{i+1}
-		logic_.dumpFormulaToFile( dump_out, interps[j], false );
-		logic_.dumpFormulaToFile( dump_out, interps[j+1], true );
-		// Print phi_i
-		dump_out << "(assert (and " << endl;
-		// NOTE adding constant true in case of empty partition
-		// remember that we are working on leaves only
-		dump_out << "true " << endl;
-		for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
-		{
-			ProofNode* n = getNode(*it);
-			const ipartitions_t & part = n->getInterpPartitionMask();
-			// Clause is in partition 1<= jp <=m if bit jp is set
-			int in_j = opensmt::tstbit( part, j+1 );
-			if ( in_j )
-			{
-				printClause( dump_out, n->getClause() );
-				dump_out << endl;
-			}
-		}
-		dump_out << "))" << endl;
-		dump_out << "(check-sat)" << endl;
-		dump_out << "(exit)" << endl;
-		dump_out.close( );
+        // Print I_i /\ ~I_{i+1}
+        logic_.dumpFormulaToFile( dump_out, interps[j], false );
+        logic_.dumpFormulaToFile( dump_out, interps[j+1], true );
+        // Print phi_i
+        dump_out << "(assert (and " << endl;
+        // NOTE adding constant true in case of empty partition
+        // remember that we are working on leaves only
+        dump_out << "true " << endl;
+        for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
+        {
+            ProofNode* n = getNode(*it);
+            const ipartitions_t & part = n->getInterpPartitionMask();
+            // Clause is in partition 1<= jp <=m if bit jp is set
+            int in_j = opensmt::tstbit( part, j+1 );
+            if ( in_j )
+            {
+                printClause( dump_out, n->getClause() );
+                dump_out << endl;
+            }
+        }
+        dump_out << "))" << endl;
+        dump_out << "(check-sat)" << endl;
+        dump_out << "(exit)" << endl;
+        dump_out.close( );
 
-		// Check !
-		bool tool_res;
-		if ( int pid = fork() )
-		{
-			int status;
-			waitpid(pid, &status, 0);
-			switch ( WEXITSTATUS( status ) )
-			{
-			case 0:
-				tool_res = false;
-				break;
-			case 1:
-				tool_res = true;
-				break;
-			default:
-				perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-				exit( EXIT_FAILURE );
-			}
-		}
-		else
-		{
-			if( verbose() > 0 ) { cerr << "# Checking I_"<< j <<" /\\ phi_"<< j+1 <<" -> I_"<<j+1  << endl; }
-			execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-			perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-			exit( EXIT_FAILURE );
-		}
-		if ( tool_res == true )
-		{
-			if( verbose() > 0 ) cerr << "# External tool says inductiveness does not hold" << endl;
-			property_holds = false;
-		}
-		else remove(name);
-	}
-	if( verbose() )
-	{
-		if(property_holds) cerr << "# The path interpolation property is satisfied" << endl;
-		else cerr << "# The path interpolation property is NOT satisfied" << endl;
-	}
-	return property_holds;
+        // Check !
+        bool tool_res;
+        if ( int pid = fork() )
+        {
+            int status;
+            waitpid(pid, &status, 0);
+            switch ( WEXITSTATUS( status ) )
+            {
+                case 0:
+                    tool_res = false;
+                    break;
+                case 1:
+                    tool_res = true;
+                    break;
+                default:
+                    perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                    exit( EXIT_FAILURE );
+            }
+        }
+        else
+        {
+            if( verbose() > 0 ) { cerr << "# Checking I_"<< j <<" /\\ phi_"<< j+1 <<" -> I_"<<j+1  << endl; }
+            execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+            perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+            exit( EXIT_FAILURE );
+        }
+        if ( tool_res == true )
+        {
+            if( verbose() > 0 ) cerr << "# External tool says inductiveness does not hold" << endl;
+            property_holds = false;
+        }
+        else remove(name);
+    }
+    if( verbose() )
+    {
+        if(property_holds) cerr << "# The path interpolation property is satisfied" << endl;
+        else cerr << "# The path interpolation property is NOT satisfied" << endl;
+    }
+    return property_holds;
 }
 
 // Simultaneous abstraction
@@ -627,61 +627,61 @@ bool ProofGraph::verifyPathInterpolantsFromLeaves ( vec< PTRef > & interps)
 // Requirement  I_i /\ ... /\ I_n -> false
 bool ProofGraph::verifySimultaneousAbstraction( vec< PTRef > & interps)
 {
-	if( verbose() ) cerr << "# Verifying the simultaneous abstraction property " << endl;
+    if( verbose() ) cerr << "# Verifying the simultaneous abstraction property " << endl;
 
-	// First stage: print declarations
-	const char * name = "verifysymmetric.smt2";
-	ofstream dump_out( name );
-	logic_.dumpHeaderToFile( dump_out );
+    // First stage: print declarations
+    const char * name = "verifysymmetric.smt2";
+    ofstream dump_out( name );
+    logic_.dumpHeaderToFile( dump_out );
 
-	// Add conjunction interpolants
-	for( int i = 0; i < interps.size(); i++ ) {
+    // Add conjunction interpolants
+    for( int i = 0; i < interps.size(); i++ ) {
         logic_.dumpFormulaToFile(dump_out, interps[i], false);
     }
-	dump_out << "(check-sat)" << endl;
-	dump_out << "(exit)" << endl;
-	dump_out.close( );
+    dump_out << "(check-sat)" << endl;
+    dump_out << "(exit)" << endl;
+    dump_out.close( );
 
-	// Check !
-	bool property_holds = true;
-	bool tool_res;
-	if ( int pid = fork() )
-	{
-		int status;
-		waitpid(pid, &status, 0);
-		switch ( WEXITSTATUS( status ) )
-		{
-		case 0:
-			tool_res = false;
-			break;
-		case 1:
-			tool_res = true;
-			break;
-		default:
-			perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-			exit( EXIT_FAILURE );
-		}
-	}
-	else
-	{
-		if( verbose() > 0 ) { cerr << "# Checking I_1 /\\ ... /\\ I_" << interps.size() <<" -> false" << endl; }
-		execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-		perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-		exit( EXIT_FAILURE );
-	}
-	if ( tool_res == true )
-	{
-		if(verbose()) cerr << "# External tool says  I_1 /\\ ... /\\ I_"<< interps.size() << " -> false  does not hold" << endl;
-		property_holds = false;
-	}
-	else remove(name);
+    // Check !
+    bool property_holds = true;
+    bool tool_res;
+    if ( int pid = fork() )
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        switch ( WEXITSTATUS( status ) )
+        {
+            case 0:
+                tool_res = false;
+                break;
+            case 1:
+                tool_res = true;
+                break;
+            default:
+                perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                exit( EXIT_FAILURE );
+        }
+    }
+    else
+    {
+        if( verbose() > 0 ) { cerr << "# Checking I_1 /\\ ... /\\ I_" << interps.size() <<" -> false" << endl; }
+        execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+        perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+        exit( EXIT_FAILURE );
+    }
+    if ( tool_res == true )
+    {
+        if(verbose()) cerr << "# External tool says  I_1 /\\ ... /\\ I_"<< interps.size() << " -> false  does not hold" << endl;
+        property_holds = false;
+    }
+    else remove(name);
 
-	if( verbose() )
-	{
-		if(property_holds) cerr << "# The simultaneous abstraction property is satisfied" << endl;
-		else cerr << "# The simultaneous abstraction property is NOT satisfied" << endl;
-	}
-	return property_holds;
+    if( verbose() )
+    {
+        if(property_holds) cerr << "# The simultaneous abstraction property is satisfied" << endl;
+        else cerr << "# The simultaneous abstraction property is NOT satisfied" << endl;
+    }
+    return property_holds;
 }
 
 // Generalized simultaneous abstraction
@@ -692,62 +692,62 @@ bool ProofGraph::verifySimultaneousAbstraction( vec< PTRef > & interps)
 // Requirement  I_i /\ ... /\ I_{n-1} -> I_n
 bool ProofGraph::verifyGenSimultaneousAbstraction( vec< PTRef > & interps)
 {
-	if( verbose() ) cerr << "# Verifying the generalized simultaneous abstraction property " << endl;
+    if( verbose() ) cerr << "# Verifying the generalized simultaneous abstraction property " << endl;
 
-	// First stage: print declarations
-	const char * name = "verifysymmetric.smt2";
-	ofstream dump_out( name );
-	logic_.dumpHeaderToFile( dump_out );
+    // First stage: print declarations
+    const char * name = "verifysymmetric.smt2";
+    ofstream dump_out( name );
+    logic_.dumpHeaderToFile( dump_out );
 
-	// Add conjunction interpolants
-	for( int i = 0; i < interps.size()-1; i++ ) {
+    // Add conjunction interpolants
+    for( int i = 0; i < interps.size()-1; i++ ) {
         logic_.dumpFormulaToFile(dump_out, interps[i], false);
     }
-	// Add negation last interpolant
-	logic_.dumpFormulaToFile( dump_out, interps[interps.size()-1], true );
-	dump_out << "(check-sat)" << endl;
-	dump_out << "(exit)" << endl;
-	dump_out.close( );
+    // Add negation last interpolant
+    logic_.dumpFormulaToFile( dump_out, interps[interps.size()-1], true );
+    dump_out << "(check-sat)" << endl;
+    dump_out << "(exit)" << endl;
+    dump_out.close( );
 
-	// Check !
-	bool property_holds = true;
-	bool tool_res;
-	if ( int pid = fork() )
-	{
-		int status;
-		waitpid(pid, &status, 0);
-		switch ( WEXITSTATUS( status ) )
-		{
-		case 0:
-			tool_res = false;
-			break;
-		case 1:
-			tool_res = true;
-			break;
-		default:
-			perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-			exit( EXIT_FAILURE );
-		}
-	}
-	else
-	{
-		if( verbose() > 0 ) { cerr << "# Checking I_1 /\\ ... /\\ I_"<< interps.size()-1 <<" -> I_" << interps.size() << endl; }
-		execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-		perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-		exit( EXIT_FAILURE );
-	}
-	if ( tool_res == true )
-	{
-		if(verbose()) cerr << "# External tool says  I_1 /\\ ... /\\ I_"<< interps.size()-1 <<" -> I_" << interps.size() << " does not hold" << endl;
-		property_holds = false;
-	}
-	else remove(name);
-	if( verbose() )
-	{
-		if(property_holds) cerr << "# The generalized simultaneous abstraction property is satisfied" << endl;
-		else cerr << "# The generalized simultaneous abstraction property is NOT satisfied" << endl;
-	}
-	return property_holds;
+    // Check !
+    bool property_holds = true;
+    bool tool_res;
+    if ( int pid = fork() )
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        switch ( WEXITSTATUS( status ) )
+        {
+            case 0:
+                tool_res = false;
+                break;
+            case 1:
+                tool_res = true;
+                break;
+            default:
+                perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                exit( EXIT_FAILURE );
+        }
+    }
+    else
+    {
+        if( verbose() > 0 ) { cerr << "# Checking I_1 /\\ ... /\\ I_"<< interps.size()-1 <<" -> I_" << interps.size() << endl; }
+        execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+        perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+        exit( EXIT_FAILURE );
+    }
+    if ( tool_res == true )
+    {
+        if(verbose()) cerr << "# External tool says  I_1 /\\ ... /\\ I_"<< interps.size()-1 <<" -> I_" << interps.size() << " does not hold" << endl;
+        property_holds = false;
+    }
+    else remove(name);
+    if( verbose() )
+    {
+        if(property_holds) cerr << "# The generalized simultaneous abstraction property is satisfied" << endl;
+        else cerr << "# The generalized simultaneous abstraction property is NOT satisfied" << endl;
+    }
+    return property_holds;
 }
 
 // State transition interpolation
@@ -759,68 +759,68 @@ bool ProofGraph::verifyGenSimultaneousAbstraction( vec< PTRef > & interps)
 // NOTE the vector contains first all the path interpolants and then all the symmetric interpolants
 bool ProofGraph::verifyStateTransitionInterpolants ( vec< PTRef > & interps)
 {
-	if( verbose() ) cerr << "# Verifying the state-transition interpolation property " << endl;
+    if( verbose() ) cerr << "# Verifying the state-transition interpolation property " << endl;
 
-	// m partitions, 2m+1 interpolants
-	unsigned no_part = logic_.getNofPartitions();
-	assert( (2*no_part + 1) == static_cast<unsigned>(interps.size()) );
+    // m partitions, 2m+1 interpolants
+    unsigned no_part = logic_.getNofPartitions();
+    assert( (2*no_part + 1) == static_cast<unsigned>(interps.size()) );
 
-	// Try ith constraint I_i /\ J_{i+1} -> I_{i+1}
-	bool property_holds = true;
-	for( unsigned j = 0; j < no_part && property_holds; j++ )
-	{
-		// First stage: print declarations
-		const char * name = "interpolationproperty.smt2";
-		ofstream dump_out( name );
-		logic_.dumpHeaderToFile( dump_out );
+    // Try ith constraint I_i /\ J_{i+1} -> I_{i+1}
+    bool property_holds = true;
+    for( unsigned j = 0; j < no_part && property_holds; j++ )
+    {
+        // First stage: print declarations
+        const char * name = "interpolationproperty.smt2";
+        ofstream dump_out( name );
+        logic_.dumpHeaderToFile( dump_out );
 
-		// Print I_i /\ J_{i+1} /\ ~I_{i+1}
-		logic_.dumpFormulaToFile( dump_out, interps[j], false );
-		logic_.dumpFormulaToFile( dump_out, interps[j+(no_part+1)], false );
-		logic_.dumpFormulaToFile( dump_out, interps[j+1], true );
-		dump_out << "(check-sat)" << endl;
-		dump_out << "(exit)" << endl;
-		dump_out.close( );
+        // Print I_i /\ J_{i+1} /\ ~I_{i+1}
+        logic_.dumpFormulaToFile( dump_out, interps[j], false );
+        logic_.dumpFormulaToFile( dump_out, interps[j+(no_part+1)], false );
+        logic_.dumpFormulaToFile( dump_out, interps[j+1], true );
+        dump_out << "(check-sat)" << endl;
+        dump_out << "(exit)" << endl;
+        dump_out.close( );
 
-		// Check !
-		bool tool_res;
-		if ( int pid = fork() )
-		{
-			int status;
-			waitpid(pid, &status, 0);
-			switch ( WEXITSTATUS( status ) )
-			{
-			case 0:
-				tool_res = false;
-				break;
-			case 1:
-				tool_res = true;
-				break;
-			default:
-				perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-				exit( EXIT_FAILURE );
-			}
-		}
-		else
-		{
-			if( verbose() > 0 ) { cerr << "# Checking I_"<< j <<" /\\ J_"<< j+1 <<" -> I_"<< j+1 << endl; }
-			execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-			perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-			exit( EXIT_FAILURE );
-		}
-		if ( tool_res == true )
-		{
-			if(verbose()) cerr << "# External tool says inductiveness does not hold" << endl;
-			property_holds = false;
-		}
-		else remove(name);
-	}
-	if( verbose() )
-	{
-		if(property_holds) cerr << "# The state-transition interpolation property is satisfied" << endl;
-		else cerr << "# The state-transition interpolation property is NOT satisfied" << endl;
-	}
-	return property_holds;
+        // Check !
+        bool tool_res;
+        if ( int pid = fork() )
+        {
+            int status;
+            waitpid(pid, &status, 0);
+            switch ( WEXITSTATUS( status ) )
+            {
+                case 0:
+                    tool_res = false;
+                    break;
+                case 1:
+                    tool_res = true;
+                    break;
+                default:
+                    perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                    exit( EXIT_FAILURE );
+            }
+        }
+        else
+        {
+            if( verbose() > 0 ) { cerr << "# Checking I_"<< j <<" /\\ J_"<< j+1 <<" -> I_"<< j+1 << endl; }
+            execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+            perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+            exit( EXIT_FAILURE );
+        }
+        if ( tool_res == true )
+        {
+            if(verbose()) cerr << "# External tool says inductiveness does not hold" << endl;
+            property_holds = false;
+        }
+        else remove(name);
+    }
+    if( verbose() )
+    {
+        if(property_holds) cerr << "# The state-transition interpolation property is satisfied" << endl;
+        else cerr << "# The state-transition interpolation property is NOT satisfied" << endl;
+    }
+    return property_holds;
 }
 
 
@@ -950,107 +950,107 @@ void ProofGraph::verifyTreeInterpolants( opensmt::InterpolationTree* itree, vect
 // Requirement  ( /\_(j,k) I_k /\ phi_j ) -> I_j
 bool ProofGraph::verifyTreeInterpolantsFromLeaves( opensmt::InterpolationTree* itree, vec< PTRef > & interps)
 {
-	if( verbose() ) std::cerr << "# Verifying the tree interpolation property" << std::endl;
+    if( verbose() ) std::cerr << "# Verifying the tree interpolation property" << std::endl;
 
-	// m partitions, one for each node of the tree
-	// TODO m or less interpolants - not necessarily all nodes are approximated
-	// for nodes non approximated, interpolants are the original formulae
-	assert( logic_.getNofPartitions() == static_cast<unsigned>(interps.size()) );
+    // m partitions, one for each node of the tree
+    // TODO m or less interpolants - not necessarily all nodes are approximated
+    // for nodes non approximated, interpolants are the original formulae
+    assert( logic_.getNofPartitions() == static_cast<unsigned>(interps.size()) );
 
-	// NOTE partition ids start from 1, interpolants vector from 0
-	// interpolants[i] contains interpolant for node with partition id i+1
-	std::deque< opensmt::InterpolationTree* > que;
-	que.push_back( itree );
-	bool property_holds = true;
-	do
-	{
-		opensmt::InterpolationTree* itr = que.front();
-		que.pop_front();
-		int j = itr->getPartitionId();
+    // NOTE partition ids start from 1, interpolants vector from 0
+    // interpolants[i] contains interpolant for node with partition id i+1
+    std::deque< opensmt::InterpolationTree* > que;
+    que.push_back( itree );
+    bool property_holds = true;
+    do
+    {
+        opensmt::InterpolationTree* itr = que.front();
+        que.pop_front();
+        int j = itr->getPartitionId();
 
-		// Visit j_th node and verify constraint ( /\_(j,k) I_k /\ phi_j ) -> I_j
-		// NOTE partition_ids are numbered from 1
+        // Visit j_th node and verify constraint ( /\_(j,k) I_k /\ phi_j ) -> I_j
+        // NOTE partition_ids are numbered from 1
 
-		// First stage: print declarations
-		const char * name = "interpolationproperty.smt2";
-		ofstream dump_out( name );
-		logic_.dumpHeaderToFile( dump_out );
+        // First stage: print declarations
+        const char * name = "interpolationproperty.smt2";
+        ofstream dump_out( name );
+        logic_.dumpHeaderToFile( dump_out );
 
-		// Print /\_(j,k) I_k and add children to queue
-		for( set<opensmt::InterpolationTree*>::iterator tt = itr->getChildren().begin(); tt != itr->getChildren().end(); tt++ )
-		{
-			int k = (*tt)->getPartitionId();
-			logic_.dumpFormulaToFile( dump_out, interps[k-1], false );
-			que.push_back(*tt);
-		}
-		// Print phi_j
-		int jp = itr->getPartitionId();
-		dump_out << "(assert (and" << endl;
-		// NOTE adding constant true in case of empty partition
-		// remember that we are working on leaves only
-		dump_out << "true " << endl;
-		for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
-		{
-			ProofNode* n = getNode(*it);
-			const ipartitions_t & part = n->getInterpPartitionMask();
-			// Clause is in partition 1<= jp <=m if bit jp is set
-			int in_jp = opensmt::tstbit( part, jp );
-			if ( in_jp )
-			{
-				printClause( dump_out, n->getClause() );
-				dump_out << endl;
-			}
-		}
-		dump_out << "))" << endl;
-		// Print ~I_j
-		logic_.dumpFormulaToFile( dump_out, interps[j-1], true );
+        // Print /\_(j,k) I_k and add children to queue
+        for( set<opensmt::InterpolationTree*>::iterator tt = itr->getChildren().begin(); tt != itr->getChildren().end(); tt++ )
+        {
+            int k = (*tt)->getPartitionId();
+            logic_.dumpFormulaToFile( dump_out, interps[k-1], false );
+            que.push_back(*tt);
+        }
+        // Print phi_j
+        int jp = itr->getPartitionId();
+        dump_out << "(assert (and" << endl;
+        // NOTE adding constant true in case of empty partition
+        // remember that we are working on leaves only
+        dump_out << "true " << endl;
+        for ( set<clauseid_t>::iterator it = leaves_ids.begin(); it != leaves_ids.end(); it++ )
+        {
+            ProofNode* n = getNode(*it);
+            const ipartitions_t & part = n->getInterpPartitionMask();
+            // Clause is in partition 1<= jp <=m if bit jp is set
+            int in_jp = opensmt::tstbit( part, jp );
+            if ( in_jp )
+            {
+                printClause( dump_out, n->getClause() );
+                dump_out << endl;
+            }
+        }
+        dump_out << "))" << endl;
+        // Print ~I_j
+        logic_.dumpFormulaToFile( dump_out, interps[j-1], true );
 
-		dump_out << "(check-sat)" << endl;
-		dump_out << "(exit)" << endl;
-		dump_out.close( );
+        dump_out << "(check-sat)" << endl;
+        dump_out << "(exit)" << endl;
+        dump_out.close( );
 
-		// Check !
-		bool tool_res;
-		if ( int pid = fork() )
-		{
-			int status;
-			waitpid(pid, &status, 0);
-			switch ( WEXITSTATUS( status ) )
-			{
-			case 0:
-				tool_res = false;
-				break;
-			case 1:
-				tool_res = true;
-				break;
-			default:
-				perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-				exit( EXIT_FAILURE );
-			}
-		}
-		else
-		{
-			//( /\_(j,k) I_k /\ phi_j ) -> I_j
-			if( verbose() > 0 ) { cerr << "# Checking /\\_("<< j <<",k) I_k /\\ phi_"<< j << " -> I_"<< j << endl; }
-			execlp( config.certifying_solver, config.certifying_solver, name, NULL );
-			perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
-			exit( EXIT_FAILURE );
-		}
-		if ( tool_res == true )
-		{
-			cerr << "# External tool says inductiveness does not hold" << endl;
-			property_holds = false;
-		}
-		else remove(name);
-	}
-	while( !que.empty() && property_holds );
+        // Check !
+        bool tool_res;
+        if ( int pid = fork() )
+        {
+            int status;
+            waitpid(pid, &status, 0);
+            switch ( WEXITSTATUS( status ) )
+            {
+                case 0:
+                    tool_res = false;
+                    break;
+                case 1:
+                    tool_res = true;
+                    break;
+                default:
+                    perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
+                    exit( EXIT_FAILURE );
+            }
+        }
+        else
+        {
+            //( /\_(j,k) I_k /\ phi_j ) -> I_j
+            if( verbose() > 0 ) { cerr << "# Checking /\\_("<< j <<",k) I_k /\\ phi_"<< j << " -> I_"<< j << endl; }
+            execlp( config.certifying_solver, config.certifying_solver, name, NULL );
+            perror( "Error: Certifying solver had some problems (check that it is reachable and executable)" );
+            exit( EXIT_FAILURE );
+        }
+        if ( tool_res == true )
+        {
+            cerr << "# External tool says inductiveness does not hold" << endl;
+            property_holds = false;
+        }
+        else remove(name);
+    }
+    while( !que.empty() && property_holds );
 
-	if( verbose() )
-	{
-		if(property_holds) cerr << "# The tree interpolation property is satisfied" << endl;
-		else cerr << "# The tree interpolation property is NOT satisfied" << endl;
-	}
-	return property_holds;
+    if( verbose() )
+    {
+        if(property_holds) cerr << "# The tree interpolation property is satisfied" << endl;
+        else cerr << "# The tree interpolation property is NOT satisfied" << endl;
+    }
+    return property_holds;
 }
 
 

--- a/src/proof/PGInterCheck.C
+++ b/src/proof/PGInterCheck.C
@@ -281,8 +281,7 @@ void ProofGraph::verifyPartialInterpolantFromLeaves( ProofNode* n, const ipartit
 	{
 		// Skip true and false
 		if((*it) == logic_.getTerm_true() || (*it) == logic_.getTerm_false()) continue;
-		Var variab = PTRefToVar(*it);
-		assert( getVarClass(variab, A_mask) == I_AB );
+		assert( getVarClass(PTRefToVar(*it), A_mask) == I_AB );
 	}
 	if( verbose() > 0 ) { cerr << "# The interpolant is on the shared signature" << endl; }
 
@@ -949,14 +948,12 @@ void ProofGraph::verifyTreeInterpolants( opensmt::InterpolationTree* itree, vect
 // Requirement  ( /\_(j,k) I_k /\ phi_j ) -> I_j
 bool ProofGraph::verifyTreeInterpolantsFromLeaves( opensmt::InterpolationTree* itree, vec< PTRef > & interps)
 {
-	if( verbose() ) cerr << "# Verifying the tree interpolation property" << endl;
-
-	unsigned no_part = logic_.getNofPartitions();
+	if( verbose() ) std::cerr << "# Verifying the tree interpolation property" << std::endl;
 
 	// m partitions, one for each node of the tree
 	// TODO m or less interpolants - not necessarily all nodes are approximated
 	// for nodes non approximated, interpolants are the original formulae
-	assert( no_part == interps.size() );
+	assert( logic_.getNofPartitions() == interps.size() );
 
 	// NOTE partition ids start from 1, interpolants vector from 0
 	// interpolants[i] contains interpolant for node with partition id i+1

--- a/src/proof/PGInterpolator.C
+++ b/src/proof/PGInterpolator.C
@@ -434,8 +434,8 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
     }
 
     // Clause and partial interpolant
-    ProofNode *n;
-    PTRef partial_interp;
+    ProofNode *n = nullptr;
+    PTRef partial_interp = PTRef_Undef;
 
     // Vector for topological ordering
     vector< clauseid_t > DFSv;
@@ -583,7 +583,7 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
         }
     }
 
-    if (PSFunction != NULL) delete PSFunction;
+    delete PSFunction;
 
     // Last clause visited is the empty clause with total interpolant
     assert (partial_interp == getRoot()->getPartialInterpolant());
@@ -686,13 +686,13 @@ void ProofGraph::produceMultipleInterpolants ( const std::vector< ipartitions_t 
 #endif
     }
 
-    uint64_t mem_used = 0;
-
-    if ( verbose() )
-    {
-        mem_used = memUsed();
-        //reportff( "# Memory used before generating interpolants: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-    }
+//    uint64_t mem_used = 0;
+//
+//    if ( verbose() )
+//    {
+//        mem_used = memUsed();
+//        //reportff( "# Memory used before generating interpolants: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+//    }
 
     assert ( sequence_of_interpolants.size( ) == 0 );
 
@@ -763,12 +763,12 @@ void ProofGraph::produceMultipleInterpolants ( const std::vector< ipartitions_t 
 
         if ( enabledInterpVerif() ) verifyPartialInterpolantFromLeaves ( getRoot(), A_mask );
 
-        if ( verbose() )
-        {
-            mem_used = memUsed();
-            //cerr << "# Interpolant: " << partial_interp << endl;
-            //reportff( "# Memory used after generating %d interpolants: %.3f MB\n", curr_interp+1,  mem_used == 0 ? 0 : mem_used / 1048576.0 );
-        }
+//        if ( verbose() )
+//        {
+//            mem_used = memUsed();
+//            //cerr << "# Interpolant: " << partial_interp << endl;
+//            //reportff( "# Memory used after generating %d interpolants: %.3f MB\n", curr_interp+1,  mem_used == 0 ? 0 : mem_used / 1048576.0 );
+//        }
 
         if ( printProofDotty( ) == 1 )
         {

--- a/src/proof/PGInterpolator.C
+++ b/src/proof/PGInterpolator.C
@@ -979,7 +979,7 @@ PTRef ProofGraph::compInterpLabelingInnerSimple ( ProofNode *n, const ipartition
                 vec<PTRef> or_args;
                 or_args.push (and_1);
                 or_args.push (and_2);
-                PTRef partial_interp = logic_.mkOr (or_args);
+                partial_interp = logic_.mkOr (or_args);
 
 //              PTRef and_1 = logic_.mkAnd( logic_.cons( partial_interp_ant1, logic_.cons( logic_.mkNot( logic_.cons( piv ) ) ) ) );
 //              PTRef and_2 = logic_.mkAnd( logic_.cons( partial_interp_ant2, logic_.cons( piv ) ) );
@@ -1369,8 +1369,7 @@ ProofGraph::setLeafPSLabeling (ProofNode *n, map<Var, icolor_t> *labels)
         if (var_class == I_AB)
         {
             map<Var, icolor_t>::iterator it = labels->find (v);
-            set<Var>::iterator itv = theory_only.find(v);
-            assert (itv != theory_only.end() || it != labels->end());
+            assert (theory_only.find(v) != theory_only.end() || it != labels->end());
 
             if (it->second == I_A)
                 colorA (n, v);
@@ -1400,8 +1399,7 @@ ProofGraph::setLeafPSWLabeling (ProofNode *n, map<Var, icolor_t> *labels)
         if (var_class == I_AB)
         {
             map<Var, icolor_t>::iterator it = labels->find (v);
-            set<Var>::iterator itv = theory_only.find(v);
-            assert (itv != theory_only.end() || it != labels->end());
+            assert (theory_only.find(v) != theory_only.end() || it != labels->end());
 
             if (it->second == I_A)
                 colorA (n, v);
@@ -1431,8 +1429,7 @@ ProofGraph::setLeafPSSLabeling (ProofNode *n, map<Var, icolor_t> *labels)
         if (var_class == I_AB)
         {
             map<Var, icolor_t>::iterator it = labels->find (v);
-            set<Var>::iterator itv = theory_only.find(v);
-            assert (itv != theory_only.end() || it != labels->end());
+            assert (theory_only.find(v) != theory_only.end() || it != labels->end());
 
             if (it->second == I_A)
                 colorAB (n, v);

--- a/src/proof/PGInterpolator.C
+++ b/src/proof/PGInterpolator.C
@@ -52,10 +52,8 @@ bool ProofGraph::producePathInterpolants ( vec<PTRef> &interpolants )
     if ( verbose() ) cerr << "# Path interpolation " << endl;
 
     // Generate appropriate masks
-    vec< ipartitions_t > configs;
-    while (configs.size() <= logic_.getNofPartitions()+1)
-        configs.push();
-//    configs.resize (logic_.getNofPartitions() + 1, 0);
+    std::vector< ipartitions_t > configs;
+    configs.resize (logic_.getNofPartitions() + 1, 0);
 
     // First interpolant is true -> all partitions in B
     for ( unsigned i = 1; i < configs.size(); i++ )
@@ -98,10 +96,8 @@ bool ProofGraph::produceSimultaneousAbstraction ( vec< PTRef > &interpolants )
     if ( verbose() ) cerr << "# Simultaneous abstraction " << endl;
 
     // Generate appropriate masks
-    vec< ipartitions_t > configs;
-    while (configs.size() < logic_.getNofPartitions())
-        configs.push();
-//    configs.resize (logic_.getNofPartitions(), 0);
+    std::vector< ipartitions_t > configs;
+    configs.resize (logic_.getNofPartitions(), 0);
 
     for ( unsigned i = 0; i < configs.size(); i++ )
     {
@@ -143,10 +139,8 @@ bool ProofGraph::produceGenSimultaneousAbstraction ( vec< PTRef > &interpolants 
     if ( verbose() ) cerr << "# Generalized simultaneous abstraction " << endl;
 
     // Generate appropriate masks
-    vec< ipartitions_t > configs;
-    while (configs.size() < nparts)
-        configs.push();
-//    configs.resize (nparts, 0);
+    std::vector< ipartitions_t > configs;
+    configs.resize (nparts, 0);
 
     for ( unsigned i = 0; i < nparts - 1; i++ )
     {
@@ -190,10 +184,8 @@ bool ProofGraph::produceStateTransitionInterpolants ( vec< PTRef > &interpolants
     if ( verbose() ) cerr << "# State-transition interpolation " << endl;
 
     // Generate appropriate masks
-    vec< ipartitions_t > configs;
-    while (configs.size() < (2*npart) + 1)
-        configs.push();
-//    configs.resize ((2 * npart) + 1, 0);
+    std::vector< ipartitions_t > configs;
+    configs.resize ((2 * npart) + 1, 0);
 
     // All the path interpolants
     // First interpolant is true -> all partitions in B
@@ -225,10 +217,8 @@ void ProofGraph::produceConfigMatrixInterpolants (const vec< vec<int> > &configs
     if ( verbose() ) cerr << "# General interpolation via configuration matrix " << endl;
 
     // Generate appropriate masks
-    vec< ipartitions_t > parts;
-    while (parts.size() < configs.size())
-        parts.push();
-//    parts.resize (configs.size(), 0);
+    std::vector< ipartitions_t > parts;
+    parts.resize (configs.size(), 0);
 
     // First interpolant is true -> all partitions in B
     for ( unsigned i = 0; i < parts.size(); i++ )
@@ -261,10 +251,8 @@ bool ProofGraph::produceTreeInterpolants (opensmt::InterpolationTree *it, vec<PT
     // Generate appropriate masks
     // NOTE partition ids start from 1, parts vector from 0
     // parts[i] contains configuration mask for partition id i+1
-    vec< ipartitions_t > parts;
-    while (parts.size() < logic_.getNofPartitions())
-        parts.push();
-//    parts.resize (logic_.getNofPartitions(), 0);
+    std::vector< ipartitions_t > parts;
+    parts.resize (logic_.getNofPartitions(), 0);
 
     // Visit the tree in topological order bottom up and compute the configurations
     std::deque<opensmt::InterpolationTree *> q;
@@ -665,7 +653,16 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
     }
 }
 
-void ProofGraph::produceMultipleInterpolants ( const vec< ipartitions_t > &configs, vec<PTRef> &sequence_of_interpolants )
+void ProofGraph::produceMultipleInterpolants ( const vec< ipartitions_t > &configs, vec<PTRef> &sequence_of_interpolants ) {
+    std::vector<ipartitions_t> v;
+    v.reserve(configs.size());
+    for (int i = 0; i < configs.size(); ++i) {
+        v.push_back(configs[i]);
+    }
+    produceMultipleInterpolants(v, sequence_of_interpolants);
+}
+
+void ProofGraph::produceMultipleInterpolants ( const std::vector< ipartitions_t > &configs, vec<PTRef> &sequence_of_interpolants )
 {
     /*  if( verbose() > 1 )
         {

--- a/src/proof/PGInterpolator.C
+++ b/src/proof/PGInterpolator.C
@@ -223,7 +223,7 @@ void ProofGraph::produceConfigMatrixInterpolants (const vec< vec<int> > &configs
     // First interpolant is true -> all partitions in B
     for ( unsigned i = 0; i < parts.size(); i++ )
     {
-        for (unsigned j = 0; j < configs[i].size(); ++j)
+        for (int j = 0; j < configs[i].size(); ++j)
         {
             // Set partitions[i] bit to 1 (starting from bit 1, bit 0 is untouched)
             // NOTE remember that partition ids are numbered from 0 in FunFrog!
@@ -531,10 +531,11 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
                 assert(n->getType() == clause_type::CLA_THEORY);
                 clearTSolver();
                 vec<Lit> newvec;
-                vector<Lit> &oldvec = n->getClause();
+                std::vector<Lit> &oldvec = n->getClause();
 
-                for (int i = 0; i < oldvec.size(); ++i)
-                    newvec.push(~oldvec[i]);
+                for (std::size_t j = 0; j < oldvec.size(); ++j) {
+                    newvec.push(~oldvec[j]);
+                }
 
 #ifdef ITP_DEBUG
                 cout << "; ASSERTING LITS" << endl;
@@ -553,12 +554,12 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
                     res = (tres != TRes::UNSAT);
                 }
                 assert(!res);
-                map<PTRef, icolor_t> ptref2label;
-                vector<Lit>& cl = n->getClause();
+                std::map<PTRef, icolor_t> ptref2label;
+                std::vector<Lit>& cl = n->getClause();
 
-                for(int i = 0; i < cl.size(); ++i)
+                for(std::size_t j = 0; j < cl.size(); ++j)
                 {
-                    ptref2label[varToPTRef(var(cl[i]))] = getVarColor(n, var(cl[i]));
+                    ptref2label[varToPTRef(var(cl[j]))] = getVarColor(n, var(cl[j]));
                 }
 
                 partial_interp = thandler->getInterpolant (A_mask, &ptref2label);

--- a/src/proof/PGMain.C
+++ b/src/proof/PGMain.C
@@ -42,7 +42,7 @@ void ProofGraph::transfProofForReduction( )
 	// Time left for transformation
 	double solvingTime = cpuTime( );
 
-	size_t size=0;
+//	size_t size=0;
 	int numnodes=0;
 	int numedges=0;
 	int numleaves=0;
@@ -51,13 +51,13 @@ void ProofGraph::transfProofForReduction( )
 	int maxclasize=0;
 	double avgclasize=0;
 	int numunary=0;
-	double varclasize=0;
+//	double varclasize=0;
 
 	if ( verbose() )
 	{
 		getGraphInfo( );
 
-		size = graph.size( );
+//		size = graph.size( );
 		numnodes = num_nodes;
 		numedges = num_edges;
 		numleaves = num_leaves;
@@ -66,7 +66,7 @@ void ProofGraph::transfProofForReduction( )
 		maxclasize = max_cla_size;
 		avgclasize = av_cla_size;
 		numunary = num_unary;
-		varclasize = var_cla_size;
+//		varclasize = var_cla_size;
 	}
 
 	double time=0;

--- a/src/proof/PGMain.C
+++ b/src/proof/PGMain.C
@@ -187,7 +187,7 @@ double ProofGraph::doReduction(double solving_time)
 	double red_time=0;
 	//Number of inner transformation loops
 	//-1 for exhaustiveness
-	int num_transf_loops=0;
+//	int num_transf_loops=0; // MB: not used?
 	//Number of outer transformation loops
 	//useful for alternation with recycle pivots
 	int num_global_reduction_loops=0;

--- a/src/proof/PGRules.C
+++ b/src/proof/PGRules.C
@@ -53,12 +53,9 @@ bool ProofGraph::getRuleContext(clauseid_t idv3, clauseid_t idv, RuleContext& ra
 	// v antecedents are w and v3; clauses are w clause and (~t1, C3)
 	// v clause is (C1 C2 C3)
 
-	bool found1, found2;
-	size_t size;
-
 	// Determine sign of t1 and t0 (if present) in v3
-	bool t0_in_C3=false;
-	bool sign_t0_C3=false; Lit l;
+	bool t0_in_C3 = false;
+	bool sign_t0_C3 = false;
 
 	short r0 = v3->hasOccurrenceBin(t0);
 	if(r0 != -1) { t0_in_C3 = true; sign_t0_C3 = (r0 == 0)? false : true; }
@@ -95,7 +92,8 @@ bool ProofGraph::getRuleContext(clauseid_t idv3, clauseid_t idv, RuleContext& ra
 
 	bool sign_t0_v1;
 	// Determine v1 and v2
-	ProofNode *v1=NULL,*v2=NULL;
+	ProofNode * v1 = nullptr;
+	ProofNode * v2 = nullptr;
 	// Case t1 not in C2
 	if(!t1_in_C2)
 	{
@@ -342,6 +340,7 @@ void ProofGraph::applyRuleB1( RuleContext& ra )
 
 	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
 			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    (void)v2;
 
 	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
 	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
@@ -409,7 +408,7 @@ void ProofGraph::applyRuleB2Prime( RuleContext& ra )
 
 	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
 			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
-
+    (void)v2;
 	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
 	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 

--- a/src/proof/PGRules.C
+++ b/src/proof/PGRules.C
@@ -64,6 +64,7 @@ bool ProofGraph::getRuleContext(clauseid_t idv3, clauseid_t idv, RuleContext& ra
 	bool t1_in_ant1=false, t1_in_ant2 =false;
 	bool sign_t0_ant1=false, sign_t0_ant2=false;
 	bool sign_t1_ant1=false, sign_t1_ant2=false;
+    (void)sign_t1_ant1;(void)sign_t1_ant2; // MB: For some reason this are not read ever.
 
 	// Sign of t0
 	short r1 = w->getAnt1()->hasOccurrenceBin(t0);
@@ -90,7 +91,7 @@ bool ProofGraph::getRuleContext(clauseid_t idv3, clauseid_t idv, RuleContext& ra
 	// t1 found in both antecedents clauses?
 	bool t1_in_C2=t1_in_ant1 && t1_in_ant2;
 
-	bool sign_t0_v1;
+	bool sign_t0_v1 = false; // MB: Warning! this variable was previously unintialized and there is a path to usage without setting its value!
 	// Determine v1 and v2
 	ProofNode * v1 = nullptr;
 	ProofNode * v2 = nullptr;

--- a/src/proof/PGRules.C
+++ b/src/proof/PGRules.C
@@ -181,7 +181,7 @@ clauseid_t ProofGraph::ruleApply(RuleContext& ra)
 {
 	rul_type toApply=ra.getType();
 	assert(toApply!=rNO);
-	assert(ra.getV1()!=-1);
+	assert(ra.getV1()!=static_cast<clauseid_t>(-1));
 	clauseid_t claid = 0;
 
 	if(toApply==rA1 || toApply==rA1B) claid = applyRuleA1(ra);

--- a/src/proof/PGRules.C
+++ b/src/proof/PGRules.C
@@ -27,506 +27,506 @@ along with Periplo. If not, see <http://www.gnu.org/licenses/>.
 // Return false if w has not antecedents (that is, v1 and v2 don't exist)
 bool ProofGraph::getRuleContext(clauseid_t idv3, clauseid_t idv, RuleContext& ra)
 {
-	ra.reset();
-	ProofNode* v3=getNode(idv3);
-	ProofNode* v=getNode(idv);
+    ra.reset();
+    ProofNode* v3=getNode(idv3);
+    ProofNode* v=getNode(idv);
 
-	assert((size_t)idv3<getGraphSize());
-	assert(v3!=NULL);
-	assert((size_t)idv<getGraphSize());
-	assert(v!=NULL);
+    assert((size_t)idv3<getGraphSize());
+    assert(v3!=NULL);
+    assert((size_t)idv<getGraphSize());
+    assert(v!=NULL);
 
-	assert(v->getAnt1()==v3 || v->getAnt2()==v3);
-	// assert(v->getAnt1()->getId()==idv3 || v->getAnt2()->getId()==idv3);
+    assert(v->getAnt1()==v3 || v->getAnt2()==v3);
+    // assert(v->getAnt1()->getId()==idv3 || v->getAnt2()->getId()==idv3);
 
-	// Determine w, i.e. second antecedent v
-	ProofNode* w=(v3==v->getAnt1()) ? v->getAnt2() : v->getAnt1();
-	// If w has no antecedents, no rule can be applied
-	if(w->isLeaf()) return false;
+    // Determine w, i.e. second antecedent v
+    ProofNode* w=(v3==v->getAnt1()) ? v->getAnt2() : v->getAnt1();
+    // If w has no antecedents, no rule can be applied
+    if(w->isLeaf()) return false;
 
-	// Resolution pivots
-	Var t0=w->getPivot();
-	Var t1=v->getPivot();
+    // Resolution pivots
+    Var t0=w->getPivot();
+    Var t1=v->getPivot();
 
-	// w antecedents are v1,v2; clauses are (t0 t1 C1) and (~t0 C2)
-	// w clause is (t1 C1 C2)
-	// v antecedents are w and v3; clauses are w clause and (~t1, C3)
-	// v clause is (C1 C2 C3)
+    // w antecedents are v1,v2; clauses are (t0 t1 C1) and (~t0 C2)
+    // w clause is (t1 C1 C2)
+    // v antecedents are w and v3; clauses are w clause and (~t1, C3)
+    // v clause is (C1 C2 C3)
 
-	// Determine sign of t1 and t0 (if present) in v3
-	bool t0_in_C3 = false;
-	bool sign_t0_C3 = false;
+    // Determine sign of t1 and t0 (if present) in v3
+    bool t0_in_C3 = false;
+    bool sign_t0_C3 = false;
 
-	short r0 = v3->hasOccurrenceBin(t0);
-	if(r0 != -1) { t0_in_C3 = true; sign_t0_C3 = (r0 == 0)? false : true; }
+    short r0 = v3->hasOccurrenceBin(t0);
+    if(r0 != -1) { t0_in_C3 = true; sign_t0_C3 = (r0 == 0)? false : true; }
 
-	// Check condition: t1 not in C2
-	bool t1_in_ant1=false, t1_in_ant2 =false;
-	bool sign_t0_ant1=false, sign_t0_ant2=false;
-	bool sign_t1_ant1=false, sign_t1_ant2=false;
+    // Check condition: t1 not in C2
+    bool t1_in_ant1=false, t1_in_ant2 =false;
+    bool sign_t0_ant1=false, sign_t0_ant2=false;
+    bool sign_t1_ant1=false, sign_t1_ant2=false;
     (void)sign_t1_ant1;(void)sign_t1_ant2; // MB: For some reason this are not read ever.
 
-	// Sign of t0
-	short r1 = w->getAnt1()->hasOccurrenceBin(t0);
-	assert(r1 != -1);
-	if(r1 != -1) { sign_t0_ant1 = (r1 == 0)? false : true; }
-	// Look for t1
-	r1 = w->getAnt1()->hasOccurrenceBin(t1);
-	if(r1 != -1) { t1_in_ant1 = true; sign_t1_ant1 = (r1 == 0)? false : true; }
+    // Sign of t0
+    short r1 = w->getAnt1()->hasOccurrenceBin(t0);
+    assert(r1 != -1);
+    if(r1 != -1) { sign_t0_ant1 = (r1 == 0)? false : true; }
+    // Look for t1
+    r1 = w->getAnt1()->hasOccurrenceBin(t1);
+    if(r1 != -1) { t1_in_ant1 = true; sign_t1_ant1 = (r1 == 0)? false : true; }
 
-	// Sign of t0
-	short r2;
-	if( proofCheck() )
-	{
-		r2 = w->getAnt2()->hasOccurrenceBin(t0);
-		assert(r2 != -1);
-		sign_t0_ant2 = (r2 == 0)? false : true;
-		assert(sign_t0_ant2 == (!sign_t0_ant1));
-	}
-	else sign_t0_ant2 = (!sign_t0_ant1);
-	// Look for t1
-	r2 = w->getAnt2()->hasOccurrenceBin(t1);
-	if(r2 != -1) { t1_in_ant2 = true; sign_t1_ant2 = (r2 == 0)? false : true; }
+    // Sign of t0
+    short r2;
+    if( proofCheck() )
+    {
+        r2 = w->getAnt2()->hasOccurrenceBin(t0);
+        assert(r2 != -1);
+        sign_t0_ant2 = (r2 == 0)? false : true;
+        assert(sign_t0_ant2 == (!sign_t0_ant1));
+    }
+    else sign_t0_ant2 = (!sign_t0_ant1);
+    // Look for t1
+    r2 = w->getAnt2()->hasOccurrenceBin(t1);
+    if(r2 != -1) { t1_in_ant2 = true; sign_t1_ant2 = (r2 == 0)? false : true; }
 
-	// t1 found in both antecedents clauses?
-	bool t1_in_C2=t1_in_ant1 && t1_in_ant2;
+    // t1 found in both antecedents clauses?
+    bool t1_in_C2=t1_in_ant1 && t1_in_ant2;
 
-	bool sign_t0_v1 = false; // MB: Warning! this variable was previously unintialized and there is a path to usage without setting its value!
-	// Determine v1 and v2
-	ProofNode * v1 = nullptr;
-	ProofNode * v2 = nullptr;
-	// Case t1 not in C2
-	if(!t1_in_C2)
-	{
-		if(t1_in_ant1)
-		{	v1=w->getAnt1(); sign_t0_v1=sign_t0_ant1; }
-		else
-		{	v1=w->getAnt2(); sign_t0_v1=sign_t0_ant2; }
-		v2=(v1==w->getAnt1()) ? w->getAnt2() : w->getAnt1();
-		assert(v1!=v2);
-	}
-	// Case t1 in C2
-	else
-	{
-		// If t0 in C3 we can determine who is v1 and
-		// who is v2 looking at the sign of t0
-		// otherwise they are interchangeable
-		if(t0_in_C3)
-		{
-			v1=(sign_t0_ant1==sign_t0_C3) ? w->getAnt1() : w->getAnt2();
-			v2=(v1==w->getAnt1()) ? w->getAnt2() : w->getAnt1();
-		}
-		// As we like
-		else
-		{	v1=w->getAnt1(); v2=w->getAnt2(); }
-	}
-	assert(v2);
+    bool sign_t0_v1 = false; // MB: Warning! this variable was previously unintialized and there is a path to usage without setting its value!
+    // Determine v1 and v2
+    ProofNode * v1 = nullptr;
+    ProofNode * v2 = nullptr;
+    // Case t1 not in C2
+    if(!t1_in_C2)
+    {
+        if(t1_in_ant1)
+        {	v1=w->getAnt1(); sign_t0_v1=sign_t0_ant1; }
+        else
+        {	v1=w->getAnt2(); sign_t0_v1=sign_t0_ant2; }
+        v2=(v1==w->getAnt1()) ? w->getAnt2() : w->getAnt1();
+        assert(v1!=v2);
+    }
+        // Case t1 in C2
+    else
+    {
+        // If t0 in C3 we can determine who is v1 and
+        // who is v2 looking at the sign of t0
+        // otherwise they are interchangeable
+        if(t0_in_C3)
+        {
+            v1=(sign_t0_ant1==sign_t0_C3) ? w->getAnt1() : w->getAnt2();
+            v2=(v1==w->getAnt1()) ? w->getAnt2() : w->getAnt1();
+        }
+            // As we like
+        else
+        {	v1=w->getAnt1(); v2=w->getAnt2(); }
+    }
+    assert(v2);
 
-	//Update applicability info
-	ra.cv1=v1->getId();
-	ra.cv2=v2->getId();
-	ra.cw=w->getId();
-	ra.cv3=v3->getId();
-	ra.cv=v->getId();
+    //Update applicability info
+    ra.cv1=v1->getId();
+    ra.cv2=v2->getId();
+    ra.cw=w->getId();
+    ra.cv3=v3->getId();
+    ra.cv=v->getId();
 
-	assert(ra.cv == idv);
-	assert(idv == v->getId());
-	assert(v == graph[idv]);
-	assert(v == graph[ra.cv]);
+    assert(ra.cv == idv);
+    assert(idv == v->getId());
+    assert(v == graph[idv]);
+    assert(v == graph[ra.cv]);
 
-	//Rules application
-	if(!t1_in_C2 && !t0_in_C3)
-	{
-		//A1 undo case
-		if((v3->getAnt1()==v2 || v3->getAnt2()==v2) && (v3->getPivot()==w->getPivot())
-				&& (/*v3->getNumResolvents()==1 && */w->getNumResolvents()==1))
-			ra.type=rA1prime;
-		//A2 leading to B case
-		else if(v3->getAnt1()!=NULL && v3->getAnt2()!=NULL && w->getPivot()==v3->getPivot())
-			ra.type=rA2B;
-		//A2 unary case
-		else if(graph[ra.cv2]->getClauseSize()==1)
-			ra.type=rA2u;
-		else
-			ra.type=rA2;
-		return true;
-	}
-	else if(t1_in_C2 && !t0_in_C3)
-	{
-		if(graph[ra.cv3]->getAnt1()!=NULL && graph[ra.cw]->getPivot()==graph[ra.cv3]->getPivot())
-			ra.type=rA1B;
-		else
-			ra.type=rA1;
-		return true;	}
-	else if(t1_in_C2 && t0_in_C3)
-	{	ra.type=rB1; return true;	}
-	else if(!t1_in_C2 && t0_in_C3 && sign_t0_C3==sign_t0_v1)
-	{
-		if(graph[ra.cv]->getClauseSize()==1)
-			ra.type=rB2;
-		else
-			ra.type=rB2prime;
-		return true;
-	}
-	else if(!t1_in_C2 && t0_in_C3 && sign_t0_C3!=sign_t0_v1)
-	{	ra.type=rB3; return true;	}
-	else
-		//Rules are exhaustive!
-	{	opensmt_error("Unknown reduction rule context");	}
-	return false;
+    //Rules application
+    if(!t1_in_C2 && !t0_in_C3)
+    {
+        //A1 undo case
+        if((v3->getAnt1()==v2 || v3->getAnt2()==v2) && (v3->getPivot()==w->getPivot())
+           && (/*v3->getNumResolvents()==1 && */w->getNumResolvents()==1))
+            ra.type=rA1prime;
+            //A2 leading to B case
+        else if(v3->getAnt1()!=NULL && v3->getAnt2()!=NULL && w->getPivot()==v3->getPivot())
+            ra.type=rA2B;
+            //A2 unary case
+        else if(graph[ra.cv2]->getClauseSize()==1)
+            ra.type=rA2u;
+        else
+            ra.type=rA2;
+        return true;
+    }
+    else if(t1_in_C2 && !t0_in_C3)
+    {
+        if(graph[ra.cv3]->getAnt1()!=NULL && graph[ra.cw]->getPivot()==graph[ra.cv3]->getPivot())
+            ra.type=rA1B;
+        else
+            ra.type=rA1;
+        return true;	}
+    else if(t1_in_C2 && t0_in_C3)
+    {	ra.type=rB1; return true;	}
+    else if(!t1_in_C2 && t0_in_C3 && sign_t0_C3==sign_t0_v1)
+    {
+        if(graph[ra.cv]->getClauseSize()==1)
+            ra.type=rB2;
+        else
+            ra.type=rB2prime;
+        return true;
+    }
+    else if(!t1_in_C2 && t0_in_C3 && sign_t0_C3!=sign_t0_v1)
+    {	ra.type=rB3; return true;	}
+    else
+        //Rules are exhaustive!
+    {	opensmt_error("Unknown reduction rule context");	}
+    return false;
 }
 
 //Given a 5 nodes context, applies the corresponding rule
 clauseid_t ProofGraph::ruleApply(RuleContext& ra)
 {
-	rul_type toApply=ra.getType();
-	assert(toApply!=rNO);
-	assert(ra.getV1()!=static_cast<clauseid_t>(-1));
-	clauseid_t claid = 0;
+    rul_type toApply=ra.getType();
+    assert(toApply!=rNO);
+    assert(ra.getV1()!=static_cast<clauseid_t>(-1));
+    clauseid_t claid = 0;
 
-	if(toApply==rA1 || toApply==rA1B) claid = applyRuleA1(ra);
-	else if (toApply==rA1prime) applyRuleA1Prime(ra);
-	else if(toApply==rA2 || toApply==rA2u || toApply==rA2B) applyRuleA2(ra);
-	else if(toApply==rB1) applyRuleB1(ra);
-	else if(toApply==rB2prime) applyRuleB2Prime(ra);
-	else if(toApply==rB2) applyRuleB2(ra);
-	else if(toApply==rB3) applyRuleB3(ra);
-	return claid;
+    if(toApply==rA1 || toApply==rA1B) claid = applyRuleA1(ra);
+    else if (toApply==rA1prime) applyRuleA1Prime(ra);
+    else if(toApply==rA2 || toApply==rA2u || toApply==rA2B) applyRuleA2(ra);
+    else if(toApply==rB1) applyRuleB1(ra);
+    else if(toApply==rB2prime) applyRuleB2Prime(ra);
+    else if(toApply==rB2) applyRuleB2(ra);
+    else if(toApply==rB3) applyRuleB3(ra);
+    return claid;
 }
 
 clauseid_t ProofGraph::applyRuleA1( RuleContext& ra )
 {
-	assert(getNode(ra.getW())->getNumResolvents()==1);
+    assert(getNode(ra.getW())->getNumResolvents()==1);
 
-	//Transformation A1
-	//v1 is combined with v3
-	//v2 is combined with v3
-	//the results are combined together to give v
+    //Transformation A1
+    //v1 is combined with v3
+    //v2 is combined with v3
+    //the results are combined together to give v
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	//w' given by resolution v1,v3 over v pivot
-	mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
+    //w' given by resolution v1,v3 over v pivot
+    mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
 
-	assert(w->getAnt1()==v2 || w->getAnt2()==v2);
-	if(w->getAnt1()==v2) w->setAnt1(v3); else w->setAnt2(v3);
-	v3->remRes(ra.getV());
-	v3->addRes(ra.getW());
+    assert(w->getAnt1()==v2 || w->getAnt2()==v2);
+    if(w->getAnt1()==v2) w->setAnt1(v3); else w->setAnt2(v3);
+    v3->remRes(ra.getV());
+    v3->addRes(ra.getW());
 
-	//Creation new node y
-	ProofNode* y=new ProofNode(logic_);
-	y->initClause();
-	//y given by resolution v2,v3 over v pivot
-	mergeClauses(v2->getClause(),v3->getClause(),y->getClause(),v->getPivot());
+    //Creation new node y
+    ProofNode* y=new ProofNode(logic_);
+    y->initClause();
+    //y given by resolution v2,v3 over v pivot
+    mergeClauses(v2->getClause(),v3->getClause(),y->getClause(),v->getPivot());
 
-	v2->remRes(ra.getW());
-	y->setAnt1(v2);
-	y->setAnt2(v3);
-	y->setType(clause_type::CLA_DERIVED);
-	y->setPivot(v->getPivot());
-	y->setId(graph.size());
-	y->addRes(ra.getV());
-	graph.push_back(y);
-	v2->addRes(y->getId());
-	v3->addRes(y->getId());
-	// Return id new node
-	clauseid_t claid = y->getId();
+    v2->remRes(ra.getW());
+    y->setAnt1(v2);
+    y->setAnt2(v3);
+    y->setType(clause_type::CLA_DERIVED);
+    y->setPivot(v->getPivot());
+    y->setId(graph.size());
+    y->addRes(ra.getV());
+    graph.push_back(y);
+    v2->addRes(y->getId());
+    v3->addRes(y->getId());
+    // Return id new node
+    clauseid_t claid = y->getId();
 
-	//for(size_t k = 0; k<getGraphSize(); k++) if(getNode(k)!=NULL) assert(getNode(k)->getId()==k);
+    //for(size_t k = 0; k<getGraphSize(); k++) if(getNode(k)!=NULL) assert(getNode(k)->getId()==k);
 
-	//NOTE for interpolation
-	if(produceInterpolants()) y->initIData();
+    //NOTE for interpolation
+    if(produceInterpolants()) y->initIData();
 
-	//v pivot becomes w pivot and viceversa
-	Var aux;
-	aux=w->getPivot(); w->setPivot(v->getPivot()); v->setPivot(aux);
-	//v new antecedents are w and y
-	if(v->getAnt1()==v3) v->setAnt1(y); else v->setAnt2(y);
-	assert( (w->getAnt1()==v1 && w->getAnt2()==v3) || (w->getAnt2()==v1 && w->getAnt1()==v3));
-	assert( (v->getAnt1()==y && v->getAnt2()==w) || (v->getAnt2()==y && v->getAnt1()==w));
-	A1++;
-	return claid;
+    //v pivot becomes w pivot and viceversa
+    Var aux;
+    aux=w->getPivot(); w->setPivot(v->getPivot()); v->setPivot(aux);
+    //v new antecedents are w and y
+    if(v->getAnt1()==v3) v->setAnt1(y); else v->setAnt2(y);
+    assert( (w->getAnt1()==v1 && w->getAnt2()==v3) || (w->getAnt2()==v1 && w->getAnt1()==v3));
+    assert( (v->getAnt1()==y && v->getAnt2()==w) || (v->getAnt2()==y && v->getAnt1()==w));
+    A1++;
+    return claid;
 }
 
 void ProofGraph::applyRuleA1Prime( RuleContext& ra )
 {
-	assert(getNode(ra.getW())->getNumResolvents()==1);
+    assert(getNode(ra.getW())->getNumResolvents()==1);
 
-	//Transformation to undo A1 effect -> factorization
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    //Transformation to undo A1 effect -> factorization
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
-	Var aux;
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    Var aux;
 
-	ProofNode * newv2 = NULL;
-	if(v3->getAnt1()==v2) newv2=v3->getAnt2();
-	else if(v3->getAnt2()==v2) newv2=v3->getAnt1();
+    ProofNode * newv2 = NULL;
+    if(v3->getAnt1()==v2) newv2=v3->getAnt2();
+    else if(v3->getAnt2()==v2) newv2=v3->getAnt1();
 
-	assert(v3->getAnt1()==v2 || v3->getAnt2()==v2);
+    assert(v3->getAnt1()==v2 || v3->getAnt2()==v2);
 
-	//Go back to A1 initial configuration
-	mergeClauses(v1->getClause(),newv2->getClause(),w->getClause(),v->getPivot());
+    //Go back to A1 initial configuration
+    mergeClauses(v1->getClause(),newv2->getClause(),w->getClause(),v->getPivot());
 
-	//Update antecedents
-	w->setAnt1(v1);
-	w->setAnt2(newv2);
-	v->setAnt1(w);
-	v->setAnt2(v2);
-	//Swap pivots
-	aux=v->getPivot(); v->setPivot(w->getPivot()); w->setPivot(aux);
-	//remove v3 if useless
-	v2->remRes(ra.getW());
-	v2->addRes(ra.getV());
-	v3->remRes(ra.getV());
-	newv2->addRes(ra.getW()); // Gains w
-	assert(v3->getAnt1()->getNumResolvents()>=2 && v3->getAnt2()->getNumResolvents()>=2);
-	if(v3->getNumResolvents()==0)
-	{
-		newv2->remRes(v3->getId());
-		v2->remRes(v3->getId());
-		removeNode(v3->getId());
-	}
-	A1prime++;
+    //Update antecedents
+    w->setAnt1(v1);
+    w->setAnt2(newv2);
+    v->setAnt1(w);
+    v->setAnt2(v2);
+    //Swap pivots
+    aux=v->getPivot(); v->setPivot(w->getPivot()); w->setPivot(aux);
+    //remove v3 if useless
+    v2->remRes(ra.getW());
+    v2->addRes(ra.getV());
+    v3->remRes(ra.getV());
+    newv2->addRes(ra.getW()); // Gains w
+    assert(v3->getAnt1()->getNumResolvents()>=2 && v3->getAnt2()->getNumResolvents()>=2);
+    if(v3->getNumResolvents()==0)
+    {
+        newv2->remRes(v3->getId());
+        v2->remRes(v3->getId());
+        removeNode(v3->getId());
+    }
+    A1prime++;
 }
 
 void ProofGraph::applyRuleA2( RuleContext& ra )
 {
-	assert(getNode(ra.getW())->getNumResolvents()==1);
+    assert(getNode(ra.getW())->getNumResolvents()==1);
 
-	//Transformation A2(plain swap)
-	//v2 and v3 change place
-	//w changes but v doesn't
+    //Transformation A2(plain swap)
+    //v2 and v3 change place
+    //w changes but v doesn't
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	//Remove v2 from w antecedents, add v3 to w antecedents
-	if(w->getAnt1()==v2) w->setAnt1(v3);
-	else w->setAnt2(v3);
-	//Remove v3 from v antecedents, add v2 to v antecedents
-	if(v->getAnt1()==v3) v->setAnt1(v2);
-	else v->setAnt2(v2);
+    //Remove v2 from w antecedents, add v3 to w antecedents
+    if(w->getAnt1()==v2) w->setAnt1(v3);
+    else w->setAnt2(v3);
+    //Remove v3 from v antecedents, add v2 to v antecedents
+    if(v->getAnt1()==v3) v->setAnt1(v2);
+    else v->setAnt2(v2);
 
-	v2->remRes(ra.getW());
-	v2->addRes(ra.getV());
-	v3->remRes(ra.getV());
-	v3->addRes(ra.getW());
+    v2->remRes(ra.getW());
+    v2->addRes(ra.getV());
+    v3->remRes(ra.getV());
+    v3->addRes(ra.getW());
 
-	//Change w clause to resolvent of v1 and v3 over t1 : t0 C1 C3
-	mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
+    //Change w clause to resolvent of v1 and v3 over t1 : t0 C1 C3
+    mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
 
-	//Change pivots w:t0->t1,v:t1->t0;
-	Var aux;
-	aux=w->getPivot(); w->setPivot(v->getPivot()); v->setPivot(aux);
-	A2++;
+    //Change pivots w:t0->t1,v:t1->t0;
+    Var aux;
+    aux=w->getPivot(); w->setPivot(v->getPivot()); v->setPivot(aux);
+    A2++;
 }
 
 void ProofGraph::applyRuleB1( RuleContext& ra )
 {
-	//Transformation B1
-	//v1 is combined with v3
-	//v2 does not contribute anymore
-	//w might be removed
-	//the new result v' (t0 C1 C3) subsumes v (t0 C1 C2 C3)
-	//Must propagate changes
+    //Transformation B1
+    //v1 is combined with v3
+    //v2 does not contribute anymore
+    //w might be removed
+    //the new result v' (t0 C1 C3) subsumes v (t0 C1 C2 C3)
+    //Must propagate changes
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
     (void)v2;
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	//v new antecedents are v1 and v3
-	if(v->getAnt1()==w) v->setAnt1(v1);
-	else v->setAnt2(v1);
-	// w loses v as resolvent, v1 gains v as resolvent
-	v1->addRes(ra.getV());
-	w->remRes(ra.getV());
+    //v new antecedents are v1 and v3
+    if(v->getAnt1()==w) v->setAnt1(v1);
+    else v->setAnt2(v1);
+    // w loses v as resolvent, v1 gains v as resolvent
+    v1->addRes(ra.getV());
+    w->remRes(ra.getV());
 
-	//Change v clause to resolvent of v1 and v3 over t1 : t0 C1 C3
-	mergeClauses(v1->getClause(),v3->getClause(),v->getClause(),v->getPivot());
-	//Remove w, if no more resolvents (and in case also v2, w was its only resolvent)
-	if(w->getNumResolvents()==0) removeTree(w->getId());
-	B1++;
+    //Change v clause to resolvent of v1 and v3 over t1 : t0 C1 C3
+    mergeClauses(v1->getClause(),v3->getClause(),v->getClause(),v->getPivot());
+    //Remove w, if no more resolvents (and in case also v2, w was its only resolvent)
+    if(w->getNumResolvents()==0) removeTree(w->getId());
+    B1++;
 }
 
 void ProofGraph::applyRuleB2( RuleContext& ra )
 {
-	assert(getNode(ra.getW())->getNumResolvents()==1);
+    assert(getNode(ra.getW())->getNumResolvents()==1);
 
-	//Transformation B2(swap with loss of literal) NB: useful only for B2k!
-	//v2 and v3 change place
-	//w changes and v loses t0: the new v' (C1 C2 C3) subsumes v (t0 C1 C2 C3)
-	//Must propagate changes
+    //Transformation B2(swap with loss of literal) NB: useful only for B2k!
+    //v2 and v3 change place
+    //w changes and v loses t0: the new v' (C1 C2 C3) subsumes v (t0 C1 C2 C3)
+    //Must propagate changes
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	//Remove v2 from w antecedents, add v3 to w antecedents
-	if(w->getAnt1()==v2) w->setAnt1(v3);
-	else w->setAnt2(v3);
-	//Remove v3 from v antecedents, add v2 to v antecedents
-	if(v->getAnt1()==v3) v->setAnt1(v2);
-	else v->setAnt2(v2);
+    //Remove v2 from w antecedents, add v3 to w antecedents
+    if(w->getAnt1()==v2) w->setAnt1(v3);
+    else w->setAnt2(v3);
+    //Remove v3 from v antecedents, add v2 to v antecedents
+    if(v->getAnt1()==v3) v->setAnt1(v2);
+    else v->setAnt2(v2);
 
-	v2->remRes(ra.getW());
-	v2->addRes(ra.getV());
-	v3->remRes(ra.getV());
-	v3->addRes(ra.getW());
+    v2->remRes(ra.getW());
+    v2->addRes(ra.getV());
+    v3->remRes(ra.getV());
+    v3->addRes(ra.getW());
 
-	//Change w clause to resolvent of v1 and v3 over t1 : t0 C1 C3
-	mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
-	//Change v clause to resolvent of w and v2 over t0 : C1 C2 C3
-	mergeClauses(w->getClause(),v2->getClause(),v->getClause(),w->getPivot());
+    //Change w clause to resolvent of v1 and v3 over t1 : t0 C1 C3
+    mergeClauses(v1->getClause(),v3->getClause(),w->getClause(),v->getPivot());
+    //Change v clause to resolvent of w and v2 over t0 : C1 C2 C3
+    mergeClauses(w->getClause(),v2->getClause(),v->getClause(),w->getPivot());
 
-	//Change pivots w:t0->t1,v:t1->t0;
-	Var aux;
-	aux=w->getPivot();w->setPivot(v->getPivot());v->setPivot(aux);
-	B2++;
+    //Change pivots w:t0->t1,v:t1->t0;
+    Var aux;
+    aux=w->getPivot();w->setPivot(v->getPivot());v->setPivot(aux);
+    B2++;
 }
 
 void ProofGraph::applyRuleB2Prime( RuleContext& ra )
 {
-	//Transformation B2'
-	//v1 is combined with v3
-	//v2 does not contribute anymore
-	//w might be removed
-	//the new result v' (t0 C1 C3) subsumes v (t0 C1 C2 C3)
-	//Must propagate changes
+    //Transformation B2'
+    //v1 is combined with v3
+    //v2 does not contribute anymore
+    //w might be removed
+    //the new result v' (t0 C1 C3) subsumes v (t0 C1 C2 C3)
+    //Must propagate changes
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
     (void)v2;
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	//v new antecedents are v1 and v3
-	if(v->getAnt1()==w) v->setAnt1(v1);
-	else v->setAnt2(v1);
-	// w loses v as resolvent, v1 gains v as resolvent
-	v1->addRes(ra.getV());
-	w->remRes(ra.getV());
+    //v new antecedents are v1 and v3
+    if(v->getAnt1()==w) v->setAnt1(v1);
+    else v->setAnt2(v1);
+    // w loses v as resolvent, v1 gains v as resolvent
+    v1->addRes(ra.getV());
+    w->remRes(ra.getV());
 
-	//Change v clause to resolvent of v1 and v3 over t1 : t0 C1 C3
-	mergeClauses(v1->getClause(),v3->getClause(),v->getClause(),v->getPivot());
-	//Remove w, if no more resolvents (and in case also v2, w was its only resolvent)
-	if(w->getNumResolvents()==0) removeTree(w->getId());
-	B2prime++;
+    //Change v clause to resolvent of v1 and v3 over t1 : t0 C1 C3
+    mergeClauses(v1->getClause(),v3->getClause(),v->getClause(),v->getPivot());
+    //Remove w, if no more resolvents (and in case also v2, w was its only resolvent)
+    if(w->getNumResolvents()==0) removeTree(w->getId());
+    B2prime++;
 }
 
 void ProofGraph::applyRuleB3( RuleContext& ra )
 {
-	//Transformation B3
-	//Supercut!!!
-	//v1, v3 don't contribute anymore
-	//w might be removed
-	//v is replaced by v2 and removed
-	//the new result v2 (~t0 C2) subsumes v (~t0 C1 C2 C3)
-	//Must propagate changes
+    //Transformation B3
+    //Supercut!!!
+    //v1, v3 don't contribute anymore
+    //w might be removed
+    //v is replaced by v2 and removed
+    //the new result v2 (~t0 C2) subsumes v (~t0 C1 C2 C3)
+    //Must propagate changes
 
-	ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
-			*w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
+    ProofNode *v1=getNode(ra.getV1()),*v2=getNode(ra.getV2()),
+            *w=getNode(ra.getW()),*v3=getNode(ra.getV3()),*v=getNode(ra.getV());
 
-	assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
-	assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
+    assert((v->getAnt1()==w && v->getAnt2()== v3) || (v->getAnt1()==v3 && v->getAnt2()== w));
+    assert((w->getAnt1()==v1 && w->getAnt2()== v2) || (w->getAnt1()==v2 && w->getAnt2()==v1));
 
-	if( proofCheck() > 1 )
-	{
-		for(unsigned u = 0; u < getGraphSize(); u++)
-			if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
-			{
-				cerr << u << " detached" << endl;
-				opensmt_error_();
-			}
-	}
+    if( proofCheck() > 1 )
+    {
+        for(unsigned u = 0; u < getGraphSize(); u++)
+            if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
+            {
+                cerr << u << " detached" << endl;
+                opensmt_error_();
+            }
+    }
 
-	w->remRes( ra.getV() );
-	v3->remRes( ra.getV() );
-	// v2 inherits v children
-	set<clauseid_t>& resolvents = v->getResolvents();
-	for(set<clauseid_t>::iterator it = resolvents.begin(); it!=resolvents.end(); it++)
-	{
-		assert((*it)<getGraphSize());
-		ProofNode* res = getNode((*it));
-		assert(res!=NULL);
-		if(res->getAnt1() == v) res->setAnt1( v2 );
-		else if (res->getAnt2() == v) res->setAnt2( v2 );
-		else opensmt_error_();
-		v2->addRes((*it));
-	}
-	assert(v->getNumResolvents()>0);
+    w->remRes( ra.getV() );
+    v3->remRes( ra.getV() );
+    // v2 inherits v children
+    set<clauseid_t>& resolvents = v->getResolvents();
+    for(set<clauseid_t>::iterator it = resolvents.begin(); it!=resolvents.end(); it++)
+    {
+        assert((*it)<getGraphSize());
+        ProofNode* res = getNode((*it));
+        assert(res!=NULL);
+        if(res->getAnt1() == v) res->setAnt1( v2 );
+        else if (res->getAnt2() == v) res->setAnt2( v2 );
+        else opensmt_error_();
+        v2->addRes((*it));
+    }
+    assert(v->getNumResolvents()>0);
 
-	// w might become useless
-	if(w->getNumResolvents()==0)
-	{
-		v1->remRes( ra.getW() );
-		v2->remRes( ra.getW() );
-		removeNode( ra.getW() );
-		// v1 can become useless
-		assert(v2->getNumResolvents()>0);
-		if(v1->getNumResolvents()==0) removeTree(v1->getId());
-	}
-	// v3 can become useless
-	if(v3->getNumResolvents()==0) removeTree(v3->getId());
-	//Remove v
-	removeNode(v->getId());
+    // w might become useless
+    if(w->getNumResolvents()==0)
+    {
+        v1->remRes( ra.getW() );
+        v2->remRes( ra.getW() );
+        removeNode( ra.getW() );
+        // v1 can become useless
+        assert(v2->getNumResolvents()>0);
+        if(v1->getNumResolvents()==0) removeTree(v1->getId());
+    }
+    // v3 can become useless
+    if(v3->getNumResolvents()==0) removeTree(v3->getId());
+    //Remove v
+    removeNode(v->getId());
 
-	/*
-	// NOTE rule application in line with other rules, where v stays there
-	// alternative: copy content of v2 into v and keep both nodes
-	// NOTE We cannot create another leaf!!
-	if(v2->getType() == CLAORIG) return;
+    /*
+    // NOTE rule application in line with other rules, where v stays there
+    // alternative: copy content of v2 into v and keep both nodes
+    // NOTE We cannot create another leaf!!
+    if(v2->getType() == CLAORIG) return;
 
-	v->setAnt1(v2->getAnt1());
-	v->setAnt2(v2->getAnt2());
-	v->getAnt1()->addRes(v->getId());
-	v->getAnt2()->addRes(v->getId());
+    v->setAnt1(v2->getAnt1());
+    v->setAnt2(v2->getAnt2());
+    v->getAnt1()->addRes(v->getId());
+    v->getAnt2()->addRes(v->getId());
 
-	v->setPivot(v2->getPivot());
-	v->setType(v2->getType());
-	v->setClause(v2->getClause());
-	assert(v->getNumResolvents()>0); // TODO what if v was the root?
+    v->setPivot(v2->getPivot());
+    v->setType(v2->getType());
+    v->setClause(v2->getClause());
+    assert(v->getNumResolvents()>0); // TODO what if v was the root?
 
-	checkClause(v->getId());
+    checkClause(v->getId());
 
-	for(unsigned u = 0; u < getGraphSize(); u++)
-		if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
-		{
-			cerr << u << " detached" << endl;
-			opensmt_error_();
-		}
+    for(unsigned u = 0; u < getGraphSize(); u++)
+        if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
+        {
+            cerr << u << " detached" << endl;
+            opensmt_error_();
+        }
 
-	// w might become useless
-	w->remRes( ra.getV() );
-	v3->remRes( ra.getV() );
-	if(w->getNumResolvents()==0) removeTree(w->getId());
-	// v3 can become useless
-	if(v3->getNumResolvents()==0) removeTree(v3->getId());*/
+    // w might become useless
+    w->remRes( ra.getV() );
+    v3->remRes( ra.getV() );
+    if(w->getNumResolvents()==0) removeTree(w->getId());
+    // v3 can become useless
+    if(v3->getNumResolvents()==0) removeTree(v3->getId());*/
 
-	if( proofCheck() > 1 )
-	{
-		for(unsigned u = 0; u < getGraphSize(); u++)
-			if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
-			{
-				cerr << u << " detached" << endl;
-				opensmt_error_();
-			}
-	}
+    if( proofCheck() > 1 )
+    {
+        for(unsigned u = 0; u < getGraphSize(); u++)
+            if(getNode(u) != NULL && !isRoot(getNode(u)) && getNode(u)->getNumResolvents() == 0)
+            {
+                cerr << u << " detached" << endl;
+                opensmt_error_();
+            }
+    }
 
-	B3++;
+    B3++;
 }
 
 #endif

--- a/src/proof/PGTransformationAlgorithms.C
+++ b/src/proof/PGTransformationAlgorithms.C
@@ -927,11 +927,11 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
 		}
 
 		cerr << "# RE\t";
-		if(num_nodes >= new_n_nodes)
+		if(num_nodes >= static_cast<int>(new_n_nodes))
 			cerr << "Nodes: " << new_n_nodes << "(-" << 100*((double)(num_nodes - new_n_nodes)/num_nodes) << "%)\t";
 		else
 			cerr << "Nodes: " << new_n_nodes << "(+" << 100*((double)(new_n_nodes - num_nodes)/num_nodes) << "%)\t";
-		if(num_edges >= new_n_edges)
+		if(num_edges >= static_cast<int>(new_n_edges))
 			cerr << "Edges: " << new_n_edges << "(-" << 100*((double)(num_edges - new_n_edges)/num_edges) << "%)\t";
 		else
 			cerr << "Edges: " << new_n_edges << "(+" << 100*((double)(new_n_edges - num_edges)/num_edges) << "%)\t";

--- a/src/proof/PGTransformationAlgorithms.C
+++ b/src/proof/PGTransformationAlgorithms.C
@@ -193,7 +193,7 @@ double ProofGraph::recyclePivotsIter()
 		reportf( "# Memory used after recycling, before restructuring: %.3f MB\n",  mem_used == 0 ? 0 : mem_used / 1048576.0 );
 	}
 
-	bool warning = false;
+//	bool warning = false;
 	// Restructuring, from leaves to root
 	std::deque<clauseid_t>q;
 	q.assign(leaves_ids.begin(),leaves_ids.end());
@@ -250,7 +250,7 @@ double ProofGraph::recyclePivotsIter()
 						// NOTE not clear how this might happen
 						if ( n->getAnt1() == n->getAnt2() )
 						{
-							warning=true;
+//							warning=true; // MB suspicious situation!
 							ProofNode* replacing = n->getAnt1();
 							set<clauseid_t>& resolvents = n->getResolvents();
 							for(set<clauseid_t>::iterator it = resolvents.begin(); it!=resolvents.end(); it++)

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -36,7 +36,7 @@ struct PTRef {
     inline friend bool operator< (const PTRef& a1, const PTRef& a2)    { return a1.x > a2.x;  }
 };
 
-static struct PTRef PTRef_Undef = {INT32_MAX};
+const struct PTRef PTRef_Undef = {INT32_MAX};
 
 struct PTRefHash {
     uint32_t operator () (const PTRef& s) const {

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -146,7 +146,7 @@ class Pterm {
 #endif
 private:
     // MB: Constructor is private to forbid any use outside PtermAllocator, which is a friend
-    Pterm(const SymRef sym_, const vec<PTRef>& ps, PTRef t) : sym(sym_) {
+    Pterm(const SymRef sym_, const vec<PTRef> & ps) : sym(sym_) {
         header.type      = 0;
         header.has_extra = 0;
         header.reloced   = 0;
@@ -155,11 +155,7 @@ private:
 
         var              = var_Undef;
 
-        for (int i = 0; i < ps.size(); i++) args[i] = ps[i];
-//        setExpReason(PtAsgn(PTRef_Undef, l_Undef));
-//        setExpParent(PTRef_Undef);
-//        setExpRoot(t);
-//        setExpTimeStamp(0);
+        for (int i = 0; i < ps.size(); i++) { args[i] = ps[i]; }
     }
 };
 
@@ -206,13 +202,13 @@ class PtermAllocator : public RegionAllocator<uint32_t>
         to.n_terms = n_terms;
         RegionAllocator<uint32_t>::moveTo(to); }*/
 
-    PTRef alloc(const SymRef sym, const vec<PTRef>& ps, bool extra = false)
+    PTRef alloc(const SymRef sym, const vec<PTRef> & ps)
     {
         assert(sizeof(PTRef) == sizeof(uint32_t));
 
         uint32_t v = RegionAllocator<uint32_t>::alloc(ptermWord32Size(ps.size()));
         PTRef tid = {v};
-        new (lea(tid)) Pterm(sym, ps, tid);
+        new(lea(tid)) Pterm(sym, ps);
         operator[](tid).setId(n_terms++);
 
         return tid;

--- a/src/simplifiers/BoolRewriting.cpp
+++ b/src/simplifiers/BoolRewriting.cpp
@@ -66,7 +66,7 @@ PTRef rewriteMaxArityClassic(Logic & logic, PTRef root) {
     Map<PTRef,int,PTRefHash> PTRefToIncoming;
     computeIncomingEdges(logic, root, PTRefToIncoming);
     return rewriteMaxArity(logic, root,
-            [&logic, &PTRefToIncoming](PTRef candidate)
+            [&PTRefToIncoming](PTRef candidate)
             {
                 assert(PTRefToIncoming.has(candidate) && PTRefToIncoming[candidate] >= 1);
                 return PTRefToIncoming[candidate] > 1;

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -472,7 +472,7 @@ void CoreSMTSolver::removeClause(CRef cr)
 
 bool CoreSMTSolver::satisfied(const Clause& c) const
 {
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
         if (value(c[i]) == l_True)
             return true;
     return false;
@@ -506,7 +506,7 @@ void CoreSMTSolver::cancelUntil(int level)
 }
 
 void CoreSMTSolver::printClause(Clause & cl) {
-    for (int i = 0; i < cl.size(); ++i) {
+    for (unsigned i = 0; i < cl.size(); ++i) {
         std::cout << cl[i].x << ' ';
     }
     std::cout << '\n';
@@ -916,7 +916,7 @@ void CoreSMTSolver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
         if (c.learnt())
             claBumpActivity(c);
 
-        for (int j = (p == lit_Undef) ? 0 : 1; j < c.size(); j++)
+        for (unsigned j = (p == lit_Undef) ? 0 : 1; j < c.size(); j++)
         {
             Lit q = c[j];
 
@@ -1093,7 +1093,7 @@ void CoreSMTSolver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
             else
             {
                 Clause& c = ca[reason(var(out_learnt[i]))];
-                for (int k = 1; k < c.size(); k++)
+                for (unsigned k = 1; k < c.size(); k++)
                     if (!seen[var(c[k])] && level(var(c[k])) > 0)
                     {
                         out_learnt[j++] = out_learnt[i];
@@ -1149,7 +1149,7 @@ void CoreSMTSolver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
         proof.resolve(c, v);
         // Look for level 0 unit clauses
         Clause& cla = ca[ c ];
-        for (int k = 1; k < cla.size(); k++)
+        for (unsigned k = 1; k < cla.size(); k++)
         {
             Var vv = var(cla[k]);
             if (level( vv ) == 0) proof.resolve( units[ vv ], vv );
@@ -1281,7 +1281,7 @@ bool CoreSMTSolver::litRedundant(Lit p, uint32_t abstract_levels)
 
         analyze_stack.pop();
 
-        for (int i = 1; i < c.size(); i++)
+        for (unsigned i = 1; i < c.size(); i++)
         {
             Lit p  = c[i];
 
@@ -1359,7 +1359,7 @@ void CoreSMTSolver::analyzeFinal(Lit p, vec<Lit>& out_conflict)
                 else
                 {
                     Clause& c = ca[reason(x)];
-                    for (int j = 1; j < c.size(); j++)
+                    for (unsigned j = 1; j < c.size(); j++)
                         if (level(var(c[j])) > 0)
                             seen[var(c[j])] = 1;
                 }
@@ -1449,7 +1449,7 @@ CRef CoreSMTSolver::propagate()
             }
 
             // Look for new watch:
-            for (int k = 2; k < c.size(); k++)
+            for (unsigned k = 2; k < c.size(); k++)
                 if (value(c[k]) != l_False)
                 {
                     c[1] = c[k];
@@ -1463,7 +1463,7 @@ CRef CoreSMTSolver::propagate()
             if (decisionLevel() == 0)
             {
                 proof.beginChain( cr );
-                for (int k = 1; k < c.size(); k++)
+                for (unsigned k = 1; k < c.size(); k++)
                 {
                     assert(level(var(c[k])) == 0);
                     proof.resolve( units[var(c[k])], var(c[k]) );
@@ -2199,7 +2199,7 @@ void CoreSMTSolver::declareVarsToTheories()
     top_level_lits = trail.size();
     for (int i = 0; i < clauses.size(); i++) {
         Clause & c = ca[clauses[i]];
-        for (int j = 0; j < c.size(); j++) {
+        for (unsigned j = 0; j < c.size(); j++) {
             Var v = var(c[j]);
             if (!var_seen[v]) {
                 var_seen[v] = true;

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -1702,7 +1702,7 @@ void CoreSMTSolver::popBacktrackPoint()
     //
     size_t new_stack_size = undo_stack_size.last();
     undo_stack_size.pop();
-    while ( undo_stack.size( ) > new_stack_size )
+    while (static_cast<size_t>(undo_stack.size()) > new_stack_size )
     {
         const undo_stack_el op = undo_stack.last();
 

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -128,13 +128,6 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     , split_next            (split_units == spm_time ? cpuTime() + split_inittune : decisions + split_inittune)
     , split_preference      (sppref_undef)
     , unadvised_splits      (0)
-
-
-#ifdef PRODUCE_PROOF
-    , proof_                ( new Proof( ca ) )
-    , proof                 ( * proof_ )
-    , proof_graph           ( NULL )
-#endif
 #ifdef PEDANTIC_DEBUG
     , max_dl_debug          (0)
     , analyze_cnt           (0)
@@ -147,8 +140,11 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     , luby_i                (0)
     , luby_k                (1)
     , cuvti                 (false)
-    , next_it_i             (0)
-    , next_it_j             (1)
+#ifdef PRODUCE_PROOF
+    , proof_                ( new Proof( ca ) )
+    , proof                 ( * proof_ )
+    , proof_graph           ( nullptr )
+#endif
 #ifdef STATISTICS
     , preproc_time          (0)
     , elim_tvars            (0)

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -135,11 +135,6 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     , proof                 ( * proof_ )
     , proof_graph           ( NULL )
 #endif
-
-#ifdef STATISTICS
-    , preproc_time          (0)
-    , elim_tvars            (0)
-#endif
 #ifdef PEDANTIC_DEBUG
     , max_dl_debug          (0)
     , analyze_cnt           (0)
@@ -154,6 +149,10 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     , cuvti                 (false)
     , next_it_i             (0)
     , next_it_j             (1)
+#ifdef STATISTICS
+    , preproc_time          (0)
+    , elim_tvars            (0)
+#endif
 { }
 
 void

--- a/src/smtsolvers/CoreSMTSolver.C
+++ b/src/smtsolvers/CoreSMTSolver.C
@@ -1861,8 +1861,6 @@ lbool CoreSMTSolver::search(int nof_conflicts, int nof_learnts)
 
     starts++;
 
-    bool first = true;
-
 #ifdef STATISTICS
     const double start = cpuTime( );
 #endif
@@ -1906,7 +1904,6 @@ lbool CoreSMTSolver::search(int nof_conflicts, int nof_learnts)
                 }
                 else return l_False;
             }
-            first = false;
             learnt_clause.clear();
             analyze(confl, learnt_clause, backtrack_level);
 

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -788,9 +788,7 @@ protected:
     //
     set< PTRef >     interface_equalities;       // To check that we do not duplicate eij
     set< PTRef >     atoms_seen;                 // Some interface equalities may already exists in the formula
-
-    int                next_it_i;                  // Next index i
-    int                next_it_j;                  // Next index j
+    
     //
     // Data structures required for incrementality, backtrackability
     //

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -113,7 +113,7 @@ public:
     {
         learnts.push();
         vec<Lit>& learnt = learnts.last();
-        for (int i = 0; i < c.size(); i++)
+        for (unsigned i = 0; i < c.size(); i++)
             learnt.push(c[i]);
     }
 
@@ -672,7 +672,7 @@ public:
     void     printClause      ( Clause& );
     //void     printClause      ( vec< Lit > & );
 
-	void   populateClauses  (vec<PTRef> & clauses, const vec<CRef> & crefs, int limit = std::numeric_limits<int>::max());
+	void   populateClauses  (vec<PTRef> & clauses, const vec<CRef> & crefs, unsigned int limit = std::numeric_limits<unsigned int>::max());
 	void   populateClauses  (vec<PTRef> & clauses, const vec<Lit> & lits);
 	char * printCnfClauses  ();
 	char * printCnfLearnts  ();
@@ -1120,7 +1120,7 @@ inline void CoreSMTSolver::printLit(Lit l)
 template<class C>
 inline void CoreSMTSolver::printClause(const C& c)
 {
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
     {
         printLit(c[i]);
         fprintf(stderr, " ");
@@ -1128,7 +1128,7 @@ inline void CoreSMTSolver::printClause(const C& c)
 
     Logic& logic = theory_handler.getLogic();
     vec<PTRef> args;
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
     {
         PTRef tr = sign(c[i]) ? logic.mkNot(theory_handler.varToTerm(var(c[i]))) : theory_handler.varToTerm(var(c[i]));
         args.push(tr);
@@ -1139,7 +1139,7 @@ inline void CoreSMTSolver::printClause(const C& c)
     free(clause);
 }
 
-inline void CoreSMTSolver::populateClauses(vec<PTRef> & clauses, const vec<CRef> & crefs, int limit)
+inline void CoreSMTSolver::populateClauses(vec<PTRef> & clauses, const vec<CRef> & crefs, unsigned int limit)
 {
 	Logic& logic = theory_handler.getLogic();
 	for (int i = 0; i < crefs.size(); i++) {
@@ -1148,7 +1148,7 @@ inline void CoreSMTSolver::populateClauses(vec<PTRef> & clauses, const vec<CRef>
 			continue;
 		}
 		vec<PTRef> literals;
-		for (int j = 0; j < clause.size(); j++) {
+		for (unsigned j = 0; j < clause.size(); j++) {
 			Lit& literal = clause[j];
 			Var v = var(literal);
 			PTRef ptr = theory_handler.varToTerm(v);
@@ -1200,7 +1200,7 @@ inline void CoreSMTSolver::printSMTClause( ostream & os, const C& c )
 {
     if ( c.size( ) == 0 ) os << "-";
     if ( c.size( ) > 1 ) os << "(or ";
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
     {
         Var v = var(c[i]);
         if ( v <= 1 ) continue;

--- a/src/smtsolvers/Debug.C
+++ b/src/smtsolvers/Debug.C
@@ -82,7 +82,7 @@ void CoreSMTSolver::verifyModel()
         next:;
     }
 
-    assert(!failed);
+    assert(!failed); (void)failed;
 
     // Removed line
     // reportf("Verified %d original clauses.\n", clauses.size());

--- a/src/smtsolvers/Debug.C
+++ b/src/smtsolvers/Debug.C
@@ -71,7 +71,7 @@ void CoreSMTSolver::verifyModel()
     {
         assert(ca[clauses[i]].mark() == 0);
         Clause& c = ca[clauses[i]];
-        for (int j = 0; j < c.size(); j++)
+        for (unsigned j = 0; j < c.size(); j++)
             if (modelValue(c[j]) == l_True)
                 goto next;
 

--- a/src/smtsolvers/GhostSMTSolver.cpp
+++ b/src/smtsolvers/GhostSMTSolver.cpp
@@ -50,7 +50,7 @@ GhostSMTSolver::attachClause(CRef in_clause)
     if (c.learnt())
         return;
 
-    for (int i = 0; i < c.size(); i++) {
+    for (unsigned i = 0; i < c.size(); i++) {
         Lit l = c[i];
         if (theory_handler.isTheoryTerm(var(l))) {
             int idx = toInt(l);
@@ -218,11 +218,11 @@ void GhostSMTSolver::verifyModel()
     {
         assert(ca[clauses[i]].mark() == 0);
         Clause& c = ca[clauses[i]];
-        for (int j = 0; j < c.size(); j++)
+        for (unsigned j = 0; j < c.size(); j++)
             if (modelValue(c[j]) == l_True)
                 goto next;
 
-        for (int j = 0; j < c.size(); j++)
+        for (unsigned j = 0; j < c.size(); j++)
             if (modelValue(c[j]) == l_Undef && isGhost(c[j]))
                 goto next;
 

--- a/src/smtsolvers/GhostSMTSolver.cpp
+++ b/src/smtsolvers/GhostSMTSolver.cpp
@@ -233,7 +233,7 @@ void GhostSMTSolver::verifyModel()
         next:;
     }
 
-    assert(!failed);
+    assert(!failed); (void)failed;
 
     // Removed line
     // reportf("Verified %d original clauses.\n", clauses.size());

--- a/src/smtsolvers/LAScore.cpp
+++ b/src/smtsolvers/LAScore.cpp
@@ -143,7 +143,7 @@ double LookaheadScoreDeep::computeScoreFromClauses(const vec<CRef> &clauses, con
         bool is_taut = false;
 
         const Clause& c = ca[clauses[i]];
-        for (int j = 0; j < c.size(); j++) {
+        for (unsigned j = 0; j < c.size(); j++) {
             if (value(c[j]) == l_False) {
                 ++nf;
             }

--- a/src/smtsolvers/LAScore.cpp
+++ b/src/smtsolvers/LAScore.cpp
@@ -8,7 +8,7 @@
 
 
 bool LookaheadScoreClassic::isAlreadyChecked(Var v) const {
-    return (LAexacts[v].getRound() == latest_round);
+    return (static_cast<unsigned int>(LAexacts[v].getRound()) == latest_round);
 }
 
 Lit LookaheadScoreClassic::getBest() {
@@ -122,7 +122,7 @@ void LookaheadScoreDeep::updateSolverScore(double &ss, const LookaheadSMTSolver 
 }
 
 double LookaheadScoreDeep::getSolverScore(const LookaheadSMTSolver *solver) {
-    if (base_score_round >= 0 && base_score_round == latest_round) {
+    if (base_score_round >= 0 && static_cast<unsigned int>(base_score_round) == latest_round) {
         return cached_score;
     }
 
@@ -163,8 +163,8 @@ double LookaheadScoreDeep::computeScoreFromClauses(const vec<CRef> &clauses, con
     return score;
 }
 
-bool LookaheadScoreDeep::safeToSkip(Var v, Lit p) const {
-    return LAexacts[v].getRound() == latest_round;
+bool LookaheadScoreDeep::safeToSkip(Var v, Lit) const {
+    return static_cast<unsigned int>(LAexacts[v].getRound()) == latest_round;
 }
 
 void LookaheadScoreDeep::setChecked(Var v) {
@@ -180,7 +180,7 @@ void LookaheadScoreDeep::updateLABest(Var v) {
 }
 
 bool LookaheadScoreDeep::isAlreadyChecked(Var v) const {
-    return (LAexacts[v].getRound() == latest_round);
+    return (static_cast<unsigned int>(LAexacts[v].getRound()) == latest_round);
 }
 
 Lit LookaheadScoreDeep::getBest() {

--- a/src/smtsolvers/LAScore.h
+++ b/src/smtsolvers/LAScore.h
@@ -165,7 +165,7 @@ private:
     vec<DoubleVal> LAexacts;
     double cached_score;
     double computeScoreFromClauses(const vec<CRef>& clauses, const LookaheadSMTSolver *solver);
-    bool current(const DoubleVal &e) const { return latest_round == e.getRound(); }
+    bool current(const DoubleVal &e) const { return latest_round == static_cast<unsigned int>(e.getRound()); }
 public:
     explicit LookaheadScoreDeep(const vec<lbool> &assigns, const SMTConfig &c)
             : LookaheadScore(assigns), base_score_round(-1)

--- a/src/smtsolvers/LookaheadSMTSolver.cpp
+++ b/src/smtsolvers/LookaheadSMTSolver.cpp
@@ -371,7 +371,7 @@ LookaheadSMTSolver::laresult LookaheadSMTSolver::lookaheadLoop(Lit& best)
                 for (int j = 0; j < clauses.size(); j++)
                 {
                     Clause& c = ca[clauses[j]];
-                    int k;
+                    unsigned k;
                     for (k = 0; k < c.size(); k++)
                     {
                         if (value(c[k]) == l_True)

--- a/src/smtsolvers/LookaheadSMTSolver.cpp
+++ b/src/smtsolvers/LookaheadSMTSolver.cpp
@@ -48,7 +48,7 @@ lbool LookaheadSMTSolver::solve_()
     if (res == LALoopRes::sat)
     {
         model.growTo(nVars());
-        for (int i = 0; i < dec_vars; i++) {
+        for (unsigned int i = 0; i < dec_vars; i++) {
             Var p = var(trail[i]);
             model[p] = value(p);
         }
@@ -369,7 +369,7 @@ LookaheadSMTSolver::laresult LookaheadSMTSolver::lookaheadLoop(Lit& best)
             // It is possible that all variables are assigned here.
             // In this case it seems that we have a satisfying assignment.
             // This is in fact a debug check
-            if (trail.size() == dec_vars)
+            if (static_cast<unsigned int>(trail.size()) == dec_vars)
             {
 #ifdef LADEBUG
                 printf("All vars set?\n");
@@ -464,7 +464,7 @@ LookaheadSMTSolver::laresult LookaheadSMTSolver::lookaheadLoop(Lit& best)
         }
     }
     best = score->getBest();
-    if (trail.size() == dec_vars && best == lit_Undef)
+    if (static_cast<unsigned int>(trail.size()) == dec_vars && best == lit_Undef)
     {
 #ifdef LADEBUG
         printf("All variables are already set, so we have nothing to branch on and this is a SAT answer\n");

--- a/src/smtsolvers/LookaheadSMTSolver.cpp
+++ b/src/smtsolvers/LookaheadSMTSolver.cpp
@@ -19,16 +19,6 @@ Var LookaheadSMTSolver::newVar(bool sign, bool dvar)
 
 lbool LookaheadSMTSolver::solve_()
 {
-    int d;
-    if (config.sat_split_type() == spt_lookahead) {
-        if (config.sat_split_fixvars() > 0)
-            d = config.sat_split_fixvars();
-		d = getLog2Ceil(config.sat_split_num());
-    }
-    else {
-        d = -1;
-    }
-
     declareVarsToTheories();
 
     double nof_conflicts = restart_first;

--- a/src/smtsolvers/Proof.C
+++ b/src/smtsolvers/Proof.C
@@ -34,6 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #endif
 
+#ifndef NDEBUG
 namespace {
 void print(Clause& cl, ostream& out) {
     for (int i = 0; i < cl.size(); ++i) {
@@ -42,6 +43,7 @@ void print(Clause& cl, ostream& out) {
     out << '\n';
 }
 }
+#endif // NDEBUG
 
 void CoreSMTSolver::dumpRndInter(std::ofstream& dump_out)
 {

--- a/src/smtsolvers/Proof.C
+++ b/src/smtsolvers/Proof.C
@@ -34,17 +34,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #endif
 
-#ifndef NDEBUG
-namespace {
-void print(Clause& cl, ostream& out) {
-    for (int i = 0; i < cl.size(); ++i) {
-        out << cl[i].x << ' ';
-    }
-    out << '\n';
-}
-}
-#endif // NDEBUG
-
 void CoreSMTSolver::dumpRndInter(std::ofstream& dump_out)
 {
 

--- a/src/smtsolvers/Proof.C
+++ b/src/smtsolvers/Proof.C
@@ -427,7 +427,7 @@ void CoreSMTSolver::printInter( ostream & out )
         opensmt_error( "Please choose a value between 0 and 3" );
 
 
-    for( size_t i = 0 ; i < sequence_of_interpolants.size( ) ; i ++ )
+    for( int i = 0 ; i < sequence_of_interpolants.size( ) ; i ++ )
     {
         // Before printing, we have to undo definitions
         // for instance those introduced when converting

--- a/src/smtsolvers/SimpSMTSolver.C
+++ b/src/smtsolvers/SimpSMTSolver.C
@@ -236,7 +236,7 @@ bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause, std::pair<
         // consequence of how backward subsumption is used to mimic
         // forward subsumption.
         subsumption_queue.insert(cr);
-        for (int i = 0; i < c.size(); i++)
+        for (unsigned i = 0; i < c.size(); i++)
         {
             occurs[var(c[i])].push(cr);
             n_occ[toInt(c[i])]++;
@@ -257,7 +257,7 @@ void SimpSMTSolver::removeClause(CRef cr)
     const Clause& c = ca[cr];
 
     if (use_simplification)
-        for (int i = 0; i < c.size(); i++)
+        for (unsigned i = 0; i < c.size(); i++)
         {
             n_occ[toInt(c[i])]--;
             updateElimHeap(var(c[i]));
@@ -307,11 +307,11 @@ bool SimpSMTSolver::merge(const Clause& _ps, const Clause& _qs, Var v, vec<Lit>&
     const Clause& ps =  ps_smallest ? _qs : _ps;
     const Clause& qs =  ps_smallest ? _ps : _qs;
 
-    for (int i = 0; i < qs.size(); i++)
+    for (unsigned i = 0; i < qs.size(); i++)
     {
         if (var(qs[i]) != v)
         {
-            for (int j = 0; j < ps.size(); j++)
+            for (unsigned j = 0; j < ps.size(); j++)
             {
                 if (var(ps[j]) == var(qs[i]))
                 {
@@ -327,7 +327,7 @@ next:
         ;
     }
 
-    for (int i = 0; i < ps.size(); i++)
+    for (unsigned i = 0; i < ps.size(); i++)
         if (var(ps[i]) != v)
             out_clause.push(ps[i]);
 
@@ -348,11 +348,11 @@ bool SimpSMTSolver::merge(const Clause& _ps, const Clause& _qs, Var v, int& size
 
     size = ps.size()-1;
 
-    for (int i = 0; i < qs.size(); i++)
+    for (unsigned i = 0; i < qs.size(); i++)
     {
         if (var(__qs[i]) != v)
         {
-            for (int j = 0; j < ps.size(); j++)
+            for (unsigned j = 0; j < ps.size(); j++)
             {
                 if (var(__ps[j]) == var(__qs[i]))
                 {
@@ -465,7 +465,7 @@ bool SimpSMTSolver::backwardSubsumptionCheck(bool verbose)
 
         // Find best variable to scan:
         Var best = var(c[0]);
-        for (int i = 1; i < c.size(); i++)
+        for (unsigned i = 1; i < c.size(); i++)
             if (occurs[var(c[i])].size() < occurs[best].size())
                 best = var(c[i]);
 
@@ -476,8 +476,7 @@ bool SimpSMTSolver::backwardSubsumptionCheck(bool verbose)
         for (int j = 0; j < _cs.size(); j++)
             if (c.mark())
                 break;
-            else if (!ca[cs[j]].mark() && cs[j] != cr && (subsumption_lim == -1 || ca[cs[j]].size() < subsumption_lim))
-            {
+            else if (!ca[cs[j]].mark() && cs[j] != cr && (subsumption_lim == -1 || ca[cs[j]].size() < static_cast<unsigned>(subsumption_lim)))            {
                 Lit l = c.subsumes(ca[cs[j]]);
 
                 if (l == lit_Undef)
@@ -509,7 +508,7 @@ bool SimpSMTSolver::asymm(Var v, CRef cr)
 
     trail_lim.push(trail.size());
     Lit l = lit_Undef;
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
         if (var(c[i]) != v && value(c[i]) != l_False)
         {
             uncheckedEnqueue(~c[i]);
@@ -561,7 +560,7 @@ static void mkElimClause(vec<uint32_t>& elimclauses, Var v, Clause& c)
 
     // Copy clause to elimclauses-vector. Remember position where the
     // variable 'v' occurs:
-    for (int i = 0; i < c.size(); i++)
+    for (unsigned i = 0; i < c.size(); i++)
     {
         elimclauses.push(toInt(c[i]));
         if (var(c[i]) == v)
@@ -663,7 +662,7 @@ bool SimpSMTSolver::substitute(Var v, Lit x)
         Clause& c = ca[cls[i]];
 
         subst_clause.clear();
-        for (int j = 0; j < c.size(); j++)
+        for (unsigned j = 0; j < c.size(); j++)
         {
             Lit p = c[j];
             subst_clause.push(var(p) == v ? x ^ sign(p) : p);

--- a/src/smtsolvers/Theory.C
+++ b/src/smtsolvers/Theory.C
@@ -230,7 +230,7 @@ CoreSMTSolver::handleUnsat()
         // Empty clause derived
         // ADDED CODE BEGIN
         proof.beginChain( confl );
-        for ( int k = 0; k < c.size() ; k ++ )
+        for ( unsigned k = 0; k < c.size() ; k ++ )
         {
             //assert( level[ var(c[k]) ] == 0 );
             //assert( value( c[k] ) == l_False );
@@ -407,7 +407,7 @@ int CoreSMTSolver::analyzeUnsatLemma(CRef confl)
 
     // Get highest decision level
     int max_decision_level = level(var(c[0]));
-    for ( int i = 1 ; i < c.size( ) ; i++ )
+    for ( unsigned i = 1 ; i < c.size( ) ; i++ )
         if ( level(var(c[i])) > max_decision_level )
             max_decision_level = level(var(c[i]));
 
@@ -417,7 +417,7 @@ int CoreSMTSolver::analyzeUnsatLemma(CRef confl)
     {
 #ifdef PRODUCE_PROOF
         proof.beginChain( confl );
-        for ( int k = 0; k < c.size() ; k ++ )
+        for ( unsigned k = 0; k < c.size() ; k ++ )
         {
             assert(level(var(c[k])) == 0);
             assert(value( c[k] ) == l_False);

--- a/src/tsolvers/LIATHandler.C
+++ b/src/tsolvers/LIATHandler.C
@@ -3,7 +3,7 @@
 #include <liasolver/LIASolver.h>
 
 LIATHandler::LIATHandler(SMTConfig& c, LIALogic& l, vec<DedElem>& d, TermMapper& tmap)
-        : TSolverHandler(c, d, l, tmap)
+        : TSolverHandler(c, d, tmap)
         , logic(l)
 {
     liasolver = new LIASolver(config, logic, deductions);

--- a/src/tsolvers/LIATHandler.C
+++ b/src/tsolvers/LIATHandler.C
@@ -49,9 +49,8 @@ void LIATHandler::fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs)
             Pterm& p = logic.getPterm(tr);
             args.push(p[0]);
             args.push(p[1]);
-            char* msg;
-            PTRef i1 = logic.mkNumLeq(args, &msg);
-            PTRef i2 = logic.mkNumGeq(args, &msg);
+            PTRef i1 = logic.mkNumLeq(args);
+            PTRef i2 = logic.mkNumGeq(args);
             // These can simplify to true and false, and we don't
             // want them to LRA solver
             if (!refs.has(i1) && logic.isNumLeq(i1)) {
@@ -86,9 +85,8 @@ bool LIATHandler::assertLit_special(PtAsgn a)
         vec<PTRef> args;
         args.push(p[0]);
         args.push(p[1]);
-        char* msg;
-        PTRef i1 = logic.mkNumLeq(args, &msg);
-        PTRef i2 = logic.mkNumGeq(args, &msg);
+        PTRef i1 = logic.mkNumLeq(args);
+        PTRef i2 = logic.mkNumGeq(args);
         res &= assertLit(PtAsgn(i1, l_True));
         res &= assertLit(PtAsgn(i2, l_True));
     }

--- a/src/tsolvers/LRATHandler.C
+++ b/src/tsolvers/LRATHandler.C
@@ -53,9 +53,8 @@ void LRATHandler::fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs)
             Pterm& p = logic.getPterm(tr);
             args.push(p[0]);
             args.push(p[1]);
-            char* msg;
-            PTRef i1 = logic.mkNumLeq(args, &msg);
-            PTRef i2 = logic.mkNumGeq(args, &msg);
+            PTRef i1 = logic.mkNumLeq(args);
+            PTRef i2 = logic.mkNumGeq(args);
             // These can simplify to true and false, and we don't
             // want them to LRA solver
             if (!refs.has(i1) && logic.isNumLeq(i1)) {
@@ -89,9 +88,8 @@ bool LRATHandler::assertLit_special(PtAsgn a)
         vec<PTRef> args;
         args.push(p[0]);
         args.push(p[1]);
-        char* msg;
-        PTRef i1 = logic.mkNumLeq(args, &msg);
-        PTRef i2 = logic.mkNumGeq(args, &msg);
+        PTRef i1 = logic.mkNumLeq(args);
+        PTRef i2 = logic.mkNumGeq(args);
         bool res = assertLit(PtAsgn(i1, l_True));
         return res && assertLit(PtAsgn(i2, l_True));
     }

--- a/src/tsolvers/LRATHandler.C
+++ b/src/tsolvers/LRATHandler.C
@@ -3,7 +3,7 @@
 #include "lrasolver/LRASolver.h"
 
 LRATHandler::LRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap)
-        : TSolverHandler(c, d, l, tmap)
+        : TSolverHandler(c, d, tmap)
         , logic(l)
 {
     lrasolver = new LRASolver(config, logic, deductions);

--- a/src/tsolvers/THandler.C
+++ b/src/tsolvers/THandler.C
@@ -692,7 +692,7 @@ const char* THandler::printAsrtClause(vec<Lit>& r) {
 
 const char* THandler::printAsrtClause(Clause* c) {
     vec<Lit> v;
-    for (int i = 0; i < c->size(); i++)
+    for (unsigned i = 0; i < c->size(); i++)
         v.push((*c)[i]);
     return printAsrtClause(v);
 }

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -37,16 +37,11 @@ class THandler
 private:
     Theory             &theory;
     TermMapper         &tmap;                     // Mappings between TRefs and Lits
-#ifdef PEDANTIC_DEBUG
-public:
-#endif
-    SMTConfig          &config;                   // Reference to configuration, needed for PRODUCE_PROOF
 public:
 
     THandler ( SMTConfig& c, Theory& tsh)
     : theory             (tsh)
     , tmap               (tsh.getTmap())
-    , config             (c)
     , checked_trail_size (0)
     { }
 
@@ -61,12 +56,9 @@ public:
     const TSolverHandler& getSolverHandler() const;// { return theory.getTSolverHandler(); }
     TermMapper&           getTMap()      ;//          { return tmap; }
 
-#ifdef PEDANTIC_DEBUG
-    void    getConflict          ( vec<Lit>&, vec<VarData>&, int &, vec<Lit>& ); // Returns theory conflict in terms of literals
-#else
     void    getConflict          ( vec<Lit>&, vec<VarData>&, int & ); // Returns theory conflict in terms of literals
     void    getNewSplits         ( vec<Lit>& ); // Return the new splits as a vector of literals that needs to be interpreted as a clause.
-#endif
+
 #ifdef PRODUCE_PROOF
     PTRef getInterpolant         (const ipartitions_t&, map<PTRef, icolor_t>*);
 #endif

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -39,7 +39,7 @@ private:
     TermMapper         &tmap;                     // Mappings between TRefs and Lits
 public:
 
-    THandler ( SMTConfig& c, Theory& tsh)
+    THandler(Theory & tsh)
     : theory             (tsh)
     , tmap               (tsh.getTmap())
     , checked_trail_size (0)

--- a/src/tsolvers/TSolver.C
+++ b/src/tsolvers/TSolver.C
@@ -49,7 +49,7 @@ void TSolver::pushBacktrackPoint()
 bool TSolver::isKnown(PTRef tr)
 {
     uint32_t id = Idx(getLogic().getPterm(tr).getId());
-    if (known_preds.size() <= id)
+    if (static_cast<unsigned int>(known_preds.size()) <= id)
         return false;
     return known_preds[id];
 }

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -177,7 +177,7 @@ public:
     SolverId getId() { return id; }
     bool hasExplanation() { return has_explanation; }
     virtual void declareAtom(PTRef tr) = 0;
-    virtual void  informNewSplit(PTRef tr) { };
+    virtual void  informNewSplit(PTRef) { };
     virtual Logic& getLogic() = 0;
     virtual bool isValid(PTRef tr) = 0;
     bool         isKnown(PTRef tr);

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -53,7 +53,7 @@ protected:
 
     Map<PTRef,PtAsgn,PTRefHash> substs;
 
-    TSolverHandler(SMTConfig &c, vec<DedElem> &d, Logic& l, TermMapper& tmap)
+    TSolverHandler(SMTConfig & c, vec<DedElem> & d, TermMapper & tmap)
         : config(c)
         , tmap(tmap)
         , deductions(d)

--- a/src/tsolvers/UFLRATHandler.C
+++ b/src/tsolvers/UFLRATHandler.C
@@ -52,9 +52,8 @@ void UFLRATHandler::fillTmpDeds(PTRef root, Map<PTRef,int,PTRefHash> &refs)
             Pterm& p = logic.getPterm(tr);
             args.push(p[0]);
             args.push(p[1]);
-            char* msg;
-            PTRef i1 = logic.mkNumLeq(args, &msg);
-            PTRef i2 = logic.mkNumGeq(args, &msg);
+            PTRef i1 = logic.mkNumLeq(args);
+            PTRef i2 = logic.mkNumGeq(args);
             // These can simplify to true and false, and we don't
             // want them to LRA solver
             if (!refs.has(i1) && logic.isNumLeq(i1)) {

--- a/src/tsolvers/UFTHandler.C
+++ b/src/tsolvers/UFTHandler.C
@@ -7,7 +7,7 @@
 #endif // PRODUCE_PROOF
 
 UFTHandler::UFTHandler(SMTConfig& c, Logic& l, vec<DedElem>& d, TermMapper& tmap)
-    : TSolverHandler(c, d, l, tmap)
+    : TSolverHandler(c, d, tmap)
     , logic(l)
 {
 #ifdef PRODUCE_PROOF

--- a/src/tsolvers/bvsolver/BVSolver.C
+++ b/src/tsolvers/bvsolver/BVSolver.C
@@ -98,7 +98,7 @@ void BVSolver::popBacktrackPoint ( )
     //
     // Restore stack size
     //
-    while ( stack.size( ) > stack_new_size ) 
+    while (static_cast<unsigned>(stack.size()) > stack_new_size )
     {
         stack.pop();
     }

--- a/src/tsolvers/bvsolver/BitBlaster.C
+++ b/src/tsolvers/bvsolver/BitBlaster.C
@@ -298,7 +298,7 @@ BitBlaster::bbEq(PTRef tr)
 
     // Produce the result
     vec<PTRef> result_args;
-    for ( unsigned i = 0 ; i < bs[bb_lhs].size() ; i ++ )
+    for ( int i = 0 ; i < bs[bb_lhs].size() ; i ++ )
     {
         result_args.push(logic.mkEq(bs[bb_lhs][i], bs[bb_rhs][i]));
     }
@@ -380,7 +380,7 @@ BitBlaster::bbBvule(PTRef tr)
     // Produce the result
     //
     PTRef lt_prev = PTRef_Undef;
-    for (unsigned i = 0 ; i < bs[bb_lhs].size() ; i ++)
+    for (int i = 0 ; i < bs[bb_lhs].size() ; i ++)
     {
         // Produce ~l[i] & r[i]
         PTRef not_l   = logic.mkNot(bs[bb_lhs][i]);
@@ -1043,7 +1043,7 @@ BitBlaster::bbBvurem(PTRef tr)
         //
         PTRef carry = PTRef_Undef;
 
-        for( unsigned j = 0 ; j < minuend.size( ) ; j++ )
+        for (unsigned j = 0; j < static_cast<unsigned>(minuend.size()); j++)
         {
             PTRef bit_1 = minuend[ j ];
             PTRef bit_2 = subtrahend[ j ];
@@ -1073,7 +1073,7 @@ BitBlaster::bbBvurem(PTRef tr)
         //
         // Adds one, if bit_i is one
         //
-        for (unsigned j = 0 ; j < minuend.size( ) ; j++)
+        for (unsigned j = 0; j < static_cast<unsigned>(minuend.size()); j++)
         {
             PTRef bit_1 = minuend[ j ];
             PTRef bit_2 = j == 0 ? logic.getTerm_true() : logic.getTerm_false();
@@ -1285,7 +1285,7 @@ BitBlaster::bbBvmul(PTRef tr)
         for ( unsigned j = 0 ; j < size - i ; j ++ )
             addend.push(logic.mkAnd(bs[bb_arg2][i], bs[bb_arg1][j]));
 
-        assert( addend.size( ) == size );
+        assert(static_cast<unsigned>(addend.size()) == size);
         // Accumulate computed term
         PTRef carry = PTRef_Undef;
 
@@ -1341,11 +1341,11 @@ BitBlaster::bbSignExtend(PTRef tr)
     PTRef x = logic.getPterm(tr)[0];
     BVRef bb_x = bbTerm(x);
     // Copy x
-    unsigned i;
-    for ( i = 0 ; i < bs[bb_x].size( ) ; i ++ )
+    int i = 0;
+    for ( ; i < bs[bb_x].size( ) ; i ++ )
         result.push(bs[bb_x][i]);
     // Sign extend
-    for ( ; (int)i < bitwidth; i ++ ) // Should be bit width of what?
+    for ( ; i < bitwidth; i ++ ) // Should be bit width of what?
         result.push(bs[bb_x].lsb());
 
     return bs.newBvector(names, result, mkActVar(s_bbSignExtend), tr);
@@ -1400,8 +1400,8 @@ BitBlaster::bbConstant(PTRef tr)
     {
         const std::string value = logic.getSymName(tr);
 
-        assert(value.length() == bitwidth);
-        for (unsigned i = 0 ; i < bitwidth; i ++)
+        assert(value.length() == static_cast<unsigned>(bitwidth));
+        for (int i = 0 ; i < bitwidth; i ++)
         {
             asgns[i] = value[bitwidth-i-1] == '1' ? logic.getTerm_true() : logic.getTerm_false();
         }
@@ -2114,7 +2114,7 @@ PTRef BitBlaster::simplify( PTRef formula )
 void BitBlaster::computeModel( )
 {
     model.clear();
-    for ( unsigned i = 0 ; i < variables.size( ) ; i++ )
+    for (unsigned i = 0; i < static_cast<unsigned>(variables.size()); i++)
     {
         PTRef e = variables[ i ];
         Real value = 0;

--- a/src/tsolvers/bvsolver/BitBlaster.C
+++ b/src/tsolvers/bvsolver/BitBlaster.C
@@ -57,13 +57,8 @@ const char* BitBlaster::s_bbBvlsh       = ".bbBvlsh";
 const char* BitBlaster::s_bbBvlrsh      = "s_bbBvlrsh";
 const char* BitBlaster::s_bbBvarsh      = "s_bbBvarsh";
 
-BitBlaster::BitBlaster ( const SolverId i
-                       , SMTConfig & c
-                       , MainSolver& mainSolver
-                       , BVLogic& bvlogic
-                       , vec<PtAsgn> & ex
-                       , vec<DedElem> & d
-                       , vec<PTRef> & s )
+BitBlaster::BitBlaster(SolverId, SMTConfig & c, MainSolver & mainSolver, BVLogic & bvlogic, vec<PtAsgn> & ex,
+                       vec<DedElem> & d, vec<PTRef> & s)
     : last_refined(0)
     , config      (c)
     , mainSolver  (mainSolver)
@@ -160,7 +155,7 @@ BitBlaster::assertLit (PtAsgn pta)
     //
     vec< Lit > clause;
     clause.push( mkLit( act_var, (pta.sgn == l_True ? false : true) ) );
-    bool res = addClause( clause, pta.tr );
+    bool res = addClause(clause);
 
     return res;
 }
@@ -1467,7 +1462,7 @@ BitBlaster::bbDistinct(PTRef tr)
 }
 
 bool
-BitBlaster::addClause(vec< Lit > & c, PTRef tr)
+BitBlaster::addClause(vec<Lit> & c)
 {
     return solverP.addOriginalClause(c);
 }
@@ -2217,67 +2212,3 @@ BitBlaster::notifyEquality(PTRef tr)
         return l_Undef;
 }
 
-lbool
-BitBlaster::glueBtoUF(BVRef br, PTRef tr)
-{
-    /*
-    char* msg;
-
-    vec<PTRef> bv;
-    bs.copyTo(br, bv);
-    PTRef eq_tr = logic.mkGlueBtoUF(bv, tr);
-    sstat status = mainSolver.insertFormula(eq_tr, &msg);
-    if (status == s_True)
-        return l_True;
-    else if (status == s_False)
-        return l_False;
-    else
-        return l_Undef;
-    */
-    return l_Undef;
-}
-
-lbool
-BitBlaster::glueUFtoB(PTRef tr, BVRef br)
-{
-    /*
-    char* msg;
-    vec<PTRef> bv;
-    bs.copyTo(br, bv);
-    PTRef and_tr = logic.mkGlueUFtoB(tr, bv);
-    bs.bindPTRefToBVRef(tr,br);
-    sstat status = mainSolver.insertFormula(and_tr, &msg);
-    if (status == s_True)
-        return l_True;
-    else if (status == s_False)
-        return l_False;
-    else
-        return l_Undef;
-    */
-    return l_Undef;
-}
-
-lbool
-BitBlaster::glueUFtoUF(PTRef tr1, PTRef tr2)
-{
-    /*
-    BVRef br1 = bs.getBoundBVRef(tr1);
-    BVRef br2 = bs.getBoundBVRef(tr2);
-
-    vec<PTRef> and_args;
-    for (int i = 0; i < bs[br1].size(); i++)
-        and_args.push(logic.mkEq(bs[br1][i], bs[br2][i]));
-    PTRef iff_tr = logic.mkEq(logic.mkEq(tr1, tr2), logic.mkAnd(and_args));
-
-    char* msg;
-    sstat status = mainSolver.insertFormula(iff_tr, &msg);
-
-    if (status == s_True)
-        return l_True;
-    else if (status == s_False)
-        return l_False;
-    else
-        return l_Undef;
-*/
-    return l_Undef;
-}

--- a/src/tsolvers/bvsolver/BitBlaster.C
+++ b/src/tsolvers/bvsolver/BitBlaster.C
@@ -337,7 +337,9 @@ BitBlaster::bbBvslt(PTRef tr)
     assert( bs[bb_lhs].size( ) == bs[bb_rhs].size( ) );
 
     // <a>_S < <b>_S <=> (msb(a) <=> msb(b)) xor add(a, ~b, 1).cout
-    PTRef tr_out = logic.mkXor(logic.mkEq(bs[bb_lhs].msb(), bs[bb_rhs].msb()), bbBvadd_carryonly(logic.mkBVPlus(lhs, logic.mkBVCompl(rhs)), logic.getTerm_true()));
+    PTRef tr_out = logic.mkXor(logic.mkEq(bs[bb_lhs].msb(), bs[bb_rhs].msb()), bbBvadd_carryonly(logic.mkBVPlus(lhs,
+                                                                                                                logic.mkBVCompl(
+                                                                                                                        rhs)), logic.getTerm_true()));
 
     // Save result and return
     vec<PTRef> asgns;

--- a/src/tsolvers/bvsolver/BitBlaster.C
+++ b/src/tsolvers/bvsolver/BitBlaster.C
@@ -961,9 +961,10 @@ BitBlaster::bbBvudiv(PTRef tr)
             // O[2] O[1] O[0]
             //      N[2] N[1] N[0]
             //
-            for (int j = size - 1 ; j >= 1 ; j --)
+            for (int j = size - 1 ; j >= 1 ; j --) {
                 minuend[j] = minuend[j - 1];
-                minuend[0] = bs[dividend][i - 1];
+            }
+            minuend[0] = bs[dividend][i - 1];
         }
     }
     //

--- a/src/tsolvers/bvsolver/BitBlaster.h
+++ b/src/tsolvers/bvsolver/BitBlaster.h
@@ -38,13 +38,8 @@ class BitBlaster
 {
 public:
 
-    BitBlaster ( SolverId
-               , SMTConfig &
-               , MainSolver&
-               , BVLogic&
-               , vec<PtAsgn> &
-               , vec<DedElem> &
-               , vec<PTRef> & );
+    BitBlaster(SolverId, SMTConfig & c, MainSolver & mainSolver, BVLogic & bvlogic, vec<PtAsgn> & ex,
+               vec<DedElem> & d, vec<PTRef> & s);
     ~BitBlaster ( );
 
     lbool inform             (PTRef); // For the interface for bitvector solver
@@ -63,9 +58,6 @@ public:
     // Public Theory refinement stuff
     lbool notifyEqualities   (); // Check all refined equalities, add explicit new terms for them
     void  bindCUFToBV        (PTRef cuf_tr, PTRef bv_tr) { assert(!pToB.has(cuf_tr)); bbTerm(bv_tr); pToB.insert(cuf_tr, bv_tr); refined.push(cuf_tr); }
-    lbool glueBtoUF          (BVRef br, PTRef tr);  // (= tr (c br_1 ... br_32))
-    lbool glueUFtoB          (PTRef tr, BVRef br);  // (= br_0 (e0 tr)) /\ ... /\ (= br_32 (e32 tr))
-    lbool glueUFtoUF         (PTRef tr1, PTRef tr2); // (= uf1 uf2) <-> (and (= .b00_0 .b00_1) ... (= .b31_0 .b31_1))
     PTRef mkCollate32        (vec<PTRef>& bits);
     PTRef mkExtract          (PTRef tr, int i);
     // Theory refinement stuff
@@ -87,7 +79,7 @@ private:
     THandler&      thandler;
     SimpSMTSolver& solverP;                       // Solver with proof logger
 
-    bool addClause ( vec< Lit > &, PTRef );
+    bool addClause(vec<Lit> & c);
 
     static const char* s_bbEq;
     static const char* s_bbAnd;

--- a/src/tsolvers/bvsolver/Bvector.h
+++ b/src/tsolvers/bvsolver/Bvector.h
@@ -133,7 +133,7 @@ class BvectorAllocator : public RegionAllocator<uint32_t>
         to.n_terms = n_terms;
         RegionAllocator<uint32_t>::moveTo(to); }
 
-    BVRef alloc(const vec<PTRef>& names, const vec<PTRef>& asgn, PTRef act_var, bool extra = false)
+    BVRef alloc(const vec<PTRef> & names, const vec<PTRef> & asgn, PTRef act_var)
     {
         assert(sizeof(PTRef) == sizeof(uint32_t));
         assert(names.size() == asgn.size());
@@ -149,7 +149,7 @@ class BvectorAllocator : public RegionAllocator<uint32_t>
         return tid;
     }
 
-    BVRef alloc(Bvector&, bool) { assert(false); return BVRef_Undef; }
+    BVRef alloc(Bvector&, bool) = delete;
 
     // Deref, Load Effective Address (LEA), Inverse of LEA (AEL):
     Bvector&       operator[](BVRef r)         { return (Bvector&)RegionAllocator<uint32_t>::operator[](r.x); }
@@ -164,18 +164,18 @@ class BvectorAllocator : public RegionAllocator<uint32_t>
         RegionAllocator<uint32_t>::free(ptermWord32Size(t.size()));
     }
 
-    void reloc(BVRef& tr, BvectorAllocator& to)
-    {
-        Bvector& t = operator[](tr);
-
-        if (t.reloced()) { tr = t.relocation(); return; }
-
-        tr = to.alloc(t, false);
-        t.relocate(tr);
-
-        // Copy extra data-fields:
-        to[tr].set_signed(t.is_signed());
-    }
+//    void reloc(BVRef& tr, BvectorAllocator& to)
+//    {
+//        Bvector& t = operator[](tr);
+//
+//        if (t.reloced()) { tr = t.relocation(); return; }
+//
+//        tr = to.alloc(t, false);
+//        t.relocate(tr);
+//
+//        // Copy extra data-fields:
+//        to[tr].set_signed(t.is_signed());
+//    }
     friend class BVStore;
 };
 #endif

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -215,7 +215,7 @@ public:
 
     void clearSolver() { clearModel(); } // Only clear the possible computed values
 
-    void print(ostream& out) { return; }
+    void print(ostream&) { return; }
 
 protected:
     inline Enode& getEnode(ERef er) { return enode_store[er]; }

--- a/src/tsolvers/egraph/EgraphDebug.C
+++ b/src/tsolvers/egraph/EgraphDebug.C
@@ -348,10 +348,8 @@ void Egraph::checkForbidReferences(ERef er) {
     do {
         Elist& e_old = forbid_allocator[er_old];
         for (int j = 0; j < forbid_allocator.referenced_by[e_old.getId()].size(); j++) {
-            ERef referer = forbid_allocator.referenced_by[e_old.getId()][j];
-            assert (e_old.e != referer);
+            assert (e_old.e != forbid_allocator.referenced_by[e_old.getId()][j]);
         }
-
     } while (start != er_old);
 }
 
@@ -361,8 +359,7 @@ void Egraph::checkRefConsistency() {
         for (int j = 0; j < referers.size(); j++) {
             ERef referer = referers[j];
             if (referer == ERef_Undef) continue;
-            ELRef forbid = enode_store[referer].getForbid();
-            assert(forbid_allocator[forbid].getId() == i);
+            assert(forbid_allocator[enode_store[referer].getForbid()].getId() == i);
         }
     }
 }

--- a/src/tsolvers/egraph/EgraphDebug.C
+++ b/src/tsolvers/egraph/EgraphDebug.C
@@ -354,7 +354,7 @@ void Egraph::checkForbidReferences(ERef er) {
 }
 
 void Egraph::checkRefConsistency() {
-    for (int i = 0; i < forbid_allocator.referenced_by.size(); i++) {
+    for (unsigned int i = 0; i < static_cast<unsigned int>(forbid_allocator.referenced_by.size()); i++) {
         vec<ERef>& referers = forbid_allocator.referenced_by[i];
         for (int j = 0; j < referers.size(); j++) {
             ERef referer = referers[j];

--- a/src/tsolvers/egraph/EgraphSolver.C
+++ b/src/tsolvers/egraph/EgraphSolver.C
@@ -413,7 +413,7 @@ void Egraph::declareTerm(PTRef tr) {
 
     if (logic.hasSortBool(tr)) {
         Pterm& t = logic.getPterm(tr);
-        while (known_preds.size() <= Idx(t.getId()))
+        while (static_cast<unsigned int>(known_preds.size()) <= Idx(t.getId()))
             known_preds.push(false);
         known_preds[Idx(t.getId())] = true;
     }
@@ -1970,25 +1970,11 @@ uint32_t UseVector::addParent(ERef parent) {
 }
 
 void UseVector::clearEntryAt(int index) {
-    assert(index >= 0 && index < data.size() && data[index].isValid());
+    assert(index >= 0 && static_cast<std::size_t>(index) < data.size() && data[index].isValid());
     data[index] = UseVector::indexToFreeEntry(free);
     free = index;
     --nelems;
 }
-
-//void UseVector::markEntry(Entry& entry) {
-//    // MB: TODO: I probably do not need to decrement the number of elements, since this use vector should not be accessed until backtracking makes it valid again
-//    assert(entry.isValid());
-//    entry.mark();
-//    --this->nelems;
-//}
-//
-//void UseVector::unMarkEntry(Entry& entry) {
-//    // MB: TODO: check if the decrement in markEntry needs to be undone
-//    assert(entry.isMarked());
-//    entry.unmark();
-//    ++this->nelems;
-//}
 
 uint32_t UseVector::getFreeSlotIndex() {
     auto ret = free;
@@ -1996,7 +1982,7 @@ uint32_t UseVector::getFreeSlotIndex() {
         Entry e = data[free];
         assert(e.isFree());
         free = freeEntryToIndex(e);
-        assert(free < 0 || free < data.size());
+        assert(free < 0 || static_cast<std::size_t>(free) < data.size());
         return ret;
     }
     ret = data.size();

--- a/src/tsolvers/egraph/EgraphSolver.C
+++ b/src/tsolvers/egraph/EgraphSolver.C
@@ -1035,13 +1035,11 @@ void Egraph::merge ( ERef x, ERef y, PtAsgn reason )
     cerr << "y isConstant is " << isConstant(y) << endl;
 #endif
     { // sanity checks
-        const Enode& an_x = getEnode(x);
-        const Enode& an_y = getEnode(y);
-        assert( an_x.type() == an_y.type() );
-        assert( !an_x.isTerm() || !isConstant(x) || !isConstant(y));
-        assert( an_x.getRoot( ) != an_y.getRoot( ) );
-        assert( x == an_x.getRoot( ) );
-        assert( y == an_y.getRoot( ) );
+        assert( getEnode(x).type() == getEnode(y).type() );
+        assert( !getEnode(x).isTerm() || !isConstant(x) || !isConstant(y));
+        assert( getEnode(x).getRoot( ) != getEnode(y).getRoot( ) );
+        assert( x == getEnode(x).getRoot( ) );
+        assert( y == getEnode(y).getRoot( ) );
     }
 
     // Step 1: Ensure that the constant or the one with a larger equivalence
@@ -1926,11 +1924,9 @@ void Egraph::doExplain(ERef x, ERef y, PtAsgn reason_inequality) {
 void Egraph::explainConstants(ERef p, ERef q) {
     ERef enr_proot = getEnode(p).getRoot();
     ERef enr_qroot = getEnode(q).getRoot();
-    const Enode& en_proot = getEnode(enr_proot);
-    const Enode& en_qroot = getEnode(enr_qroot);
-    assert(en_proot.isTerm() && en_qroot.isTerm());
-    assert(logic.isConstant(en_proot.getTerm()));
-    assert(logic.isConstant(en_qroot.getTerm()));
+    assert(getEnode(enr_proot).isTerm() && getEnode(enr_qroot).isTerm());
+    assert(logic.isConstant(getEnode(enr_proot).getTerm()));
+    assert(logic.isConstant(getEnode(enr_qroot).getTerm()));
     assert(enr_proot != enr_qroot);
     //
     // We need explaining

--- a/src/tsolvers/egraph/Enode.h
+++ b/src/tsolvers/egraph/Enode.h
@@ -410,7 +410,7 @@ public:
 
         elr = to.alloc(el);
         to.referenced_by.push();
-        assert(to.referenced_by.size() == to[elr].getId()+1);
+        assert(static_cast<unsigned int>(to.referenced_by.size()) == to[elr].getId()+1);
 
         // copy referers from old allocator to new
         vec<ERef>& referers = referenced_by[el.getId()];

--- a/src/tsolvers/egraph/InterpolatingEgraph.h
+++ b/src/tsolvers/egraph/InterpolatingEgraph.h
@@ -12,8 +12,8 @@ class InterpolatingEgraph : public Egraph {
 public:
     InterpolatingEgraph(SMTConfig & c , Logic& l
     , vec<DedElem>& d) : Egraph{c,l,d}
-            , cgraph_            ( new CGraph( *this, config, l ) )
             , cgraph(nullptr)
+            , cgraph_( new CGraph( *this, config, l ) )
     {}
 
     virtual ~InterpolatingEgraph() override {

--- a/src/tsolvers/egraph/UFInterpolator.C
+++ b/src/tsolvers/egraph/UFInterpolator.C
@@ -204,8 +204,8 @@ icolor_t CGraph::colorNodesRec ( CNode *c, const ipartitions_t &mask )
 void
 CGraph::removeCEdge(CEdge *e)
 {
-    if(e == NULL) return;
-    for(int i = 0; i < cedges.size(); ++i)
+    if(e == nullptr) return;
+    for(std::size_t i = 0; i < cedges.size(); ++i)
     {
         if(cedges[i] == e)
         {
@@ -564,10 +564,10 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                             
                            
                             //cerr << "; Edges from X to N" << endl;
-                            vector<CEdge*> sorted;
+                            std::vector<CEdge*> sorted;
                             size_t xnl = getSortedEdges(cn_arg_x, cn_arg_n, sorted);
                             (void)xnl;
-                            for(int i = 0; i < sorted.size(); ++i)
+                            for(std::size_t i = 0; i < sorted.size(); ++i)
                             {
                                 CNode *from = sorted[i]->source;
                                 CNode *to = sorted[i]->target;
@@ -623,10 +623,10 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                             
                            
                             //cerr << "; Edges from X to N" << endl;
-                            vector<CEdge*> sorted;
+                            std::vector<CEdge*> sorted;
                             size_t xnl = getSortedEdges(cn_arg_x, cn_arg_n, sorted);
                             (void)xnl;
-                            for(int i = 0; i < sorted.size() - 1; ++i)
+                            for(std::size_t i = 0; i < sorted.size() - 1; ++i)
                             {
                                 CNode *from = sorted[i]->source;
                                 CNode *to = sorted[i]->target;
@@ -922,9 +922,9 @@ CGraph::interpolate_flat (const path_t &p)
     vec<PTRef> args;
     bool la, lb, lab, ra, rb, rab;
 
-    vector<path_t> factors;
+    std::vector<path_t> factors;
     factors.push_back (p);
-    vector<path_t> parents;
+    std::vector<path_t> parents;
     const bool a_factor = getFactorsAndParents ( p, factors, parents );
     (void)a_factor;
     // this should be a flat path
@@ -933,9 +933,9 @@ CGraph::interpolate_flat (const path_t &p)
     //cerr << "; Flat path has " << factors.size() << " factors:" << endl;
     //for(int i = 0; i < factors.size(); ++i) cerr << "; Factor " << i << " = (" << logic.printTerm(factors[i].first->e) << "," << logic.printTerm(factors[i].second->e) << ")" << endl;
 
-    for (int i = 0; i < factors.size(); i += 3)
+    for (std::size_t i = 0; i < factors.size(); i += 3)
     {
-        int j = i + 2;
+        std::size_t j = i + 2;
 
         if (j >= factors.size()) j = (factors.size() - 1);
 
@@ -1323,7 +1323,7 @@ bool CGraph::getSubpaths ( const path_t &pi
 
     if (lnode == NULL || rnode == NULL)
     {
-        for (int i = 0; i < sorted_edges.size(); ++i)
+        for (std::size_t i = 0; i < sorted_edges.size(); ++i)
         {
             scolor = sorted_edges[i]->source->color;
             tcolor = sorted_edges[i]->target->color;
@@ -1458,7 +1458,7 @@ CGraph::getSubpathsSwap ( const path_t &pi
 
     if (lnode == NULL || rnode == NULL)
     {
-        for (int i = 0; i < sorted_edges.size(); ++i)
+        for (std::size_t i = 0; i < sorted_edges.size(); ++i)
         {
             scolor = sorted_edges[i]->source->color;
             tcolor = sorted_edges[i]->target->color;
@@ -1716,7 +1716,7 @@ CGraph::Irec ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h)
 
     string lstr (";");
 
-    for (int i = 0; i < h; ++i) lstr += ' ';
+    for (unsigned i = 0; i < h; ++i) { lstr += ' '; }
 
     /*
       map< path_t, PTRef >::iterator it = cache.find( p );
@@ -1823,9 +1823,9 @@ CGraph::Irec ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h)
             bool la, lb, lab, ra, rb, rab;
             divided = true;
 
-            for (int i = 0; i < factors.size(); i += 3)
+            for (std::size_t i = 0; i < factors.size(); i += 3)
             {
-                int j = i + 2;
+                std::size_t j = i + 2;
 
                 if (j >= factors.size()) j = (factors.size() - 1);
 
@@ -1967,7 +1967,7 @@ CGraph::Irec ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h)
         }
         else
         {
-            for (int i = 0; i < factors.size(); ++i)
+            for (std::size_t i = 0; i < factors.size(); ++i)
                 conj.push (Irec (factors[i], cache, h));
         }
     }
@@ -2000,7 +2000,7 @@ CGraph::IrecSwap ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h
 
     string lstr (";");
 
-    for (int i = 0; i < h; ++i) lstr += ' ';
+    for (unsigned i = 0; i < h; ++i) { lstr += ' '; }
 
 #ifdef ITP_DEBUG
     cerr << lstr << "Interpolant IrecSwap(" << logic.printTerm (p.first->e) << "," << logic.printTerm (p.second->e) << ")" << endl;
@@ -2106,9 +2106,9 @@ CGraph::IrecSwap ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h
             bool la, lb, lab, ra, rb, rab;
             divided = true;
 
-            for (int i = 0; i < factors.size(); i += 3)
+            for (std::size_t i = 0; i < factors.size(); i += 3)
             {
-                int j = i + 2;
+                std::size_t j = i + 2;
 
                 if (j >= factors.size()) j = (factors.size() - 1);
 
@@ -2233,7 +2233,7 @@ CGraph::IrecSwap ( const path_t &p, map< path_t, PTRef > &cache , unsigned int h
             cerr << "Multiple factors, recursing on them" << endl;
 #endif
 
-            for (int i = 0; i < factors.size(); ++i)
+            for (std::size_t i = 0; i < factors.size(); ++i)
             {
 #ifdef ITP_DEBUG
                 cerr << "Recursing on factor " << logic.printTerm (factors[i].first->e) << '-' << logic.printTerm (factors[i].second->e) << endl;
@@ -2540,22 +2540,22 @@ bool CGraph::getFactorsAndParents ( const path_t      &p
 }
 
 void
-CGraph::labelFactors (vector<path_t> &factors)
+CGraph::labelFactors (std::vector<path_t> &factors)
 {
     // McMillan
     if (usingStrong())
-        for (int i = 0; i < factors.size(); ++i)
+        for (std::size_t i = 0; i < factors.size(); ++i)
             L[factors[i]] = I_B;
 
     // McMillan'
     else if (usingWeak())
-        for (int i = 0; i < factors.size(); ++i)
+        for (std::size_t i = 0; i < factors.size(); ++i)
             L[factors[i]] = I_A;
 
     // Random
     else if (usingRandom())
     {
-        for (int i = 0; i < factors.size(); ++i)
+        for (std::size_t i = 0; i < factors.size(); ++i)
         {
             if (rand() % 2)
             {
@@ -2589,7 +2589,7 @@ CGraph::verifyInterpolantWithExternalTool ( const ipartitions_t &mask )
     vec<PTRef> a_args;
     vec<PTRef> b_args;
 
-    for (int i = 0; i < cedges.size(); ++i)
+    for (std::size_t i = 0; i < cedges.size(); ++i)
     {
         CEdge *ce = cedges[i];
         vec<PTRef> eq_args;

--- a/src/tsolvers/egraph/UFInterpolator.C
+++ b/src/tsolvers/egraph/UFInterpolator.C
@@ -469,8 +469,7 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
     assert ( x );
 
     // Color from x
-    CNode *n = NULL;
-    CNode *orig_x = x;
+    CNode *n = nullptr;
 
 #ifdef COLOR_DEBUG
     cerr << "; ColorEdgesFrom " << logic.printTerm(x->e) << endl;
@@ -567,6 +566,7 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                             //cerr << "; Edges from X to N" << endl;
                             vector<CEdge*> sorted;
                             size_t xnl = getSortedEdges(cn_arg_x, cn_arg_n, sorted);
+                            (void)xnl;
                             for(int i = 0; i < sorted.size(); ++i)
                             {
                                 CNode *from = sorted[i]->source;
@@ -625,6 +625,7 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                             //cerr << "; Edges from X to N" << endl;
                             vector<CEdge*> sorted;
                             size_t xnl = getSortedEdges(cn_arg_x, cn_arg_n, sorted);
+                            (void)xnl;
                             for(int i = 0; i < sorted.size() - 1; ++i)
                             {
                                 CNode *from = sorted[i]->source;
@@ -657,8 +658,7 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                         assert ( abcommon != PTRef_Undef );
                         //cerr << "; Node " << logic.printTerm(abcommon) << " is AB" << endl;
                         assert ( cnodes_store.find ( abcommon ) != cnodes_store.end( ) );
-                        CNode *new_arg_x = cnodes_store[ abcommon ];
-                        assert ( new_arg_x->color == I_AB );
+                        assert ( cnodes_store[abcommon]->color == I_AB );
                         new_args.push ( abcommon );
 
 
@@ -668,7 +668,6 @@ bool CGraph::colorEdgesFrom ( CNode *x, const ipartitions_t &mask )
                     }
                 }
 
-                char **msg;
                 PTRef nn = logic.mkUninterpFun (logic.getPterm (x->e).symb(), new_args);
                 /*
                 if(isAstrict(logic.getIPartitions(new_args[0]), mask) && isBstrict(logic.getIPartitions(new_args[1]), mask))
@@ -927,6 +926,7 @@ CGraph::interpolate_flat (const path_t &p)
     factors.push_back (p);
     vector<path_t> parents;
     const bool a_factor = getFactorsAndParents ( p, factors, parents );
+    (void)a_factor;
     // this should be a flat path
     assert (parents.size() == 0);
 

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -111,7 +111,7 @@ public:
     , m_labels(NULL)
   { }
 
-  ~CGraph( ) { clear( ); }
+  virtual ~CGraph( ) { clear( ); }
 
 	inline int     verbose                       ( ) const { return config.verbosity(); }
     void verifyInterpolantWithExternalTool( const ipartitions_t& mask );
@@ -189,8 +189,6 @@ private:
   bool          getFactorsAndParents ( const path_t &, vector< path_t > &, vector< path_t > & );
   void labelFactors( vector<path_t> & );
   PTRef interpolate_flat(const path_t& p);
-  bool flat;
-  bool divided;
   inline path_t path                 ( CNode * c1, CNode * c2 ) { return make_pair( c1, c2 ); }
 
   bool          checkColors          ( );
@@ -200,24 +198,26 @@ private:
   Egraph &                        egraph;
   SMTConfig &                     config;
   Logic &                         logic;
-  vector< CNode * >               cnodes;
-  vector< CEdge * >               cedges;
-  map< PTRef, CNode * >       cnodes_store;
-  set< pair< PTRef, PTRef > > path_seen;
-  set< CNode * >                  colored_nodes;
-  set< CEdge * >                  colored_edges;
+  std::vector< CNode * >          cnodes;
+  std::vector< CEdge * >          cedges;
+  std::map< PTRef, CNode * >      cnodes_store;
+  std::set< pair< PTRef, PTRef >> path_seen;
+  std::set< CNode * >             colored_nodes;
+  std::set< CEdge * >             colored_edges;
   bool                            colored;
   PTRef                         conf1;
   PTRef                         conf2;
   PTRef                         conf;
-  map< path_t, icolor_t > L;
+  std::map< path_t, icolor_t > L;
   PTRef interpolant;
   icolor_t conf_color;
-  map<PTRef, icolor_t> *m_labels;
   vec<PTRef> A_basic;
   vec<PTRef> B_basic;
   unsigned int max_width;
   unsigned int max_height;
+  bool flat;
+  bool divided;
+  std::map<PTRef, icolor_t> *m_labels;
 
   struct CAdjust
   {
@@ -230,6 +230,7 @@ private:
       assert( prev->target == n );
       assert( x->next );
       assert( x->next == prev );
+      (void)n;
     }
 
     // Undo
@@ -245,7 +246,7 @@ private:
       assert( x->next != prev );
       assert( cnn->next != prev );
       x->next = prev;
-      cnn->next = NULL;
+      cnn->next = nullptr;
     }
 
   private:

--- a/src/tsolvers/lasolver/LABounds.cpp
+++ b/src/tsolvers/lasolver/LABounds.cpp
@@ -43,8 +43,9 @@ LABoundListRef LABoundListAllocator::alloc(const LVRef v, const vec<LABoundRef>&
 LABoundListRef LABoundListAllocator::alloc(LABoundList& from)
 {
     vec<LABoundRef> tmp;
-    for (int i = 0; i < from.size(); i++)
+    for (unsigned int i = 0; i < from.size(); i++) {
         tmp.push(from[i]);
+    }
     return alloc(from.getVar(), tmp);
 }
 
@@ -70,8 +71,9 @@ void LABoundStore::updateBound(BoundInfo bi) {
     vec<LABoundRef> new_bounds;
     LABoundListRef blr = var_bound_lists[getVarId(bi.v)];
 
-    for (int i = 0; i < bla[blr].size(); i++)
+    for (unsigned int i = 0; i < bla[blr].size(); i++) {
         new_bounds.push(bla[blr][i]);
+    }
 
     new_bounds.push(bi.ub);
     new_bounds.push(bi.lb);
@@ -80,8 +82,9 @@ void LABoundStore::updateBound(BoundInfo bi) {
     var_bound_lists[getVarId(bi.v)] = br;
     sort<LABoundRef,bound_lessthan>(bla[br].bounds, bla[br].size(), bound_lessthan(ba));
 
-    for (int j = 0; j < bla[br].size(); j++)
+    for (int j = 0; j < static_cast<int>(bla[br].size()); j++) {
         ba[bla[br][j]].setIdx(LABound::BLIdx{j});
+    }
 }
 
 void LABoundStore::buildBounds()
@@ -109,12 +112,12 @@ void LABoundStore::buildBounds()
         }
         LABoundListRef br = bla.alloc(keys[i], refs);
 
-        while (var_bound_lists.size() <= getVarId(keys[i]))
+        while (static_cast<unsigned int>(var_bound_lists.size()) <= getVarId(keys[i]))
             LABoundStore::var_bound_lists.push(LABoundListRef_Undef);
         var_bound_lists[getVarId(keys[i])] = br;
         sort<LABoundRef,bound_lessthan>(bla[br].bounds, bla[br].size(), bound_lessthan(ba));
 
-        for (int j = 0; j < bla[br].size(); j++)
+        for (int j = 0; static_cast<unsigned int>(j) < bla[br].size(); j++)
             ba[bla[br][j]].setIdx(LABound::BLIdx{j});
 
         // Check that the bounds are correctly ordered
@@ -152,7 +155,7 @@ void LABoundStore::buildBounds()
     for (unsigned i = 0; i < lvstore.numVars(); i++) {
         LVRef ref {i};
         auto id = getVarId(ref);
-        while (var_bound_lists.size() <= id)
+        while (static_cast<unsigned>(var_bound_lists.size()) <= id)
             var_bound_lists.push(LABoundListRef_Undef);
 
         if (var_bound_lists[id] == LABoundListRef_Undef) {
@@ -215,7 +218,7 @@ char* LABoundStore::printBounds(LVRef v) const
     LABoundListRef blr = var_bound_lists[getVarId(v)];
     char* bounds_str = (char*) malloc(1);
     bounds_str[0] = '\0';
-    for (int i = 0; i < bla[blr].size(); i++) {
+    for (unsigned int i = 0; i < bla[blr].size(); i++) {
         LABoundRef br = bla[blr][i];
         char* tmp;
         char* tmp2 = printBound(br);

--- a/src/tsolvers/lasolver/LABounds.h
+++ b/src/tsolvers/lasolver/LABounds.h
@@ -141,7 +141,7 @@ public:
         in_bounds.push(BoundInfo{v, ub, lb});
         return in_bounds.last();
     }
-    int nVars() const { return lvstore.numVars(); }
+    std::size_t nVars() const { return lvstore.numVars(); }
 };
 
 

--- a/src/tsolvers/lasolver/LARefs.h
+++ b/src/tsolvers/lasolver/LARefs.h
@@ -11,7 +11,7 @@ struct LABoundListRef
     inline friend bool operator!= (const LABoundListRef& a1, const LABoundListRef& a2) { return a1.x != a2.x; }
 };
 
-static struct LABoundListRef LABoundListRef_Undef = {INT32_MAX};
+const struct LABoundListRef LABoundListRef_Undef = {INT32_MAX};
 
 struct BoundT {
     char t;
@@ -31,8 +31,8 @@ struct LABoundRef
     inline friend bool operator!= (const LABoundRef& a1, const LABoundRef& a2) { return a1.x != a2.x; }
 };
 
-static struct LABoundRef LABoundRef_Undef = {INT32_MAX};
-static struct LABoundRef LABoundRef_Infty = { 0 };
+const struct LABoundRef LABoundRef_Undef = {INT32_MAX};
+const struct LABoundRef LABoundRef_Infty = { 0 };
 
 struct LVRef {
     uint32_t x;
@@ -53,6 +53,6 @@ struct LVRefComp {
     bool operator()(LVRef a, LVRef b) const { return a.x < b.x; }
 };
 
-static struct LVRef LVRef_Undef = { INT32_MAX };
+const struct LVRef LVRef_Undef = { INT32_MAX };
 
 #endif

--- a/src/tsolvers/lasolver/LASolver.cpp
+++ b/src/tsolvers/lasolver/LASolver.cpp
@@ -361,8 +361,6 @@ bool LASolver::assertLit( PtAsgn asgn, bool reason )
 
     assert(asgn.sgn != l_Undef);
 
-    bool is_reason = false;
-
     LABoundRefPair p = getBoundRefPair(asgn.tr);
     LABoundRef bound_ref = asgn.sgn == l_False ? p.neg : p.pos;
 
@@ -384,7 +382,7 @@ bool LASolver::assertLit( PtAsgn asgn, bool reason )
         return getStatus();
     }
     if (deduced[t.getVar()] != l_Undef && deduced[t.getVar()].deducedBy == id) {
-        is_reason = true; // This is a conflict!
+        // MB: what should happen here?
     }
 
     if (assertBoundOnVar( it, bound_ref))

--- a/src/tsolvers/lasolver/LASolver.cpp
+++ b/src/tsolvers/lasolver/LASolver.cpp
@@ -86,7 +86,7 @@ void LASolver::isProperLeq(PTRef tr)
 }
 
 LASolver::LASolver(SolverDescr dls, SMTConfig & c, LALogic& l, vec<DedElem>& d)
-        : TSolver((SolverId)descr_la_solver, (const char*)descr_la_solver, c, d)
+        : TSolver((SolverId)dls, (const char*)dls, c, d)
         , logic(l)
         , laVarMapper(l, laVarStore)
         , boundStore(laVarStore)
@@ -597,7 +597,7 @@ void LASolver::deduce(LABoundRef bound_prop) {
 //
 // Prints the current state of the solver (terms, bounds, tableau)
 //
-void LASolver::print( ostream & out )
+void LASolver::print( ostream & )
 {
     throw "Not implemented yet!";
     // print current non-basic variables

--- a/src/tsolvers/lasolver/LASolver.cpp
+++ b/src/tsolvers/lasolver/LASolver.cpp
@@ -133,7 +133,7 @@ void LASolver::clearSolver()
 void LASolver::storeExplanation(Simplex::Explanation &&explanationBounds) {
     explanation.clear();
     explanationCoefficients.clear();
-    for (int i = 0; i < explanationBounds.size(); i++) {
+    for (std::size_t i = 0; i < explanationBounds.size(); i++) {
         PtAsgn asgn = getAsgnByBound(explanationBounds[i].boundref);
         explanation.push(asgn);
         explanationCoefficients.push_back(explanationBounds[i].coeff);
@@ -316,7 +316,7 @@ void LASolver::declareAtom(PTRef leq_tr)
 
     const Pterm& t = logic.getPterm(leq_tr);
 
-    while (known_preds.size() <= Idx(t.getId()))
+    while (static_cast<unsigned int>(known_preds.size()) <= Idx(t.getId()))
         known_preds.push(false);
     known_preds[Idx(t.getId())] = true;
 }
@@ -747,7 +747,7 @@ LASolver::~LASolver( )
 #endif // STATISTICS
 }
 
-PtAsgn_reason LASolver::getDeduction()  { if (deductions_next >= th_deductions.size()) return PtAsgn_reason_Undef; else return th_deductions[deductions_next++]; }
+PtAsgn_reason LASolver::getDeduction()  { if (deductions_next >= static_cast<unsigned>(th_deductions.size())) return PtAsgn_reason_Undef; else return th_deductions[deductions_next++]; }
 
 LALogic&  LASolver::getLogic()  { return logic; }
 

--- a/src/tsolvers/lasolver/LASolver.cpp
+++ b/src/tsolvers/lasolver/LASolver.cpp
@@ -82,6 +82,7 @@ void LASolver::isProperLeq(PTRef tr)
     assert(logic.isNumVar(sum) || logic.isNumPlus(sum) || logic.isNumTimes(sum));
     assert(!logic.isNumTimes(sum) || ((logic.isNumVar(logic.getPterm(sum)[0]) && (logic.mkNumNeg(logic.getPterm(sum)[1])) == logic.getTerm_NumOne()) ||
                                       (logic.isNumVar(logic.getPterm(sum)[1]) && (logic.mkNumNeg(logic.getPterm(sum)[0])) == logic.getTerm_NumOne())));
+    (void) cons; (void)sum;
 }
 
 LASolver::LASolver(SolverDescr dls, SMTConfig & c, LALogic& l, vec<DedElem>& d)

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -136,7 +136,7 @@ protected:
     bool hasVar(PTRef expr);
     LVRef getVarForLeq(PTRef ref)  const  { return laVarMapper.getVarByLeqId(logic.getPterm(ref).getId()); }
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
-    virtual void notifyVar(LVRef v) {}                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
+    virtual void notifyVar(LVRef) {}                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
     void getConflictingBounds( LVRef, vec<PTRef> & );       // Returns the bounds conflicting with the actual model
     void getDeducedBounds( const Delta& c, BoundT, vec<PtAsgn_reason>& dst, SolverId solver_id ); // find possible deductions by value c
     void getDeducedBounds( BoundT, vec<PtAsgn_reason>& dst, SolverId solver_id );                 // find possible deductions for actual bounds values

--- a/src/tsolvers/lasolver/LAVar.cpp
+++ b/src/tsolvers/lasolver/LAVar.cpp
@@ -36,4 +36,4 @@ LVRef LAVarStore::getNewVar() {
     return lv;
 }
 
-int    LAVarStore::numVars() const { return lavars.size(); }
+std::size_t LAVarStore::numVars() const { return lavars.size(); }

--- a/src/tsolvers/lasolver/LAVar.h
+++ b/src/tsolvers/lasolver/LAVar.h
@@ -47,7 +47,7 @@ public:
     LAVarStore() {}
     LVRef  getNewVar();
     inline void   clear() {};
-    int    numVars() const ;
+    std::size_t numVars() const ;
 };
 
 

--- a/src/tsolvers/lasolver/LAVarMapper.cpp
+++ b/src/tsolvers/lasolver/LAVarMapper.cpp
@@ -8,8 +8,9 @@
 LVRef LAVarMapper::getNewVar(PTRef e_orig) {
     assert(!logic.isNegated(e_orig));
     LVRef lv = laVarStore.getNewVar();
-    if (lv.x >= laVarToPTRef.size())
+    if (lv.x >= static_cast<unsigned int>(laVarToPTRef.size())) {
         laVarToPTRef.growTo(lv.x+1, PTRef_Undef);
+    }
 
     laVarToPTRef[lv.x] = e_orig;
 
@@ -44,5 +45,5 @@ LVRef  LAVarMapper::getVarByPTId(PTId i) const { return ptermToLavar[Idx(i)]; }
 
 LVRef  LAVarMapper::getVarByLeqId(PTId i) const { return leqToLavar[Idx(i)]; }
 
-bool   LAVarMapper::hasVar(PTId i) { return ptermToLavar.size() > Idx(i) && ptermToLavar[Idx(i)] != LVRef_Undef; }
+bool   LAVarMapper::hasVar(PTId i) { return static_cast<unsigned int>(ptermToLavar.size()) > Idx(i) && ptermToLavar[Idx(i)] != LVRef_Undef; }
 

--- a/src/tsolvers/lasolver/Simplex.cpp
+++ b/src/tsolvers/lasolver/Simplex.cpp
@@ -110,7 +110,7 @@ LVRef Simplex::getBasicVarToFixByShortestPoly() const {
 }
 
 LVRef Simplex::getBasicVarToFixByBland() const {
-    int curr_var_id_x = boundStore.nVars();
+    auto curr_var_id_x = boundStore.nVars();
     LVRef current = LVRef_Undef;
     for (auto it : candidates) {
         assert(it != LVRef_Undef);
@@ -178,12 +178,12 @@ LVRef Simplex::findNonBasicForPivotByHeuristic(LVRef basicVar) {
 }
 
 LVRef Simplex::findNonBasicForPivotByBland(LVRef basicVar) {
-    int max_var_id = boundStore.nVars();
+    auto max_var_id = boundStore.nVars();
     LVRef y_found = LVRef_Undef;
     // Model doesn't fit the lower bound
     if (model->read(basicVar) < model->Lb(basicVar)) {
         // For the Bland rule
-        int curr_var_id_y = max_var_id;
+        auto curr_var_id_y = max_var_id;
         // look for nonbasic terms to fix the breaking of the bound
         for (auto term : tableau.getRowPoly(basicVar)) {
             auto y = term.var;
@@ -199,7 +199,7 @@ LVRef Simplex::findNonBasicForPivotByBland(LVRef basicVar) {
         }
     }
     else if (model->read(basicVar) > model->Ub(basicVar)) {
-        int curr_var_id_y = max_var_id;
+        auto curr_var_id_y = max_var_id;
         // look for nonbasic terms to fix the unbounding
         for (auto term : tableau.getRowPoly(basicVar)) {
             auto y = term.var;

--- a/src/tsolvers/liasolver/LIASolver.C
+++ b/src/tsolvers/liasolver/LIASolver.C
@@ -37,7 +37,7 @@ void LIASolver::notifyVar(LVRef v)
         int_vars.push(v);
     }
 
-    while(cuts.size() <= getVarId(v))
+    while(static_cast<unsigned>(cuts.size()) <= getVarId(v))
         cuts.push();
 }
 

--- a/src/tsolvers/liasolver/Matrix.cpp
+++ b/src/tsolvers/liasolver/Matrix.cpp
@@ -37,10 +37,9 @@ opensmt::Real&
 LAMatrixStore::MM(MId mid, int row, int col)
 {
     LAMatrix& m = operator[](mid);
-    int nrows = m.nRows();
     int ncols = m.nCols();
     assert(row >= 1 && col >= 1);
-    assert(row <= nrows && col <= ncols);
+    assert(row <= m.nRows() && col <= ncols);
     return vs[m.getCoeffs()][ncols*(row-1) + col-1 + 1]; // Vectors are indexed from 1 ... n
 }
 
@@ -303,33 +302,26 @@ LAMatrixStore::compute_snf(MId U, MId &S, int &dim, MId &L, MId &Li, MId &R, MId
     int imin, jmin;
     bool found;
     opensmt::Real x, valmin;
-
+    auto const& store = *this; (void) store;
     LAMatrix& Sm = operator[](S);
-    LAMatrix& Um = operator[](U);
     if (R != MId_Undef) {
-        LAMatrix &Rm = operator[](R);
-        assert(Rm.nCols() == Rm.nRows());
-        assert(Rm.nRows() == Um.nCols());
+        assert(store[R].nCols() == store[R].nRows());
+        assert(store[R].nRows() == store[U].nCols());
 
     }
     if (Ri != MId_Undef) {
-        LAMatrix& Rim = operator[](Ri);
-        LAMatrix& Rm = operator[](R);
-        assert(Rim.nRows() == Rim.nCols());
-        assert(Rim.nRows() == Rm.nCols());
+        assert(store[Ri].nRows() == store[Ri].nCols());
+        assert(store[Ri].nRows() == store[R].nCols());
 
     }
     if (L != MId_Undef) {
-        LAMatrix& Lm = operator[](L);
-        assert(Lm.nCols() == Lm.nRows());
-        assert(Lm.nCols() == Um.nRows());
+        assert(store[L].nCols() == store[L].nRows());
+        assert(store[L].nCols() == store[U].nRows());
 
     }
     if (Li != MId_Undef) {
-        LAMatrix& Lmi = operator[](Li);
-        LAMatrix& Lm = operator[](L);
-        assert(Lmi.nRows() == Lmi.nCols());
-        assert(Lmi.nRows() == Lm.nRows());
+        assert(store[Li].nRows() == store[Li].nCols());
+        assert(store[Li].nRows() == store[L].nRows());
     }
 
     //std::cout << " Rows U" << Um.nRows() << " Cols U " << Um.nCols() << " Rows S" << Sm.nRows() << " Cols S " << Sm.nCols() << "\n";
@@ -522,8 +514,7 @@ LAMatrixStore::compute_hnf_v1(const MId U1, MId &H, int &dim1, MId &R1, MId &Ri1
     LAMatrix& Hm = operator[](H);
     LAMatrix& U1m = operator[](U1);
     if (R1 != MId_Undef) {
-        LAMatrix &R1m = operator[](R1);
-        assert(R1m.nRows() == U1m.nRows());
+        assert(operator[](R1).nRows() == U1m.nRows());
     }
 
     if (H != U1)

--- a/src/tsolvers/liasolver/Matrix.cpp
+++ b/src/tsolvers/liasolver/Matrix.cpp
@@ -299,8 +299,9 @@ LAMatrixStore::least_in_col(MId H, int imin, int j)
 void
 LAMatrixStore::compute_snf(MId U, MId &S, int &dim, MId &L, MId &Li, MId &R, MId &Ri)
 {
-    int imin, jmin;
-    bool found;
+    int imin = 0;
+    int jmin = 0;
+    bool found = false;
     opensmt::Real x, valmin;
     auto const& store = *this; (void) store;
     LAMatrix& Sm = operator[](S);

--- a/src/tsolvers/liasolver/Matrix.h
+++ b/src/tsolvers/liasolver/Matrix.h
@@ -138,6 +138,7 @@ public:
     MId getNewMatrix(int rows, int cols) { matrices.push(LAMatrix(vs.getNewVec(rows*cols), rows, cols)); return MId{matrices.size_()-1}; }
     MId getNewMatrix(LAVecRef v); // Initialize a (n x 1) matrix from the contents of size n vector v
     LAMatrix& operator[] (MId i) { return matrices[i.x]; }
+    const LAMatrix& operator[] (MId i) const { return matrices[i.x]; }
     // Set Matrix t to contain values that are equal to those of s.  t and s need to agree on dimensions.
     void setMatrix(MId t, MId s) {
         assert(operator[](t).nRows() == operator[](s).nRows());

--- a/src/tsolvers/lrasolver/LRAModel.cpp
+++ b/src/tsolvers/lrasolver/LRAModel.cpp
@@ -19,7 +19,7 @@ LRAModel::addVar(LVRef v)
     if (has_model.has(v))
         return n_vars_with_model;
 
-    while (current_assignment.size() <= getVarId(v)) {
+    while (static_cast<unsigned>(current_assignment.size()) <= getVarId(v)) {
         current_assignment.push();
         last_consistent_assignment.push();
         changed_vars_set.assure_domain(getVarId(v));

--- a/src/tsolvers/lrasolver/LRASolver.cpp
+++ b/src/tsolvers/lrasolver/LRASolver.cpp
@@ -301,20 +301,19 @@ LRASolver::getInterpolant( const ipartitions_t & mask , map<PTRef, icolor_t> *la
             opensmt_error("Error: interpolation algorithm not set for LRA.");
         }
 
-        char* msg;
         if (itpAlg != ItpAlg::WEAK)
         {
             if (delta_flag)
-                itp = logic.mkNumLt(args, &msg);
+                itp = logic.mkNumLt(args);
             else
-                itp = logic.mkNumLeq(args, &msg);
+                itp = logic.mkNumLeq(args);
         }
         else
         {
             if (delta_flag_dual)
-                itp = logic.mkNumLt(args, &msg);
+                itp = logic.mkNumLt(args);
             else
-                itp = logic.mkNumLeq(args, &msg);
+                itp = logic.mkNumLeq(args);
             itp = logic.mkNot(itp);
         }
     }

--- a/src/tsolvers/lrasolver/LRASolver.cpp
+++ b/src/tsolvers/lrasolver/LRASolver.cpp
@@ -167,7 +167,7 @@ LRASolver::getInterpolant( const ipartitions_t & mask , map<PTRef, icolor_t> *la
     printf(";  %s\n", logic.printTerm(tr));
 #endif
 
-    for ( unsigned i = 0; i < explanation.size( ); i++ )
+    for ( int i = 0; i < explanation.size( ); i++ )
     {
         icolor_t color = I_UNDEF;
         const ipartitions_t & p = logic.getIPartitions(explanation[i].tr);

--- a/src/tsolvers/lrasolver/LRASolver.cpp
+++ b/src/tsolvers/lrasolver/LRASolver.cpp
@@ -171,7 +171,6 @@ LRASolver::getInterpolant( const ipartitions_t & mask , map<PTRef, icolor_t> *la
     {
         icolor_t color = I_UNDEF;
         const ipartitions_t & p = logic.getIPartitions(explanation[i].tr);
-        Pterm& t = logic.getPterm(explanation[i].tr);
         if ( isAB( p, mask ) ) {
             color = I_AB;
         }
@@ -255,12 +254,12 @@ LRASolver::getInterpolant( const ipartitions_t & mask , map<PTRef, icolor_t> *la
             opensmt::Real const_strong = interpolant.getRealConstant();
             opensmt::Real const_weak = interpolant_dual.getRealConstant();
             PTRef nonconst_strong = interpolant.getPTRefNonConstant();
-            PTRef nonconst_weak = interpolant_dual.getPTRefNonConstant();
+            //PTRef nonconst_weak = interpolant_dual.getPTRefNonConstant();
             //cout << "; Constant Strong " << const_strong << endl;
             //cout << "; Constant Weak " << const_weak << endl;
             //cout << "; NonConstant Strong " << logic.printTerm(nonconst_strong) << endl;
             //cout << "; NonConstant Weak " << logic.printTerm(nonconst_weak) << endl;
-            PTRef neg_strong = logic.mkNumNeg(nonconst_strong);
+            //PTRef neg_strong = logic.mkNumNeg(nonconst_strong);
             //assert(neg_strong == nonconst_weak);
 
             opensmt::Real lower_bound = const_strong;

--- a/src/tsolvers/lrasolver/LRA_Interpolator.cpp
+++ b/src/tsolvers/lrasolver/LRA_Interpolator.cpp
@@ -97,7 +97,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
     // assumes there are 0 on all position before col
     void normalize(std::vector<Real> & row, std::size_t col) {
 #ifndef NDEBUG
-        for (auto i = 0; i < col; ++i) {
+        for (std::size_t i = 0; i < col; ++i) {
             assert(row[i] == 0);
         }
 #endif //NDEBUG
@@ -167,7 +167,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
                 if (matrix[row][pivotCol] == 0) { continue; }
                 addToWithCoeff(matrix[row], matrix[pivotRow], -(matrix[row][pivotCol] / matrix[pivotRow][pivotCol]));
 #ifndef NDEBUG
-                for (auto col = 0; col <= pivotCol; ++col) {
+                for (std::size_t col = 0; col <= pivotCol; ++col) {
                     assert(matrix[row][col] == 0);
                 }
 #endif // NDEBUG
@@ -185,7 +185,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         auto rank = std::count_if(matrix.cbegin(), matrix.cend(), [](std::vector<Real> const & row) {
             return std::any_of(row.cbegin(), row.cend(), [](Real const & r) { return r != 0; });
         });
-        auto cols = matrix[0].size();
+        auto cols = static_cast<long>(matrix[0].size());
         assert(cols >= rank);
         return cols - rank;
     }
@@ -217,10 +217,10 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         auto pivotColsBitMap = getPivotColsBitMap(matrix);
         auto cols = pivotColsBitMap.size();
         assert(cols == matrix[0].size());
-        unsigned int pivotRow = 0;
+        std::size_t pivotRow = 0;
         for (unsigned int col = 0; col < pivotColsBitMap.size(); ++col) {
             if(pivotColsBitMap[col]) {
-                for (auto row = 0; row < matrix.size(); ++row) {
+                for (std::size_t row = 0; row < matrix.size(); ++row) {
                     if ((row != pivotRow && matrix[row][col] != 0) || (row == pivotRow && matrix[row][col] != 1)) {
                         return false;
                     }
@@ -245,6 +245,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
     }
 
     void print_matrix(std::vector<std::vector<Real>> const & matrix) {
+        (void)print_matrix; // MB: to supress compiler warning for this unused helpful debug method
         for (auto const & row : matrix) {
             for (auto const & elem : row) {
                 std::cout << elem << " ";
@@ -255,6 +256,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
     }
 
     void print_basis(std::vector<std::vector<FastRational>> const & nullBasis) {
+        (void)print_basis; // MB: to supress compiler warning for this unused helpful debug method
         std::cout << "Basis: " << '\n';
         for (auto const & base : nullBasis) {
             for (auto const & elem : base) {
@@ -432,7 +434,7 @@ PTRef LRA_Interpolator::getInterpolant(icolor_t color) {
     // this will be contain the result, inequalities corresponding to summed up partitions of explanataions (of given color)
     std::vector<PTRef> interpolant_inequalities;
     std::vector<std::pair<PtAsgn, Real>> candidates;
-    assert(explanations.size() == explanation_coeffs.size());
+    assert(explanations.size() == static_cast<int>(explanation_coeffs.size()));
     for (int i = 0; i < explanations.size(); ++i) {
         assert(explanation_coeffs[i] > 0);
         candidates.emplace_back(explanations[i], explanation_coeffs[i]);

--- a/src/tsolvers/lrasolver/LRA_Interpolator.cpp
+++ b/src/tsolvers/lrasolver/LRA_Interpolator.cpp
@@ -89,7 +89,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
      */
     void addToWithCoeff(std::vector<Real> & to, std::vector<Real> const & what, const Real & coeff) {
         assert(to.size() == what.size());
-        for (auto i = 0; i < what.size(); ++i) {
+        for (std::size_t i = 0; i < what.size(); ++i) {
             to[i] += coeff * what[i];
         }
     }
@@ -433,7 +433,7 @@ PTRef LRA_Interpolator::getInterpolant(icolor_t color) {
     std::vector<PTRef> interpolant_inequalities;
     std::vector<std::pair<PtAsgn, Real>> candidates;
     assert(explanations.size() == explanation_coeffs.size());
-    for (std::size_t i = 0; i < explanations.size(); ++i) {
+    for (int i = 0; i < explanations.size(); ++i) {
         assert(explanation_coeffs[i] > 0);
         candidates.emplace_back(explanations[i], explanation_coeffs[i]);
         trace(std::cout << "Explanation " << logic.printTerm(explanations[i].tr) << " with coeff "
@@ -500,7 +500,7 @@ PTRef LRA_Interpolator::getInterpolant(icolor_t color) {
         // rows correspond to local variables, columns correspond to explanations (inequalities)
 
         matrix_t matrix{local_vars.size()};
-        auto colInd = 0;
+        std::size_t colInd = 0;
         for (const auto & info : ineqs_local_vars) {
             // add coefficient to those rows whose corresponding variable occurs in the inequality
             for (auto const & term : info) {

--- a/src/tsolvers/lrasolver/LRA_Interpolator.cpp
+++ b/src/tsolvers/lrasolver/LRA_Interpolator.cpp
@@ -65,8 +65,6 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
     return res;
 }
 
-    void print_matrix(std::vector<std::vector<Real>> const & matrix);
-
     /**
      *
      * @param matrix
@@ -214,6 +212,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         return pivotColsBitMap;
     }
 
+#ifndef NDEBUG
     bool isReducedRowEchelonForm(std::vector<std::vector<Real>> const & matrix) {
         auto pivotColsBitMap = getPivotColsBitMap(matrix);
         auto cols = pivotColsBitMap.size();
@@ -238,6 +237,34 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         }
         return true;
     }
+
+    bool check_basis(std::vector<std::vector<FastRational>> const & basis) {
+        return std::all_of(basis.begin(), basis.end(), [](std::vector<Real> const & baseVec) {
+            return std::none_of(baseVec.begin(), baseVec.end(), [](const Real & el) { return el < 0; });
+        });
+    }
+
+    void print_matrix(std::vector<std::vector<Real>> const & matrix) {
+        for (auto const & row : matrix) {
+            for (auto const & elem : row) {
+                std::cout << elem << " ";
+            }
+            std::cout << '\n';
+        }
+        std::cout << '\n';
+    }
+
+    void print_basis(std::vector<std::vector<FastRational>> const & nullBasis) {
+        std::cout << "Basis: " << '\n';
+        for (auto const & base : nullBasis) {
+            for (auto const & elem : base) {
+                std::cout << elem << ' ';
+            }
+            std::cout << '\n';
+        }
+        std::cout << '\n';
+    }
+#endif // NDEBUG
 
     /** Given matrix in RREF computes and returns a basis of its null space
      *
@@ -331,33 +358,6 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
             first_unchecked_it = vec_with_neg_it;
         }
         return true;
-    }
-
-    bool check_basis(std::vector<std::vector<FastRational>> const & basis){
-        return std::all_of(basis.begin(), basis.end(), [](std::vector<Real> const & baseVec){
-            return std::none_of(baseVec.begin(), baseVec.end(), [](const Real& el){return el < 0;});
-        });
-    }
-
-    void print_matrix(std::vector<std::vector<Real>> const & matrix) {
-        for (auto const & row : matrix) {
-            for (auto const & elem : row) {
-                std::cout << elem << " ";
-            }
-            std::cout << '\n';
-        }
-        std::cout << '\n';
-    }
-
-    void print_basis(std::vector<std::vector<FastRational>> const & nullBasis) {
-        std::cout << "Basis: " << '\n';
-        for (auto const & base : nullBasis) {
-            for (auto const & elem : base) {
-                std::cout << elem << ' ';
-            }
-            std::cout << '\n';
-        }
-        std::cout << '\n';
     }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.0
+    GIT_TAG release-1.8.1
 )
 
 FetchContent_GetProperties(googletest)

--- a/test/unit/test_ArithmeticExpressions.cpp
+++ b/test/unit/test_ArithmeticExpressions.cpp
@@ -44,7 +44,6 @@ TEST_F(ArithmeticExpressions_test, test_Sum_Ignore_Zeros)
 
 TEST_F(ArithmeticExpressions_test, test_One_Arg_Multiplication)
 {
-    PTRef zero = logic.mkConst("0");
     PTRef two = logic.mkConst("2");
     PTRef one = logic.mkConst("1");
     PTRef a = logic.mkNumVar("a");
@@ -93,7 +92,6 @@ TEST_F(ArithmeticExpressions_test, test_Sum_Single_Arg_Nested)
 {
     PTRef a = logic.mkNumVar("a");
     PTRef two = logic.mkConst("2");
-    PTRef zero = logic.mkConst("0");
     PTRef times = logic.mkNumTimes(a,two);
     vec<PTRef> args;
     args.push(times);
@@ -121,7 +119,6 @@ TEST_F(ArithmeticExpressions_test, test_Simple_Leq)
     PTRef a = logic.mkNumVar("a");
     PTRef zero = logic.mkConst("0");
     PTRef res = logic.mkNumLeq(zero, a);
-    const Pterm& term = logic.getPterm(res);
     ASSERT_EQ(logic.getSymRef(res),logic.get_sym_Num_LEQ());
     ASSERT_EQ(logic.getPterm(res)[0], zero);
     ASSERT_EQ(logic.getPterm(res)[1], a);
@@ -133,7 +130,6 @@ TEST_F(ArithmeticExpressions_test, test_Simple_Leq_Two_Vars)
     PTRef b = logic.mkNumVar("b");
     PTRef zero = logic.mkConst("0");
     PTRef res = logic.mkNumLeq(b, a);
-    const Pterm& term = logic.getPterm(res);
     ASSERT_EQ(logic.getSymRef(res),logic.get_sym_Num_LEQ());
     ASSERT_EQ(logic.getPterm(res)[0], zero);
 }
@@ -144,7 +140,6 @@ TEST_F(ArithmeticExpressions_test, test_Simple_Leq_Two_Vars2)
     PTRef b = logic.mkNumVar("b");
     PTRef zero = logic.mkConst("0");
     PTRef res = logic.mkNumLeq(a, b);
-    const Pterm& term = logic.getPterm(res);
     ASSERT_EQ(logic.getSymRef(res),logic.get_sym_Num_LEQ());
     ASSERT_EQ(logic.getPterm(res)[0], zero);
 }
@@ -161,7 +156,6 @@ TEST_F(ArithmeticExpressions_test, test_mkNumNeg)
 
 TEST_F(ArithmeticExpressions_test, test_Inequality_Var_WithCoeff)
 {
-    PTRef one = logic.getTerm_NumOne();
     PTRef a = logic.mkNumVar("a");
     PTRef minus = logic.mkNumNeg(a);
     PTRef leq = logic.mkNumLeq(minus, a);

--- a/test/unit/test_LIACutSolver.cpp
+++ b/test/unit/test_LIACutSolver.cpp
@@ -46,9 +46,9 @@ TEST(LIACutSolver_test, test_computeEqualityBasis)
 
     LABoundStore bs(vs);
 
-    LABoundStore::BoundInfo y_minus_x_nostrict_m5 = bs.allocBoundPair(y_minus_x, -5, false);  // y - x + 5 <= 0
-    LABoundStore::BoundInfo two_x_minus_two_y_nostrict_m1 = bs.allocBoundPair(two_x_minus_two_y, -1, false);    // 2x - 2y + 1 <= 0
-    LABoundStore::BoundInfo minus_y_minus_ten_x_nostrict_m20  = bs.allocBoundPair(minus_y_minus_ten_x, -20, false);   // -y - 10x + 20 <= 0
+    //LABoundStore::BoundInfo y_minus_x_nostrict_m5 = bs.allocBoundPair(y_minus_x, -5, false);  // y - x + 5 <= 0
+    //LABoundStore::BoundInfo two_x_minus_two_y_nostrict_m1 = bs.allocBoundPair(two_x_minus_two_y, -1, false);    // 2x - 2y + 1 <= 0
+    //LABoundStore::BoundInfo minus_y_minus_ten_x_nostrict_m20  = bs.allocBoundPair(minus_y_minus_ten_x, -20, false);   // -y - 10x + 20 <= 0
 
     bs.buildBounds();
 

--- a/test/unit/test_Polynomial.cpp
+++ b/test/unit/test_Polynomial.cpp
@@ -67,8 +67,6 @@ TEST(Polynomial_test, test_Merge3){
     Polynomial poly2;
     LVRef x1 {4772};
     LVRef x2 {4776};
-    LVRef y1 {2604};
-    LVRef y2 {4624};
     poly1.addTerm(x1, 1);
     poly1.addTerm(x2, -2);
     poly2.addTerm(x2, 1);

--- a/test/unit/test_Simplex.cpp
+++ b/test/unit/test_Simplex.cpp
@@ -25,21 +25,22 @@ TEST(Simplex_test, test_ops_in_Simplex)
     LABoundStore bs(vs);
 
     LABoundStore::BoundInfo x_strict_0   = bs.allocBoundPair(x, 0, true); // x < 0 and x >= 0
-    LABoundStore::BoundInfo x_nostrict_0 = bs.allocBoundPair(x, 0, false); // x <= 0 and x > 0
     LABoundStore::BoundInfo y_strict_0   = bs.allocBoundPair(y, 0, true); // y < 0 and y >= 0
-    LABoundStore::BoundInfo y_nostrict_0 = bs.allocBoundPair(y, 0, false); // y <= 0 and y > 0
+//    LABoundStore::BoundInfo x_nostrict_0 = bs.allocBoundPair(x, 0, false); // x <= 0 and x > 0
+//    LABoundStore::BoundInfo y_nostrict_0 = bs.allocBoundPair(y, 0, false); // y <= 0 and y > 0
 
     LABoundStore::BoundInfo x_strict_1   = bs.allocBoundPair(x, 1, true); // x < 1 and x >= 1
     LABoundStore::BoundInfo x_nostrict_1 = bs.allocBoundPair(x, 1, false); // x <= 1 and x > 1
     LABoundStore::BoundInfo y_strict_1   = bs.allocBoundPair(y, 1, true); // y < 1 and y >= 1
     LABoundStore::BoundInfo y_nostrict_1 = bs.allocBoundPair(y, 1, false); // y <= 1 and y > 1
 
-    LABoundStore::BoundInfo y_minus_x_strict_0    = bs.allocBoundPair(y_minus_x, 0, true);    // y - x < 0 and y - x >= 0
     LABoundStore::BoundInfo y_minus_x_nostrict_0  = bs.allocBoundPair(y_minus_x, 0, false);   // y - x <= 0 and y - x > 0
-    LABoundStore::BoundInfo y_minus_x_strict_m1   = bs.allocBoundPair(y_minus_x, -1, true);   // y - x + 1 <  0
-    LABoundStore::BoundInfo y_minus_x_nostrict_m1 = bs.allocBoundPair(y_minus_x, -1, false);  // y - x + 1 <= 0
-    LABoundStore::BoundInfo y_minus_x_strict_1    = bs.allocBoundPair(y_minus_x, 1, true);    // y - x - 1 <  0
     LABoundStore::BoundInfo y_minus_x_nostrict_1  = bs.allocBoundPair(y_minus_x, 1, false);   // y - x - 1 <= 0
+    //LABoundStore::BoundInfo y_minus_x_strict_0    = bs.allocBoundPair(y_minus_x, 0, true);    // y - x < 0 and y - x >= 0
+    //LABoundStore::BoundInfo y_minus_x_strict_m1   = bs.allocBoundPair(y_minus_x, -1, true);   // y - x + 1 <  0
+    //LABoundStore::BoundInfo y_minus_x_nostrict_m1 = bs.allocBoundPair(y_minus_x, -1, false);  // y - x + 1 <= 0
+    //LABoundStore::BoundInfo y_minus_x_strict_1    = bs.allocBoundPair(y_minus_x, 1, true);    // y - x - 1 <  0
+
 
     bs.buildBounds();
 

--- a/test/unit/test_TheorySimplifications.cpp
+++ b/test/unit/test_TheorySimplifications.cpp
@@ -85,7 +85,7 @@ protected:
         vec<SRef> args;
         args.push(ufsort);
         args.push(ufsort);
-        f = logic.newSymb("f", args, nullptr);
+        f = logic.newSymb("f", args);
     }
     SMTConfig config;
     Logic logic;
@@ -162,7 +162,7 @@ protected:
         vec<SRef> args;
         args.push(ufsort);
         args.push(ufsort);
-        f = logic.newSymb("f", args, nullptr);
+        f = logic.newSymb("f", args);
     }
     SMTConfig config;
     Logic logic;


### PR DESCRIPTION
This PR enables checking of common types of compiler warnings for CI on Travis.
These warnings are treated as errors when compiling on CI server.
This will prevent introduction of new warnings to the source code as CI will fail.

Checking larger amount of compiler warnings (using -Wall) and treating them as errors (-Werror) is enabled only on CI and is not forced by cmake configuration.
The advantage is that the developer can focus on developing new feature without being constantly disturbed by the compiler when the code is still in a phase of active development.
The disadvantage is that when the new code is stable the developer must manually enable higher level of warnings (e.g. by setting CMAKE_CXX_FLAGS=-Wall) to clean the code and ensure it will pass CI.

To enable all this, the current code base have been cleaned up to fix the common type of warnings such as signed/unsigned comparison or unused variable, parameter, function.