### PR TITLE
Optimizations aiming at improving incremental mode.

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -123,10 +123,6 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
         const PushFrame & frame = pfstore[frames.getFrameReference(i)];
         PTRef root = frame.root;
 
-        if (logic.isFalse(root)) {
-            giveToSolver(getLogic().getTerm_false(), frame.getId());
-            return status = s_False;
-        }
 #ifdef PRODUCE_PROOF
         assert(frame.substs == logic.getTerm_true());
         vec<PTRef> const & flas =  frame.formulas;
@@ -147,6 +143,10 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
             }
         }
 #else // PRODUCE_PROOF
+        if (logic.isFalse(root)) {
+            giveToSolver(getLogic().getTerm_false(), frame.getId());
+            return status = s_False;
+        }
         FContainer fc(root);
 
         // Optimize the dag for cnfization

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -177,11 +177,6 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
 // term appears as a child in more than one term, we will not flatten
 // that structure.
 //
-void MainSolver::computeIncomingEdges(PTRef tr, Map<PTRef,int,PTRefHash>& PTRefToIncoming)
-{
-    ::computeIncomingEdges(logic, tr, PTRefToIncoming);
-}
-
 PTRef MainSolver::rewriteMaxArity(PTRef root)
 {
     return ::rewriteMaxArityClassic(logic, root);

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -121,7 +121,6 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
         getTheory().simplify(frames.getFrameReferences(), i);
         frames.setSimplifiedUntil(i + 1);
         const PushFrame & frame = pfstore[frames.getFrameReference(i)];
-        PTRef root = frame.root;
 
 #ifdef PRODUCE_PROOF
         assert(frame.substs == logic.getTerm_true());
@@ -143,6 +142,7 @@ sstat MainSolver::simplifyFormulas(char** err_msg)
             }
         }
 #else // PRODUCE_PROOF
