### PR TITLE
Fix for a broken invariant where the whole formula is ITE on the top-level

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -706,7 +706,8 @@ Logic::mkIte(vec<PTRef>& args)
     SRef sr = getSortRef(args[1]);
     if(sr != getSortRef(args[2]))
     {
-        cerr << "ITE with different return sorts" << endl;
+        std::cerr << "ITE with different return sorts" << std::endl;
+        // MB: maybe do something more elegant here?
         assert(0);
     }
 
@@ -2028,7 +2029,9 @@ void Logic::conjoinItes(PTRef root, PTRef& new_root)
 {
     std::vector<bool> seen;
     // MB: Relies on invariant: Every subterm was created before its parent, so it has lower id
-    auto size = Idx(this->getPterm(root).getId()) + 1;
+    // Ite variables are replaced by their definition, and when top level formula is ite, this invariant would be broken
+    PTRef termWithMaxId = isIteVar(root) ? getTopLevelIte(root) : root;
+    auto size = Idx(this->getPterm(termWithMaxId).getId()) + 1;
     seen.resize(size, false);
     std::vector<PTRef> queue {root};
     vec<PTRef> args;


### PR DESCRIPTION
Method Logic::conjoinItes relies on an invariant that given a formula, all of its subterms have lower ID than the root. This is true in most cases since to create a term, its subterms must have already been created. But ITEs are handled in a special way: they are represented by a variable that has a definition and this definition contains that variable as a subterm, hence has higher ID than the variable.
Thus is the root term passed to this method is an ITE variable, the invariant is broken. 
This PR handles the special case.