### PR TITLE
Provide support for linking OpenSMT against 'libedit'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ compiler:
 env:
   global:
     - PRODUCE_PROOF=OFF
+    - USE_LIBEDIT=ON
   matrix:
     - CMAKE_BUILD_TYPE=Release
     - CMAKE_BUILD_TYPE=Debug
@@ -51,7 +52,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - libgmp-dev
-      - libreadline-dev
+      - libedit-dev
       - bison
       - flex
 
@@ -65,7 +66,7 @@ before_script:
 script:
   - set -e
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS="$FLAGS" -DPRODUCE_PROOF=${PRODUCE_PROOF} -DCMAKE_INSTALL_PREFIX=${INSTALL} ..
+  - cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS="$FLAGS" -DPRODUCE_PROOF=${PRODUCE_PROOF} -DUSE_LIBEDIT:BOOL=${USE_LIBEDIT} -DCMAKE_INSTALL_PREFIX=${INSTALL} ..
   - make
   - ctest
   - make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,14 @@ option(DEBUG_GC "Debug garbage collection" OFF)
 option(LADEBUG "Debug lookahead" OFF)
 option(PRINT_DECOMPOSED_STATS "Print statistics about decomposed interpolants" OFF)
 option(STATISTICS "Compute and print solver's statistics" OFF)
+option(USE_LIBEDIT "Use libedit over readline" OFF)
 #option(ENABLE_PROFILING "Enable profiling" OFF)
 
-find_package(Readline REQUIRED)
+if (USE_LIBEDIT)
+  find_package(LibEdit REQUIRED)
+else()
+  find_package(Readline REQUIRED)
+endif()
 find_package(GMP REQUIRED)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -107,6 +112,10 @@ endif ()
 if(STATISTICS)
     add_definitions(-DSTATISTICS)
 endif(STATISTICS)
+
+if (USE_LIBEDIT)
+  add_definitions(-DUSE_LIBEDIT)
+endif()
 
 add_subdirectory(${CMAKE_SOURCE_DIR})
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To compile the system from the source code repository, you need a c++11
 compliant compiler and the following libraries and headers installed:
 
  - gmp
- - readline
+ - readline or libedit
 
 In addition the compilation system relies on `cmake` and the `smtlib2`
 parser on `flex` and `bison`.  To compile OpenSMT2, use the following
@@ -28,6 +28,12 @@ command
 ```
 $ mkdir build; cd build; cmake ..; make
 ```
+
+By default, OpenSMT is linked against the [GNU Readline Library](https://tiswww.case.edu/php/chet/readline/rltop.html). Building OpenSMT in this way means that the resulting binary is GPL licensed, and not MIT licensed. To create a MIT licensed build of OpenSMT, you should build OpenSMT such that it links against the [Editline Library](https://thrysoee.dk/editline/):
+```
+$ cmake -DUSE_LIBEDIT:BOOL=ON ..
+```
+`libedit` can be easily installed on platforms such as Ubuntu (`apt-get install libedit-dev`) or CentOS (`dnf install libedit-devel`).
 
 By default, OpenSMT is compiled without interpolation capabilities.  To enable interpolation, the cmake option `PRODUCE_PROOF` must be enabled. This can be done in the cmake configuration file
 `CMakeCache.txt` produced by `cmake` in your build directory or when configuring cmake from the command line:

--- a/cmake_modules/FindLibEdit.cmake
+++ b/cmake_modules/FindLibEdit.cmake
@@ -1,0 +1,17 @@
+# Find LibEdit
+# LibEdit_FOUND - found LibEdit lib
+# LibEdit_INCLUDE_DIR - the LibEdit include directory
+# LibEdit_LIBRARIES - Libraries needed to use LibEdit
+
+find_path(LibEdit_INCLUDE_DIR NAMES histedit.h)
+find_library(LibEdit_LIBRARIES NAMES edit libedit)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibEdit
+  DEFAULT_MSG LibEdit_INCLUDE_DIR LibEdit_LIBRARIES)
+
+mark_as_advanced(LibEdit_INCLUDE_DIR LibEdit_LIBRARIES)
+if(LibEdit_LIBRARIES)
+  message(STATUS "LibEdit library: ${LibEdit_LIBRARIES}")
+endif()
+

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -44,10 +44,21 @@ add_library(api_shared SHARED ${OBJECTS_TO_ADD})
 add_library(api_static STATIC ${OBJECTS_TO_ADD})
 
 
