### PR TITLE
Small fixes to incrementality frontend

### DIFF
--- a/regression/generic/pre-logic.smt2.expected.out
+++ b/regression/generic/pre-logic.smt2.expected.out
@@ -1,3 +1,14 @@
+success
+success
+success
+success
+success
+success
+success
+success
+success
+success
+success
 true
 quux
 Longer story
@@ -12,6 +23,11 @@ Longer story
 ( foo string 10 4075 1.23 2 ( ( ) bar ( :keyword ) ) )
 (error "No value for attr :non-existing-option")
 
+success
+success
+success
+success
+success
 (error "no value for info :foo")
 
 :error-behavior commit-adultery

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -1119,7 +1119,7 @@ int Interpret::interpFile(char *content){
     return rval;
 }
 
-/*
+
 // For reading from pipe
 int Interpret::interpPipe() {
 
@@ -1192,7 +1192,6 @@ int Interpret::interpPipe() {
     free(buf);
     return 0;
 }
-*/
 
 // For reading with readline.
 int Interpret::interpInteractive(FILE*) {

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -1126,7 +1126,6 @@ int Interpret::interpPipe() {
     int buf_sz  = 16;
     char* buf   = (char*) malloc(sizeof(char)*buf_sz);
     int rd_head = 0;
-    int rd_idx  = 0;
 
     bool done  = false;
     buf[0] = '\0';

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -275,6 +275,7 @@ void Interpret::interp(ASTNode& n) {
                         throw std::logic_error{"Unreachable code - error in logic selection"};
 
                 };
+                notify_success();
             }
             break;
         }
@@ -286,6 +287,7 @@ void Interpret::interp(ASTNode& n) {
             }
 
             setInfo(**(n.children->begin()));
+            notify_success();
             break;
         }
         case t_getinfo:
@@ -306,6 +308,7 @@ void Interpret::interp(ASTNode& n) {
             }
 
             setOption(**(n.children->begin()));
+            notify_success();
             break;
         }
         case  t_getoption:
@@ -479,14 +482,18 @@ void Interpret::interp(ASTNode& n) {
         }
         case t_push:
         {
-            if(!parse_only)
+            if(!parse_only){
                 push();
+                notify_success();
+            }
             break;
         }
         case t_pop:
         {
-            if(!parse_only)
+            if(!parse_only) {
                 pop();
+                notify_success();
+            }
             break;
         }
         case t_exit:
@@ -1077,8 +1084,9 @@ void Interpret::notify_formatted(bool error, const char* fmt_str, ...) {
 }
 
 void Interpret::notify_success() {
-    if (config.printSuccess())
-        cout << "success" << endl;
+    if (config.printSuccess()) {
+        std::cout << "success" << std::endl;
+    }
 }
 
 void Interpret::execute(const ASTNode* r) {

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,11 +1,5 @@
 add_executable(exec opensmt.cc)
 
-#get the sha1 of the last commit in git (current HEAD) and store it in a variable
-execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE GIT_SHA1 OUTPUT_STRIP_TRAILING_WHITESPACE)
-#message(${GIT_SHA1}) 
-
-target_compile_definitions(exec PRIVATE GIT_SHA1="${GIT_SHA1}")
-
 target_link_libraries(exec api_static)
 
 set_target_properties(exec PROPERTIES OUTPUT_NAME opensmt)

--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -72,8 +72,6 @@ int main( int argc, char * argv[] )
     cerr << "; this binary is compiled in debug mode (slow)" << endl;
 #endif
 
-    cerr << "; git hash: " << GIT_SHA1 << endl;
-
   // Accepts file from stdin if nothing specified
     FILE * fin = NULL;
     int opt;

--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -77,7 +77,8 @@ int main( int argc, char * argv[] )
     int opt;
 
     SMTConfig c;
-    while ((opt = getopt(argc, argv, "hdr:")) != -1) {
+    bool pipe = false;
+    while ((opt = getopt(argc, argv, "hdpr:")) != -1) {
         switch (opt) {
 
             case 'h':
@@ -93,6 +94,9 @@ int main( int argc, char * argv[] )
                 else
                     fprintf(stderr, "; Using random seed %d\n", atoi(optarg));
                 break;
+            case 'p':
+                pipe = true;
+                break;
             default: /* '?' */
                 fprintf(stderr, "Usage:\n\t%s [-d] [-h] [-r seed] filename [...]\n",
                         argv[0]);
@@ -103,9 +107,14 @@ int main( int argc, char * argv[] )
     Interpret interpreter(c);
 
     if (argc - optind == 0) {
-        fin = stdin;
         c.setInstanceName("stdin");
-        interpreter.interpInteractive(fin);
+        if (pipe) {
+            interpreter.interpPipe();
+        }
+        else {
+            fin = stdin;
+            interpreter.interpInteractive(fin);
+        }
     }
     else {
         for (int i = optind; i < argc; i++) {


### PR DESCRIPTION
Added success notification message to multiple Interpreter commands where it was missing.
Added a command line option to use front-end in pipe-like manner, since the behaviour of the readline library is not compatible with the trace executor of SMT-COMP in the incremental track.

Also, the printing of git commit hash been removed, as nobody is really using it and (hopefully) we will have a proper release versioning soon.