### PR TITLE
Update in LRA decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ command
 $ mkdir build; cd build; cmake ..; make
 ```
 
+By default, OpenSMT is compiled without interpolation capabilities.  To enable interpolation, the cmake option `PRODUCE_PROOF` must be enabled. This can be done in the cmake configuration file
+`CMakeCache.txt` produced by `cmake` in your build directory or when configuring cmake from the command line:
+```
+$ cmake -DPRODUCE_PROOF=ON ..
+```
+
+With this option OpenSMT supports a range of interpolation options for propositional
+logic, linear real arithmetic, and uninterpreted functions with
+equality.
+
+### Changing build type
 The default build type is RELEASE. Different build type can be configured using cmake variable CMAKE_BUILD_TYPE. For example, to create a debug build use
 ```
 $ cmake -DCMAKE_BUILD_TYPE=Debug ..
@@ -42,16 +53,6 @@ tests.  These are available through
 
 ```
 $ ctest
-```
-
-## Using OpenSMT2 interpolation
-
-OpenSMT supports a range of interpolation options for propositional
-logic, linear real arithmetic, and uninterpreted functions with
-equality.  To enable interpolation code the option `PRODUCE_PROOF` must be enabled. This can be done in the cmake configuration file
-`CMakeCache.txt` produced by `cmake` in your build directory or when configuring cmake from the command line:
-```
-$ cmake -DPRODUCE_PROOF=ON ..
 ```
 
 ## Installing OpenSMT2

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ command
 $ mkdir build; cd build; cmake ..; make
 ```
 
+The default build type is RELEASE. Different build type can be configured using cmake variable CMAKE_BUILD_TYPE. For example, to create a debug build use
+```
+$ cmake -DCMAKE_BUILD_TYPE=Debug ..
+```
+
+
 ## Unit tests
 
 If you have cmake version 3.11, the build system will construct unit
@@ -42,9 +48,21 @@ $ ctest
 
 OpenSMT supports a range of interpolation options for propositional
 logic, linear real arithmetic, and uninterpreted functions with
-equality.  To enable interpolation code the compilation needs to be
-configured by enabling `PRODUCE_PROOF` in the cmake configuration file
-`CMakeCache.txt` produced by `cmake` in your build directory.
+equality.  To enable interpolation code the option `PRODUCE_PROOF` must be enabled. This can be done in the cmake configuration file
+`CMakeCache.txt` produced by `cmake` in your build directory or when configuring cmake from the command line:
+```
+$ cmake -DPRODUCE_PROOF=ON ..
+```
+
+## Installing OpenSMT2
+After a successful build, an executable, a static library, and a shared library are created.
+The path to the executable is `<BUILD_DIR>/src/bin/opensmt`, the libraries are located in `<BUILD_DIR>/src/api`.
+To install OpenSMT in your system simply run
+```
+$ make install
+```
+The install directory can be customized using cmake variable CMAKE_INSTALL_PREFIX. The default is `/usr/local`.
+This installs the library in the folder `<INSTALL_DIR>/lib` and puts the necessary header files in the folder `<INSTALL_DIR>/include/opensmt`.
 
 If you have questions please mail them to me at
 antti.hyvarinen@gmail.com, or to the discussion forum!

--- a/regression_itp/dec-far2.smt2
+++ b/regression_itp/dec-far2.smt2
@@ -1,0 +1,16 @@
+(set-logic QF_LRA)
+(set-option :produce-interpolants true)
+(set-option :interpolation-lra-algorithm 4) ; decomposed Farkas
+(declare-fun x1 () Real)
+(declare-fun x2 () Real)
+(declare-fun x3 () Real)
+(declare-fun x4 () Real)
+(declare-fun x5 () Real)
+
+(assert (!(and (<= 0 (+ x1  x2 ))  (<= 0  (+ (- x1) x3)) (<= 0 (+ x1 x4)) (<= 0 (+ (- x1) x5)) ) :named A))
+(assert (!(<= 1 (+ (* (- 1) x2 ) ( * (- 1) x3 )  (* (- 1) x4 ) (* (- 1) x5 ))) :named B))
+(check-sat)
+(get-interpolants A B)
+
+
+

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -837,13 +837,15 @@ void SimplifyConstTimes::constSimplify(const SymRef& s, const vec<PTRef>& terms,
         terms_new.push(con);
     else
     {
-        Pterm& p = l.getPterm(plus);
         vec<PTRef> sum_args;
-        for(int i = 0; i < p.size(); ++i)
+        int termSize = l.getPterm(plus).size();
+        for(int i = 0; i < termSize; ++i)
         {
             vec<PTRef> times_args;
             times_args.push(con);
-            times_args.push(p[i]);
+            // MB: we cannot use Pterm& here, because in the line after next new term might be allocated, which might
+            //     trigger reallocation of the table of terms
+            times_args.push(l.getPterm(plus)[i]);
             sum_args.push(l.mkNumTimes(times_args));
         }
         terms_new.push(l.mkNumPlus(sum_args));

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -749,7 +749,6 @@ PTRef LALogic::mkConst(SRef s, const char* name)
 void SimplifyConst::simplify(const SymRef& s, const vec<PTRef>& args, SymRef& s_new, vec<PTRef>& args_new, char** msg)
 {
     vec<int> const_idx;
-    vec<PTRef> args_new_2;
     for (int i = 0; i < args.size(); i++) {
         assert(!l.isNumNeg(args[i])); // MB: No minus nodes, the check can be simplified
         if (l.isConstant(args[i]))
@@ -769,18 +768,23 @@ void SimplifyConst::simplify(const SymRef& s, const vec<PTRef>& args, SymRef& s_
                 printf("%s\n", *msg);
                 assert(false);
             }
-            int i, j, k;
-            for (i = j = k = 0; i < args.size() && k < const_terms.size(); i++) {
-                if (i != const_idx[k]) args_new_2.push(args[i]);
-                else k++;
+            vec<PTRef> args_new_2;
+            args_new_2.capacity((args.size() - const_terms.size()) + 1);
+            int i, k;
+            for (i = k = 0; k < const_terms.size(); i++) {
+                if (i != const_idx[k]) { args_new_2.push(args[i]); }
+                else { k++; }
             }
             // Copy also the rest
-            for (; i < args.size(); i++)
+            for (; i < args.size(); i++) {
                 args_new_2.push(args[i]);
+            }
             args_new_2.push(tr);
-        } else
-            args.copyTo(args_new_2);
-        constSimplify(s, args_new_2, s_new, args_new);
+            constSimplify(s, args_new_2, s_new, args_new);
+        } else {
+            constSimplify(s, args, s_new, args_new);
+        }
+
     }
 //    // A single argument for the operator, and the operator is identity
 //    // in that case

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -814,11 +814,9 @@ void SimplifyConstSum::constSimplify(const SymRef& s, const vec<PTRef>& terms, S
 }
 void SimplifyConstTimes::constSimplify(const SymRef& s, const vec<PTRef>& terms, SymRef& s_new, vec<PTRef>& terms_new) const
 {
-    //distribute the constant over the first sum
-    int i;
     PTRef con, plus;
     con = plus = PTRef_Undef;
-    for (i = 0; i < terms.size(); i++) {
+    for (int i = 0; i < terms.size(); i++) {
         if (l.isNumZero(terms[i])) {
             terms_new.clear();
             s_new = l.getPterm(l.getTerm_NumZero()).symb();
@@ -841,6 +839,8 @@ void SimplifyConstTimes::constSimplify(const SymRef& s, const vec<PTRef>& terms,
         terms_new.push(con);
     else
     {
+        assert(con != PTRef_Undef && plus != PTRef_Undef);
+        //distribute the constant over the sum
         vec<PTRef> sum_args;
         int termSize = l.getPterm(plus).size();
         for(int i = 0; i < termSize; ++i)

--- a/src/parsers/smt2new/CMakeLists.txt
+++ b/src/parsers/smt2new/CMakeLists.txt
@@ -8,8 +8,8 @@
 
 add_library(parsers OBJECT "")
 
-find_package(BISON 2.7)
-find_package(FLEX)
+find_package(BISON 3.0 REQUIRED)
+find_package(FLEX REQUIRED)
 
 BISON_TARGET(smt2newParser smt2newparser.yy ${CMAKE_CURRENT_BINARY_DIR}/smt2newparser.cc)
 FLEX_TARGET(smt2newScanner smt2newlexer.ll ${CMAKE_CURRENT_BINARY_DIR}/smt2newlexer.cc)

--- a/src/tsolvers/lrasolver/LRA_Interpolator.cc
+++ b/src/tsolvers/lrasolver/LRA_Interpolator.cc
@@ -215,7 +215,7 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         return pivotColsBitMap;
     }
 
-#ifndef NDEBUG
+#ifndef NDEBUG // ======== DEBUG METHODS ================
     bool isReducedRowEchelonForm(std::vector<std::vector<Real>> const & matrix) {
         auto pivotColsBitMap = getPivotColsBitMap(matrix);
         auto cols = pivotColsBitMap.size();
@@ -269,7 +269,21 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
         }
         std::cout << '\n';
     }
-#endif // NDEBUG
+
+    bool isDecomposition(Basis const & basis, Coordinates const & coordinates, std::vector<Real> const & original) {
+        assert(coordinates.size() == basis.size());
+        assert(std::all_of(basis.begin(), basis.end(),
+                           [&original](std::vector<Real> const & baseVec) { return baseVec.size() == original.size(); }));
+        for (std::size_t i = 0; i < original.size(); ++i) {
+            Real sum = 0;
+            for (std::size_t j = 0; j < basis.size(); ++j) {
+                sum += basis[j][i] * coordinates[j];
+            }
+            if (sum != original[i]) { return false; }
+        }
+        return true;
+    }
+#endif // NDEBUG // ======== DEBUG METHODS ================
 
     /** Given matrix in RREF computes and returns a basis of its null space
      *
@@ -365,20 +379,6 @@ std::vector<LinearTerm> getLocalTerms(ItpHelper const & helper, std::function<bo
 //        }
 //        return true;
 //    }
-
-    bool isDecomposition(Basis const & basis, Coordinates const & coordinates, std::vector<Real> const& original) {
-        assert(coordinates.size() == basis.size());
-        assert(std::all_of(basis.begin(), basis.end(),
-                [&original](std::vector<Real> const& baseVec) { return baseVec.size() == original.size(); }));
-        for (std::size_t i = 0; i < original.size(); ++i) {
-            Real sum = 0;
-            for(std::size_t j = 0; j < basis.size(); ++j) {
-                sum += basis[j][i] * coordinates[j];
-            }
-            if (sum != original[i]) { return false; }
-        }
-        return true;
-    }
 
 
     PTRef sumInequalities(std::vector<ItpHelper> const & ineqs, std::vector<Real> const & coeffs, LALogic & logic) {


### PR DESCRIPTION
This PR contains the implementation of complete algorithm for computing decomposition of the vector of Farkas coefficients based on the basis of the kernel of the matrix of coefficients of A-local  variables.
Additionaly, it contains 2 hotfixes: Increasing the version of BISON required for compilation and fixing an incorrect use of Pterm& instead of PTRef.
I also modified the code of SimplifyConst::simplify a little bit to avoid unnecessary copying of vector of arguments.

