### PR TITLE
Small fixes of memory leaks

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -832,7 +832,7 @@ bool Interpret::declareFun(ASTNode& n) // (const char* fname, const vec<SRef>& a
     char* name = buildSortName(ret_node);
 
     if (logic->containsSort(name)) {
-        SRef sr = newSort(ret_node);
+        SRef sr = logic->getSortRef(name);
         args.push(sr);
         free(name);
     } else {
@@ -879,7 +879,7 @@ bool Interpret::declareConst(ASTNode& n) //(const char* fname, const SRef ret_so
     char* name = buildSortName(ret_node);
     SRef ret_sort;
     if (logic->containsSort(name)) {
-        ret_sort = newSort(ret_node);
+        ret_sort = logic->getSortRef(name);
         free(name);
     } else {
         notify_formatted(true, "Failed to declare constant %s", fname);
@@ -932,7 +932,7 @@ bool Interpret::defineFun(const ASTNode& n)
     char* rsort_name = buildSortName(ret_node);
     SRef ret_sort;
     if (logic->containsSort(rsort_name)) {
-        ret_sort = newSort(ret_node);
+        ret_sort = logic->getSortRef(rsort_name);
         free(rsort_name);
     } else {
         notify_formatted(true, "Unknown return sort %s of %s", rsort_name, fname);

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1109,8 +1109,9 @@ bool Logic::isLit(PTRef tr) const
 
 SRef Logic::declareSort(const char* id, char** msg)
 {
-    if (containsSort(id))
+    if (containsSort(id)) {
         return getSortRef(id);
+    }
 
     IdRef idr = id_store.newIdentifier(id);
     vec<SRef> tmp;

--- a/src/logics/Theory.cc
+++ b/src/logics/Theory.cc
@@ -300,21 +300,6 @@ Theory::printFramesAsQuery(const vec<PFRef> & frames, std::ostream & s)
 }
 
 //MOVINGFROMHEADER
-
-void PushFrameAllocator::moveTo(PushFrameAllocator& to) {
-    to.id_counter = id_counter;
-    RegionAllocator<uint32_t>::moveTo(to); }
-PFRef PushFrameAllocator::alloc()
-{
-    uint32_t v = RegionAllocator<uint32_t>::alloc(sizeof(PushFrame));
-    PFRef r = {v};
-    new (lea(r)) PushFrame(id_counter++);
-    return r;
-}
-PushFrame& PushFrameAllocator::operator[](PFRef r) { return (PushFrame&)RegionAllocator<uint32_t>::operator[](r.x); }
-PushFrame* PushFrameAllocator::lea       (PFRef r) { return (PushFrame*)RegionAllocator<uint32_t>::lea(r.x); }
-PFRef      PushFrameAllocator::ael       (const PushFrame* t) { RegionAllocator<uint32_t>::Ref r = RegionAllocator<uint32_t>::ael((uint32_t*)t); return { r }; }
-
 void Theory::setSubstitutions(Map<PTRef,PtAsgn,PTRefHash>& substs) { getTSolverHandler().setSubstitutions(substs); }
 vec<DedElem>& Theory::getDeductionVec()   { return deductions; }
 

--- a/src/tsolvers/lasolver/LABounds.cc
+++ b/src/tsolvers/lasolver/LABounds.cc
@@ -13,7 +13,8 @@ LABoundRef LABoundAllocator::alloc(BoundT type, LVRef var, const Delta& delta)
 {
     uint32_t v = RegionAllocator<uint32_t>::alloc(laboundWord32Size());
     LABoundRef id = {v};
-    new (lea(id)) LABound(type, var, delta, n_bounds++);
+    new (lea(id)) LABound(type, var, delta, static_cast<int>(allocatedBounds.size()));
+    allocatedBounds.push_back(id);
     return id;
 }
 
@@ -216,15 +217,6 @@ char* LABoundStore::printBounds(LVRef v) const
 
 
 
-
-int LABoundAllocator::laboundWord32Size() {
-    return (sizeof(LABound)) / sizeof(uint32_t); }
-
-inline unsigned LABoundAllocator::getNumBounds() const { return n_bounds; }
-
-inline LABound*       LABoundAllocator::lea       (LABoundRef r)       { return (LABound*)RegionAllocator<uint32_t>::lea(r.x); }
-inline const LABound* LABoundAllocator::lea       (LABoundRef r) const { return (LABound*)RegionAllocator<uint32_t>::lea(r.x); }
-inline LABoundRef     LABoundAllocator::ael       (const LABound* t)   { RegionAllocator<uint32_t>::Ref r = RegionAllocator<uint32_t>::ael((uint32_t*)t); LABoundRef rf; rf.x = r; return rf; }
 
 inline bool           LABoundList::reloced   ()                 const { return reloc; }
 inline LABoundListRef LABoundList::relocation()                 const { return reloc_target; }


### PR DESCRIPTION
Fixes for 3 sources of possible memory leaks:

- Dealing with sorts in the Interpreter
- Allocators inheriting from RegionAllocator allocating objects possibly containing pointers to dynamically allocated data. This includes PushFrameAllocator and LABoundAllocator.

The fix for allocators is done by remembering references to allocated objects and then destructing  them properly when needed.

Fixes #69 and #70 