+        PTRef root = frame.root;
         if (logic.isFalse(root)) {
             giveToSolver(getLogic().getTerm_false(), frame.getId());
             return status = s_False;

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -128,7 +128,6 @@ class MainSolver
 
     FContainer simplifyEqualities(vec<PtChild>& terms);
 
-    void computeIncomingEdges(PTRef tr, Map<PTRef,int,PTRefHash>& PTRefToIncoming);
     PTRef rewriteMaxArity(PTRef);
 
     FContainer root_instance; // Contains the root of the instance once simplifications are done

--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -41,6 +41,7 @@ Cnfizer::Cnfizer ( SMTConfig       &config_
     , logic    (logic_)
     , tmap     (tmap)
     , s_empty  (true)
+    , alreadyAsserted(logic.getTerm_true())
 {
     frame_terms.push(logic.getTerm_true()); // frame 0 does not have a var
     frame_term = frame_terms[0];
@@ -585,10 +586,11 @@ lbool Cnfizer::getTermValue (PTRef tr) const
 }
 
 bool Cnfizer::Cache::contains(PTRef term, PTRef frame_term) {
-    return this->cache.find(std::make_pair<>(term, frame_term)) != this->cache.end();
+    return cache.find(std::make_pair<>(term, frame_term)) != cache.end()
+        || ( frame_term != zeroLevelTerm && cache.find(std::make_pair<>(term, zeroLevelTerm)) != cache.end());
 }
 
 void Cnfizer::Cache::insert(PTRef term, PTRef frame_term) {
     assert(!contains(term, frame_term));
-    this->cache.insert(std::make_pair<>(term, frame_term));
+    cache.insert(std::make_pair<>(term, frame_term));
 }

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -53,9 +53,11 @@ protected:
     bool                s_empty;
 
     class Cache {
+        PTRef zeroLevelTerm;
         using CacheEntry = std::pair<PTRef, PTRef>;
         std::unordered_set<CacheEntry, PTRefPairHash > cache;
     public:
+        Cache(PTRef zeroLevelTerm): zeroLevelTerm(zeroLevelTerm) {}
         bool contains(PTRef term, PTRef frame_term);
         void insert(PTRef term, PTRef frame_term);
     };

--- a/src/cnfizers/Tseitin.h
+++ b/src/cnfizers/Tseitin.h
@@ -44,6 +44,7 @@ public:
                 , logic_
                 , tmap_
                 , solver_ )
+        , alreadyCnfized(logic_.getTerm_true())
       {}
 
     ~Tseitin( ) { }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -761,6 +761,7 @@ PTRef Logic::mkAnd(vec<PTRef>& args) {
     if (args.size() == 0) { return getTerm_true(); }
     // Remove duplicates
     vec<PtAsgn> tmp_args;
+    tmp_args.capacity(args.size());
     for (int i = 0; i < args.size(); i++) {
         if (!hasSortBool(args[i])) {
             return PTRef_Undef;
@@ -771,7 +772,7 @@ PTRef Logic::mkAnd(vec<PTRef>& args) {
             tmp_args.push(PtAsgn(args[i], l_True));
         }
     }
-    sort(tmp_args, LessThan_PtAsgn());
+    std::sort(tmp_args.begin(), tmp_args.end(), LessThan_PtAsgn());
     int i, j;
     PtAsgn p = PtAsgn_Undef;
     for (i = 0, j = 0; i < tmp_args.size(); i++) {
@@ -794,6 +795,7 @@ PTRef Logic::mkAnd(vec<PTRef>& args) {
         return tmp_args[0].sgn == l_True ? tmp_args[0].tr : mkNot(tmp_args[0].tr);
     }
     vec<PTRef> newargs;
+    newargs.capacity(tmp_args.size());
     for (int k = 0; k < tmp_args.size(); k++) {
         newargs.push(tmp_args[k].sgn == l_True ? tmp_args[k].tr : mkNot(tmp_args[k].tr));
     }
@@ -804,6 +806,7 @@ PTRef Logic::mkOr(vec<PTRef>& args) {
     if (args.size() == 0) { return getTerm_false(); }
     // Remove duplicates
     vec<PtAsgn> tmp_args;
+    tmp_args.capacity(args.size());
     for (int i = 0; i < args.size(); i++) {
         if (!hasSortBool(args[i])) {
             return PTRef_Undef;
@@ -814,7 +817,7 @@ PTRef Logic::mkOr(vec<PTRef>& args) {
             tmp_args.push(PtAsgn(args[i], l_True));
         }
     }
-    sort(tmp_args, LessThan_PtAsgn());
+    std::sort(tmp_args.begin(), tmp_args.end(), LessThan_PtAsgn());
     int i, j;
     PtAsgn p = PtAsgn_Undef;
     for (i = 0, j = 0; i < tmp_args.size(); i++) {
@@ -837,6 +840,7 @@ PTRef Logic::mkOr(vec<PTRef>& args) {
         return tmp_args[0].sgn == l_True ? tmp_args[0].tr : mkNot(tmp_args[0].tr);
     }
     vec<PTRef> newargs;
+    newargs.capacity(tmp_args.size());
     for (int k = 0; k < tmp_args.size(); k++) {
         newargs.push(tmp_args[k].sgn == l_True ? tmp_args[k].tr : mkNot(tmp_args[k].tr));
     }

--- a/src/pterms/PtStructs.cc
+++ b/src/pterms/PtStructs.cc
@@ -14,8 +14,6 @@ uint32_t PtAsgnHash::operator () (const PtAsgn& s) const {
 
 bool LessThan_PTRef::operator () (PTRef& x, PTRef& y) { return x.x < y.x; }
 
-bool LessThan_PtAsgn::operator () (PtAsgn& x, PtAsgn& y) { return x.tr.x < y.tr.x; }
-
 
 ValPair::~ValPair() {
     if (val != NULL)

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -70,7 +70,9 @@ struct LessThan_PTRef {
 };
 
 struct LessThan_PtAsgn {
-    bool operator () (PtAsgn& x, PtAsgn& y);// { return x.tr.x < y.tr.x; }
+    bool operator () (PtAsgn x, PtAsgn y) {
+        return x.tr.x < y.tr.x;
+    }
 };
 
 class ValPair

--- a/src/simplifiers/BoolRewriting.cc
+++ b/src/simplifiers/BoolRewriting.cc
@@ -16,60 +16,55 @@
 // term appears as a child in more than one term, we will not flatten
 // that structure.
 //
-void computeIncomingEdges(const Logic& logic, PTRef tr, Map<PTRef,int,PTRefHash>& PTRefToIncoming)
+void computeIncomingEdges(const Logic& logic, PTRef root, std::unordered_map<PTRef,int,PTRefHash>& PTRefToIncoming)
 {
-    class pi {
-    public:
-        PTRef x;
-        bool done;
-        pi(PTRef x_) : x(x_), done(false) {}
-    };
-
-    assert(tr != PTRef_Undef);
-    vec<pi*> unprocessed_ptrefs;
-    unprocessed_ptrefs.push(new pi(tr));
+    assert(root != PTRef_Undef);
+    auto size = Idx(logic.getPterm(root).getId()) + 1;
+    std::vector<char> done;
+    done.resize(size, 0);
+    vec<PTRef> unprocessed_ptrefs;
+    unprocessed_ptrefs.push(root);
     while (unprocessed_ptrefs.size() > 0) {
-        pi* pi_ptr = unprocessed_ptrefs.last();
-        if (PTRefToIncoming.has(pi_ptr->x)) {
-            PTRefToIncoming[pi_ptr->x]++;
+        PTRef current = unprocessed_ptrefs.last();
+        auto it = PTRefToIncoming.find(current);
+        if (it != PTRefToIncoming.end()) {
+            it->second++;
             unprocessed_ptrefs.pop();
-            delete pi_ptr;
             continue;
         }
         bool unprocessed_children = false;
-        if (logic.isBooleanOperator(pi_ptr->x) && pi_ptr->done == false) {
-            const Pterm& t = logic.getPterm(pi_ptr->x);
+        if (logic.isBooleanOperator(current) && done[Idx(logic.getPterm(current).getId())] == 0) {
+            const Pterm& t = logic.getPterm(current);
             for (int i = 0; i < t.size(); i++) {
                 // push only unprocessed Boolean operators
-                if (!PTRefToIncoming.has(t[i])) {
-                    unprocessed_ptrefs.push(new pi(t[i]));
+                auto itChild = PTRefToIncoming.find(t[i]);
+                if (itChild == PTRefToIncoming.end()) {
+                    unprocessed_ptrefs.push(t[i]);
                     unprocessed_children = true;
                 } else {
-                    PTRefToIncoming[t[i]]++;
+                    itChild->second++;
                 }
             }
-            pi_ptr->done = true;
+            done[Idx(logic.getPterm(current).getId())] = 1;
         }
         if (unprocessed_children)
             continue;
 
         unprocessed_ptrefs.pop();
-        // All descendants of pi_ptr->x are processed
-        assert(logic.isBooleanOperator(pi_ptr->x) || logic.isAtom(pi_ptr->x));
-        assert(!PTRefToIncoming.has(pi_ptr->x));
-        PTRefToIncoming.insert(pi_ptr->x, 1);
-        delete pi_ptr;
+        assert(logic.isBooleanOperator(current) || logic.isAtom(current));
+        PTRefToIncoming.insert(std::make_pair(current, 1));
     }
 }
 
 PTRef rewriteMaxArityClassic(Logic & logic, PTRef root) {
-    Map<PTRef,int,PTRefHash> PTRefToIncoming;
+    std::unordered_map<PTRef,int,PTRefHash> PTRefToIncoming;
     computeIncomingEdges(logic, root, PTRefToIncoming);
     return rewriteMaxArity(logic, root,
             [&PTRefToIncoming](PTRef candidate)
             {
-                assert(PTRefToIncoming.has(candidate) && PTRefToIncoming[candidate] >= 1);
-                return PTRefToIncoming[candidate] > 1;
+                auto it = PTRefToIncoming.find(candidate);
+                assert(it != PTRefToIncoming.end() && it->second >= 1);
+                return it->second > 1;
             });
 }
 
@@ -106,7 +101,7 @@ PtLit decomposeLiteral(const Logic & logic, PTRef lit) {
 }
 
 PTRef _simplifyUnderAssignment(Logic & logic, PTRef root,
-                               const Map<PTRef, int, PTRefHash> & PTRefToIncoming,
+                               const std::unordered_map<PTRef, int, PTRefHash> & PTRefToIncoming,
                                std::vector<PtLit> assignment,
                                Map<PTRef, PTRef, PTRefHash> & cache
 ) {
@@ -126,9 +121,10 @@ PTRef _simplifyUnderAssignment(Logic & logic, PTRef root,
             literals.push_back(term[i]);
             continue;
         }
-        assert(PTRefToIncoming.has(term[i]));
-        assert(PTRefToIncoming[term[i]] >= 1);
-        if (PTRefToIncoming[term[i]] > 1) {
+        auto it = PTRefToIncoming.find(term[i]);
+        assert(it != PTRefToIncoming.end());
+        assert(it->second >= 1);
+        if (it->second > 1) {
             non_owning_children.push_back(term[i]);
         }
         else{
@@ -176,7 +172,7 @@ PTRef _simplifyUnderAssignment(Logic & logic, PTRef root,
 }
 
 PTRef simplifyUnderAssignment(Logic & logic, PTRef root) {
-    Map<PTRef, int, PTRefHash> incomingEdges;
+    std::unordered_map<PTRef, int, PTRefHash> incomingEdges;
     ::computeIncomingEdges(logic, root, incomingEdges);
     Map<PTRef, PTRef, PTRefHash> cache;
     return _simplifyUnderAssignment(logic, root, incomingEdges, {},  cache);

--- a/src/simplifiers/BoolRewriting.h
+++ b/src/simplifiers/BoolRewriting.h
@@ -12,7 +12,7 @@
 
 class Logic;
 
-void computeIncomingEdges(const Logic& logic, PTRef tr, Map<PTRef,int,PTRefHash>& PTRefToIncoming);
+void computeIncomingEdges(const Logic& logic, PTRef tr, std::unordered_map<PTRef,int,PTRefHash>& PTRefToIncoming);
 
 PTRef rewriteMaxArityAggresive(Logic & logic, PTRef root);
 

--- a/src/simplifiers/BoolRewriting.h
+++ b/src/simplifiers/BoolRewriting.h
@@ -37,15 +37,7 @@ PTRef mergeAndOrArgs(Logic & logic, PTRef tr, Map<PTRef,PTRef,PTRefHash>& cache,
     for (int i = 0; i < t.size(); i++) {
         PTRef subst = cache[t[i]];
         changed |= (subst != t[i]);
-        if (logic.getSymRef(t[i]) != sr) {
-            new_args.push(subst);
-            continue;
-        }
-        if (doNotMerge(t[i])) {
-            new_args.push(subst);
-            continue;
-        }
-        if (logic.getSymRef(subst) == sr) {
+        if (logic.getSymRef(subst) == sr && !doNotMerge(t[i])) {
             changed = true;
             const Pterm& substs_t = logic.getPterm(subst);
             for (int j = 0; j < substs_t.size(); j++)
@@ -77,12 +69,15 @@ PTRef rewriteMaxArity(Logic & logic, const PTRef root, T doNotRewrite) {
         bool unprocessed_children = false;
         const Pterm& t = logic.getPterm(tr);
         for (int i = 0; i < t.size(); i++) {
-            if (logic.isBooleanOperator(t[i]) && !cache.has(t[i])) {
+            if (cache.has(t[i])) { continue; }
+            if (logic.isBooleanOperator(t[i])) {
                 unprocessed_ptrefs.push(t[i]);
                 unprocessed_children = true;
             }
-            else if (logic.isAtom(t[i]))
+            else if (logic.isAtom(t[i])) {
+                assert(!cache.has(t[i]));
                 cache.insert(t[i], t[i]);
+            }
         }
         if (unprocessed_children)
             continue;

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -2201,6 +2201,9 @@ lbool CoreSMTSolver::solve_()
 {
 //    opensmt::PrintStopWatch watch("solve time", cerr);
 
+    for (Lit l : this->assumptions) {
+        this->addVar_(var(l));
+    }
     this->clausesUpdate();
 
     // Inform theories of the variables that are actually seen by the

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(RewritingTest)
 target_sources(RewritingTest
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_simplifyAssignment.cpp"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Dominators.cpp"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Rewriting.cpp"
     )
 
 target_link_libraries(RewritingTest api_static gtest gtest_main)

--- a/test/unit/test_LogicMkTerms.cc
+++ b/test/unit/test_LogicMkTerms.cc
@@ -7,7 +7,9 @@
 
 class LogicMkTermsTest: public ::testing::Test {
 public:
-    LogicMkTermsTest() {}
+    SMTConfig config;
+    Logic logic;
+    LogicMkTermsTest(): logic{config} {}
 };
 
 TEST_F(LogicMkTermsTest, test_Distinct){
@@ -107,4 +109,16 @@ TEST_F(LogicMkTermsTest, test_ManyDistinct) {
         ASSERT_EQ(distincts1[i].x, distincts2[i].x);
         ASSERT_EQ(distincts1[i].x, distincts3[i].x);
     }
+}
+
+TEST_F(LogicMkTermsTest, testMkOrTautology) {
+    PTRef a = logic.mkBoolVar("a");
+    PTRef nota = logic.mkNot(a);
+    ASSERT_EQ(logic.mkOr(a, nota), logic.getTerm_true());
+}
+
+TEST_F(LogicMkTermsTest, testMkAndContradiction) {
+    PTRef a = logic.mkBoolVar("a");
+    PTRef nota = logic.mkNot(a);
+    ASSERT_EQ(logic.mkAnd(a, nota), logic.getTerm_false());
 }

--- a/test/unit/test_Rewriting.cpp
+++ b/test/unit/test_Rewriting.cpp
@@ -1,0 +1,45 @@
+//
+// Created by Martin Blicha on 17.05.20.
+//
+
+#include <gtest/gtest.h>
+#include <BoolRewriting.h>
+#include <Logic.h>
+#include <SMTConfig.h>
+
+
+TEST(Rewriting_test, test_RewriteClassicConjunction)
+{
+    SMTConfig config;
+    Logic logic{config};
+    PTRef a = logic.mkBoolVar("a");
+    PTRef b = logic.mkBoolVar("b");
+    PTRef c = logic.mkBoolVar("c");
+    PTRef d = logic.mkBoolVar("d");
+    PTRef conj = logic.mkAnd(logic.mkAnd(a,b), logic.mkAnd(c,d));
+    PTRef res = ::rewriteMaxArityClassic(logic, conj);
+    vec<PTRef> args {a,b,c,d};
+    ASSERT_EQ(res, logic.mkAnd(args));
+}
+
+TEST(Rewriting_test, test_RewriteClassicWithSimplification)
+{
+    SMTConfig config;
+    Logic logic{config};
+    PTRef a = logic.mkBoolVar("a");
+    PTRef b = logic.mkBoolVar("b");
+    PTRef c = logic.mkBoolVar("c");
+    PTRef d = logic.mkBoolVar("d");
+    PTRef l3 = logic.mkAnd(a, logic.mkAnd(b, logic.mkNot(a)));
+    PTRef l2 = logic.mkOr(l3, logic.mkAnd(c,d));
+    PTRef l1 = logic.mkAnd(b, l2);
+    // l1 is (and b (or (and c d) (and a (and b (not a)))))
+    // which is equivalent to (and b c d)
+    PTRef res = ::rewriteMaxArityClassic(logic, l1);
+//    std::cout << logic.printTerm(res) << std::endl;
+    vec<PTRef> args {b,c,d};
+    ASSERT_EQ(res, logic.mkAnd(args));
+}
+
+
+


### PR DESCRIPTION
Main optimization is in the caching inside CNFizer where formulas inserted in frames other than level 0 are checked also for level 0, to avoid asserting redundant clauses to the SAT solver.

Functions related to rewriting terms before cnfization have been polished, Logic::mkAnd has been changed to reflect Logic::mkOr and to catch situations where arguments contain two complementary terms.