+if (USE_LIBEDIT)
+  set(line_library ${LibEdit_LIBRARIES})
+  target_include_directories(api_shared
+                             PRIVATE
+                             ${LibEdit_INCLUDE_DIRS})
+  target_include_directories(api_static
+                             PRIVATE
+                             ${LibEdit_INCLUDE_DIRS})
+else()
+  set(line_library ${Readline_LIBRARY})
+endif()
 
-target_link_libraries(api_shared ${Readline_LIBRARY} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
+target_link_libraries(api_shared ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
 
-target_link_libraries(api_static ${Readline_LIBRARY} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
+target_link_libraries(api_static ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
 
 set_target_properties(api_shared PROPERTIES OUTPUT_NAME opensmt2)
 

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -31,8 +31,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cstdlib>
 #include <cassert>
 #include <cstdio>
+#ifdef USE_LIBEDIT
+#include <editline/readline.h>
+#else
 #include <readline/readline.h>
 #include <readline/history.h>
+#endif
 #include "Interpret.h"
 #include "Theory.h"
 #include "UFLRATheory.h"


### PR DESCRIPTION
## Issue

I discussed this with Natasha Sharygina at the Facebook TAV event in 2018, but managed to completely forget about this for a long time ...

Currently, OpenSMT has a "hard" dependency against `readline`, however `readline` is a [GPL licensed library](https://tiswww.case.edu/php/chet/readline/rltop.html).

A great reference for this is [here](https://en.wikipedia.org/wiki/GNU_Readline):

> GNU Readline is notable for being a free software library which is licensed under the GNU General Public License (GPL) ... linking to ... Readline requires the entire combined resulting application to be licensed under the GPL when distributed, to comply with section 5 of the GPL.

Basically, while the _code_ of OpenSMT might be MIT licensed, if anyone is linking against a _binary build_ of OpenSMT (e.g., `libopensmt2.so`) without their application being GPL (or, at least, GPL compatible"), then they are infringing on the GPL:

```
[avj@tempvm build]$ ldd ./src/api/libopensmt2.so
	linux-vdso.so.1 (0x00007ffd6cf76000)
	libreadline.so.7 => /lib64/libreadline.so.7 (0x00007f110550b000)
	libgmp.so.10 => /lib64/libgmp.so.10 (0x00007f1105273000)
	libgmpxx.so.4 => /lib64/libgmpxx.so.4 (0x00007f110506c000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f1104cd7000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f1104955000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f110473d000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f110451d000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f110415a000)
	libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f1103f2d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f1105a9d000)
```

## Solution

This PR allows a user to _optionally_ link against a BSD-licensed drop-in replacement for `readline` called [`libedit`](https://thrysoee.dk/editline/):

```
cmake -DUSE_LIBEDIT:BOOL=ON ..
```

Results in:

```
[avj@tempvm build]$ ldd ./src/api/libopensmt2.so
	linux-vdso.so.1 (0x00007ffcf0376000)
	libedit.so.0 => /lib64/libedit.so.0 (0x00007f0a55738000)
	libgmp.so.10 => /lib64/libgmp.so.10 (0x00007f0a554a0000)
	libgmpxx.so.4 => /lib64/libgmpxx.so.4 (0x00007f0a55299000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f0a54f04000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f0a54b82000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f0a5496a000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f0a5474a000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f0a54387000)
	libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f0a5415a000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0a55cb3000)
```

`README.md` has been updated to inform the user how to create an MIT-licensed build of OpenSMT.

`libedit` can be easily installed on platforms such as Ubuntu (`apt-get install libedit-dev`) or CentOS (`dnf install libedit-devel`).

I have checked that this branch builds on both CentOS 8 and Ubuntu 20.04, and confirmed that `ctest` passes cleanly and that `./src/bin/opensmt` works on both platforms.