### PR TITLE
Refactoring of TSolver

### DIFF
--- a/examples/test-bv.cc
+++ b/examples/test-bv.cc
@@ -90,11 +90,10 @@ main(int argc, char** argv)
     PTRef eq3 = logic.mkBVEq(op_tr, d);
 
     vec<PtAsgn> asgns;
-    vec<DedElem> deds;
     vec<PTRef> foo;
 
     SolverId id = {42};
-    BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+    BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
     BVRef output;
 
     lbool stat;

--- a/examples/test-cuf.cc
+++ b/examples/test-cuf.cc
@@ -37,11 +37,10 @@ main(int argc, char** argv)
     mainSolver.insertFormula(eq3, &msg);
 
     vec<PtAsgn> asgns;
-    vec<DedElem> deds;
     vec<PTRef> foo;
 
     SolverId id = {42};
-    BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+    BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
     BVRef output;
 
     lbool stat;

--- a/examples/test-cuf3.cc
+++ b/examples/test-cuf3.cc
@@ -27,11 +27,10 @@ main(int argc, char** argv)
     PTRef eq_neg = logic.mkBVNot(eq);
 
     vec<PtAsgn> asgns;
-    vec<DedElem> deds;
     vec<PTRef> foo;
 
     SolverId id = {42};
-    BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+    BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
     BVRef output;
 
     lbool stat;

--- a/examples/test10_BV.cc
+++ b/examples/test10_BV.cc
@@ -29,11 +29,10 @@ int main(int argc, char** argv)
     PTRef LOr = logic.mkBVLor(eq1_neg, eq2);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test11_BV.cc
+++ b/examples/test11_BV.cc
@@ -37,11 +37,10 @@ int main(int argc, char** argv)
     //PTRef eq4 = logic.mkBVEq(eq3, LOr);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test13_BV.cc
+++ b/examples/test13_BV.cc
@@ -37,11 +37,10 @@ int main(int argc, char** argv)
     //PTRef eq4 = logic.mkBVEq(eq3, LOr);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test15_ex1CADE.cc
+++ b/examples/test15_ex1CADE.cc
@@ -47,11 +47,10 @@ int main(int argc, char** argv)
     PTRef assert = logic.mkBVEq(constOne, eq_not);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test16_ex2CADE_BV.cc
+++ b/examples/test16_ex2CADE_BV.cc
@@ -73,11 +73,10 @@ int main(int argc, char** argv)
 
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
 	SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test17_ex2CADE_CUF.cc
+++ b/examples/test17_ex2CADE_CUF.cc
@@ -72,7 +72,6 @@ int main(int argc, char** argv)
 
     SolverId id = { 5 };
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
 	char* msg;

--- a/examples/test18_ex2CADE_glue_BV-CUF.cc
+++ b/examples/test18_ex2CADE_glue_BV-CUF.cc
@@ -113,10 +113,9 @@ int main(int argc, char** argv)
 
 //***** BItBlasting of C1_bv and C2_bv and two******
     vec<PtAsgn> asgns;
-    vec<DedElem> deds;
     vec<PTRef> foo;
     SolverId id = {42};
-    BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+    BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
     BVRef output1;
     lbool stat;

--- a/examples/test4_BV.cc
+++ b/examples/test4_BV.cc
@@ -45,10 +45,9 @@ main(int argc, char** argv)
     PTRef eq = logic.mkAnd(args);*/
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
-	BitBlaster bbb({42}, c, *mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb({42}, c, *mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test5_BV.cc
+++ b/examples/test5_BV.cc
@@ -46,11 +46,10 @@ int main(int argc, char** argv)
     PTRef eq4 = logic.mkBVEq(d, d2);
 /******************************************************/
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test7_BV.cc
+++ b/examples/test7_BV.cc
@@ -39,11 +39,10 @@ int main(int argc, char** argv)
     PTRef eq4 = logic.mkBVEq(d, LOr);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test8_BV.cc
+++ b/examples/test8_BV.cc
@@ -38,11 +38,10 @@ int main(int argc, char** argv)
     PTRef eq3 = logic.mkBVEq(GT, one);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/examples/test9_BV.cc
+++ b/examples/test9_BV.cc
@@ -46,11 +46,10 @@ int main(int argc, char** argv)
     PTRef eq5 = logic.mkBVLor(a_neg, eq4);
 
 	vec<PtAsgn> asgns;
-	vec<DedElem> deds;
 	vec<PTRef> foo;
 
     SolverId id = {42};
-	BitBlaster bbb(id, c, mainSolver, logic, asgns, deds, foo);
+	BitBlaster bbb(id, c, mainSolver, logic, asgns, foo);
 
 	BVRef output1;
 	lbool stat;

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -96,7 +96,6 @@ class MainSolver
     THandler&           thandler;
     PushFrameAllocator& pfstore;
     TermMapper&         tmap;
-    vec<DedElem>        deductions;
     SimpSMTSolver*      smt_solver;
     Tseitin             ts;
     PushFramesWrapper   frames;

--- a/src/cnfizers/TermMapper.cc
+++ b/src/cnfizers/TermMapper.cc
@@ -60,8 +60,8 @@ Var TermMapper::addBinding(PTRef tr)
 
 void TermMapper::getTerm(PTRef r, PTRef& p, bool& sgn) const {
     sgn = false;
-    while (logic.term_store[r].symb() == logic.getSym_not()) {
-        r = logic.term_store[r][0];
+    while (logic.getPterm(r).symb() == logic.getSym_not()) {
+        r = logic.getPterm(r)[0];
         sgn = !sgn;
     }
     p = r;

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -590,9 +590,7 @@ void Logic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
 }
 
 
-//
-// XXX Comments? This method is currently under development
-//
+
 void Logic::simplifyTree(PTRef tr, PTRef& root_out)
 {
     vec<pi> queue;
@@ -2025,10 +2023,9 @@ Logic::implies(PTRef implicant, PTRef implicated)
 void Logic::conjoinItes(PTRef root, PTRef& new_root)
 {
     std::vector<bool> seen;
-    // MB: Relies on invariant: Every subterm was created before its parent, so it has lower id
-    // Ite variables are replaced by their definition, and when top level formula is ite, this invariant would be broken
-    PTRef termWithMaxId = isIteVar(root) ? getTopLevelIte(root) : root;
-    auto size = Idx(this->getPterm(termWithMaxId).getId()) + 1;
+    //MB: ITE var and its definition do not satisfy the id invariant of parent-child terms
+    //    We need to make sure we cover all possible ID in the bitmap.
+    auto size = getNumberOfTerms();
     seen.resize(size, false);
     std::vector<PTRef> queue {root};
     vec<PTRef> args;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -153,6 +153,8 @@ class Logic {
 
     void conjoinItes(PTRef root, PTRef& new_root);
 
+    std::size_t getNumberOfTerms() const { return term_store.getNumberOfTerms(); }
+
   private:
     vec<bool> appears_in_uf;
   public:

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -119,9 +119,7 @@ class Logic {
     IdentifierStore     id_store;
     SStore              sort_store;
     SymStore            sym_store;
-  public:
     PtStore             term_store;
-  protected:
     opensmt::Logic_t    logic_type;
     SymRef              sym_TRUE;
     SymRef              sym_FALSE;

--- a/src/logics/Theory.cc
+++ b/src/logics/Theory.cc
@@ -275,15 +275,12 @@ Theory::printFramesAsQuery(const vec<PFRef> & frames, std::ostream & s)
 
 //MOVINGFROMHEADER
 void Theory::setSubstitutions(Map<PTRef,PtAsgn,PTRefHash>& substs) { getTSolverHandler().setSubstitutions(substs); }
-vec<DedElem>& Theory::getDeductionVec()   { return deductions; }
 
 TermMapper&  LRATheory::getTmap() { return tmap; }
 LRALogic&    LRATheory::getLogic()    { return lralogic; }
 LRATHandler& LRATheory::getTSolverHandler() { return lratshandler; }
-LRATHandler* LRATheory::getTSolverHandler_new(vec<DedElem> &d) { return new LRATHandler(config, lralogic, d, tmap); }
 
 TermMapper&  LIATheory::getTmap() { return tmap; }
 LIALogic&    LIATheory::getLogic()    { return lialogic; }
 LIATHandler& LIATheory::getTSolverHandler() { return liatshandler; }
-LIATHandler* LIATheory::getTSolverHandler_new(vec<DedElem> &d) { return new LIATHandler(config, lialogic, d, tmap); }
 

--- a/src/logics/Theory.h
+++ b/src/logics/Theory.h
@@ -249,7 +249,6 @@ class CUFTheory : public Theory
     virtual BVLogic&  getLogic()             { return cuflogic; }
     virtual CUFTHandler& getTSolverHandler() { return tshandler; }
     virtual const CUFTHandler& getTSolverHandler() const { return tshandler; }
-    virtual CUFTHandler *getTSolverHandler_new(vec<DedElem>& d) { return new CUFTHandler(config, cuflogic, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 

--- a/src/logics/Theory.h
+++ b/src/logics/Theory.h
@@ -152,7 +152,6 @@ public:
 class Theory
 {
   protected:
-    vec<DedElem>        deductions;
     SMTConfig &         config;
     PTRef getCollateFunction(const vec<PFRef> & formulas, int curr);
     Theory(SMTConfig &c) : config(c) { }
@@ -163,10 +162,8 @@ class Theory
     virtual TermMapper     &getTmap() = 0;
     virtual Logic          &getLogic()              = 0;
     virtual TSolverHandler &getTSolverHandler()     = 0;
-    virtual TSolverHandler *getTSolverHandler_new(vec<DedElem>&) = 0;
     virtual bool            simplify(const vec<PFRef>&, int) = 0; // Simplify a vector of PushFrames in an incrementality-aware manner
     virtual void            purify(const vec<PFRef>&, int);        // Purify a vector of PushFrames
-    vec<DedElem>           &getDeductionVec();//   { return deductions; }
     bool                    computeSubstitutions(PTRef coll_f, const vec<PFRef>& frames, int curr);
     void                    printFramesAsQuery(const vec<PFRef> & frames, std::ostream & s);
     virtual                ~Theory()                           {};
@@ -184,12 +181,11 @@ class LRATheory : public Theory
         : Theory(c)
         , lralogic(c)
         , tmap(lralogic)
-        , lratshandler(c, lralogic, deductions, tmap)
+        , lratshandler(c, lralogic, tmap)
     { }
     ~LRATheory() {};
     virtual LRALogic&    getLogic();//    { return lralogic; }
     virtual LRATHandler& getTSolverHandler();// { return lratshandler; }
-    virtual LRATHandler *getTSolverHandler_new(vec<DedElem> &d);// { return new LRATHandler(config, lralogic, d, tmap); }
     virtual bool simplify(const vec<PFRef>&, int); // Theory specific simplifications
 };
 
@@ -205,12 +201,11 @@ public:
     : Theory(c)
     , lialogic(c)
     , tmap(lialogic)
-    , liatshandler(c, lialogic, deductions, tmap)
+    , liatshandler(c, lialogic, tmap)
     { }
     ~LIATheory() {};
     virtual LIALogic&    getLogic();//    { return lialogic; }
     virtual LIATHandler& getTSolverHandler();// { return liatshandler; }
-    virtual LIATHandler *getTSolverHandler_new(vec<DedElem> &d);// { return new LIATHandler(config, lialogic, d, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 
@@ -225,14 +220,13 @@ class UFTheory : public Theory
         : Theory(c)
         , uflogic(c)
         , tmap(uflogic)
-        , tshandler(c, uflogic, deductions, tmap)
+        , tshandler(c, uflogic, tmap)
     {}
     ~UFTheory() {}
     virtual TermMapper&  getTmap()              { return tmap; }
     virtual Logic&       getLogic()             { return uflogic; }
     virtual UFTHandler&  getTSolverHandler()    { return tshandler; }
     virtual const UFTHandler& getTSolverHandler() const { return tshandler; }
-    virtual UFTHandler *getTSolverHandler_new(vec<DedElem>& d) { return new UFTHandler(config, uflogic, d, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 
@@ -248,14 +242,14 @@ class CUFTheory : public Theory
       : Theory(c)
       , cuflogic(c, width)
       , tmap(cuflogic)
-      , tshandler(c, cuflogic, deductions, tmap)
+      , tshandler(c, cuflogic, tmap)
     {}
     ~CUFTheory() {}
     virtual TermMapper& getTmap()            { return tmap; }
     virtual BVLogic&  getLogic()             { return cuflogic; }
     virtual CUFTHandler& getTSolverHandler() { return tshandler; }
     virtual const CUFTHandler& getTSolverHandler() const { return tshandler; }
-    virtual CUFTHandler *getTSolverHandler_new(vec<DedElem>& d) { return new CUFTHandler(config, cuflogic, d, tmap); }
+    virtual CUFTHandler *getTSolverHandler_new(vec<DedElem>& d) { return new CUFTHandler(config, cuflogic, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 

--- a/src/logics/UFLRATheory.h
+++ b/src/logics/UFLRATheory.h
@@ -45,7 +45,6 @@ class UFLRATheory : public Theory
     { }
     virtual LRALogic& getLogic() { return lralogic; }
     virtual UFLRATHandler& getTSolverHandler() { return uflratshandler; }
-    virtual UFLRATHandler *getTSolverHandler_new(vec<DedElem> &d) { return new UFLRATHandler(config, lralogic, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 

--- a/src/logics/UFLRATheory.h
+++ b/src/logics/UFLRATheory.h
@@ -41,11 +41,11 @@ class UFLRATheory : public Theory
         : Theory(c)
         , lralogic(c)
         , tmap(lralogic)
-        , uflratshandler(c, lralogic, deductions, tmap)
+        , uflratshandler(c, lralogic, tmap)
     { }
     virtual LRALogic& getLogic() { return lralogic; }
     virtual UFLRATHandler& getTSolverHandler() { return uflratshandler; }
-    virtual UFLRATHandler *getTSolverHandler_new(vec<DedElem> &d) { return new UFLRATHandler(config, lralogic, d, tmap); }
+    virtual UFLRATHandler *getTSolverHandler_new(vec<DedElem> &d) { return new UFLRATHandler(config, lralogic, tmap); }
     virtual bool simplify(const vec<PFRef>&, int);
 };
 

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -126,7 +126,7 @@ const PtermIter& PtermIter::operator++ () { i++; return *this; }
 
 PTRef PtStore::newTerm(const SymRef sym, const vec<PTRef>& ps) {
     PTRef tr = pta.alloc(sym, ps); idToPTRef.push(tr);
-    assert(idToPTRef.size() == pta.getNumTerms());
+    assert(idToPTRef.size_() == pta.getNumTerms());
     return tr;
 }
 

--- a/src/pterms/PtStore.h
+++ b/src/pterms/PtStore.h
@@ -101,6 +101,8 @@ class PtStore {
     PTRef getFromCplxMap(PTLKey& k);// { return cplx_map[k]; }
 
     PtermIter getPtermIter();// { return PtermIter(idToPTRef); }
+
+    std::size_t getNumberOfTerms() const { return pta.getNumTerms(); }
 };
 
 #endif

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -195,7 +195,7 @@ class PtermAllocator : public RegionAllocator<uint32_t>
     PtermAllocator(uint32_t start_cap) : RegionAllocator<uint32_t>(start_cap), n_terms(0) {}
     PtermAllocator() : n_terms(0) {}
 
-    int getNumTerms() const { return n_terms; }
+    uint32_t getNumTerms() const { return n_terms; }
 
     void moveTo(PtermAllocator& to) {
         to.n_terms = n_terms;

--- a/src/simplifiers/BoolRewriting.cc
+++ b/src/simplifiers/BoolRewriting.cc
@@ -19,6 +19,7 @@
 void computeIncomingEdges(const Logic& logic, PTRef root, std::unordered_map<PTRef,int,PTRefHash>& PTRefToIncoming)
 {
     assert(root != PTRef_Undef);
+    // MB: Relies on an invariant that id of a child is lower than id of a parent.
     auto size = Idx(logic.getPterm(root).getId()) + 1;
     std::vector<char> done;
     done.resize(size, 0);

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -267,9 +267,6 @@ Var CoreSMTSolver::newVar(bool sign, bool dvar)
     if ( v != 0 && v != 1 )
         undo_stack.push(undo_stack_el(undo_stack_el::NEWVAR, v));
 
-    // Add the deduction entry for this variable
-    theory_handler.pushDeduction();
-
     return v;
 }
 

--- a/src/tsolvers/CUFTHandler.cc
+++ b/src/tsolvers/CUFTHandler.cc
@@ -1,8 +1,8 @@
 #include "CUFTHandler.h"
 #include "CUFLogic.h"
 
-CUFTHandler::CUFTHandler(SMTConfig& c, CUFLogic& l, vec<DedElem>& d, TermMapper& tmap)
-    : UFTHandler(c, l, d, tmap)
+CUFTHandler::CUFTHandler(SMTConfig & c, CUFLogic & l, TermMapper & tmap)
+    : UFTHandler(c, l, tmap)
     , logic(l)
 {}
 

--- a/src/tsolvers/CUFTHandler.h
+++ b/src/tsolvers/CUFTHandler.h
@@ -34,7 +34,7 @@ class CUFTHandler : public UFTHandler
   private:
     CUFLogic&   logic;
   public:
-    CUFTHandler(SMTConfig& c, CUFLogic& l, vec<DedElem>& d, TermMapper& tmap);
+    CUFTHandler(SMTConfig & c, CUFLogic & l, TermMapper & tmap);
     virtual ~CUFTHandler();
     virtual CUFLogic& getLogic();
 };

--- a/src/tsolvers/Deductions.h
+++ b/src/tsolvers/Deductions.h
@@ -35,7 +35,7 @@ struct SolverId {
     bool operator!= (const SolverId id2) const { return id != id2.id; }
 };
 
-static SolverId SolverId_Undef = {UINT32_MAX};
+static const SolverId SolverId_Undef = {UINT32_MAX};
 
 class SolverDescr
 {
@@ -61,17 +61,17 @@ class SolverDescr
 };
 
 
-struct DedElem {
-    DedElem(SolverId id, lbool p) : deducedBy(id), polarity(p) {}
-    SolverId deducedBy;
-    lbool    polarity;
-    bool operator== (const lbool l) const { return l == polarity; }
-    bool operator!= (const lbool l) const { return l != polarity; }
-    bool operator== (const SolverId id) const { return id == deducedBy; }
-    bool operator!=(const SolverId id) const { return id != deducedBy; }
-};
-
-//static DedElem DedElem_Undef = {SolverId_Undef, l_Undef};
-static DedElem DedElem_Undef(SolverId_Undef, l_Undef);
+//struct DedElem {
+//    DedElem(SolverId id, lbool p) : deducedBy(id), polarity(p) {}
+//    SolverId deducedBy;
+//    lbool    polarity;
+//    bool operator== (const lbool l) const { return l == polarity; }
+//    bool operator!= (const lbool l) const { return l != polarity; }
+//    bool operator== (const SolverId id) const { return id == deducedBy; }
+//    bool operator!=(const SolverId id) const { return id != deducedBy; }
+//};
+//
+////static DedElem DedElem_Undef = {SolverId_Undef, l_Undef};
+//static DedElem DedElem_Undef(SolverId_Undef, l_Undef);
 
 #endif

--- a/src/tsolvers/LIATHandler.cc
+++ b/src/tsolvers/LIATHandler.cc
@@ -2,11 +2,11 @@
 #include "TreeOps.h"
 #include <liasolver/LIASolver.h>
 
-LIATHandler::LIATHandler(SMTConfig& c, LIALogic& l, vec<DedElem>& d, TermMapper& tmap)
-        : TSolverHandler(c, d, tmap)
+LIATHandler::LIATHandler(SMTConfig & c, LIALogic & l, TermMapper & tmap)
+        : TSolverHandler(c, tmap)
         , logic(l)
 {
-    liasolver = new LIASolver(config, logic, deductions);
+    liasolver = new LIASolver(config, logic);
     SolverId my_id = liasolver->getId();
     tsolvers[my_id.id] = liasolver;
     solverSchedule.push(my_id.id);

--- a/src/tsolvers/LIATHandler.h
+++ b/src/tsolvers/LIATHandler.h
@@ -14,7 +14,7 @@ class LIATHandler : public TSolverHandler
     LIALogic& logic;
     LIASolver *liasolver;
   public:
-    LIATHandler(SMTConfig& c, LIALogic& l, vec<DedElem>& d, TermMapper& tmap);
+    LIATHandler(SMTConfig & c, LIALogic & l, TermMapper & tmap);
     virtual ~LIATHandler();
     virtual Logic& getLogic() override;
     virtual const Logic& getLogic() const override;

--- a/src/tsolvers/LRATHandler.cc
+++ b/src/tsolvers/LRATHandler.cc
@@ -2,11 +2,11 @@
 #include "TreeOps.h"
 #include "lrasolver/LRASolver.h"
 
-LRATHandler::LRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap)
-        : TSolverHandler(c, d, tmap)
+LRATHandler::LRATHandler(SMTConfig& c, LRALogic& l, TermMapper& tmap)
+        : TSolverHandler(c, tmap)
         , logic(l)
 {
-    lrasolver = new LRASolver(config, logic, deductions);
+    lrasolver = new LRASolver(config, logic);
     SolverId my_id = lrasolver->getId();
     tsolvers[my_id.id] = lrasolver;
     solverSchedule.push(my_id.id);

--- a/src/tsolvers/LRATHandler.h
+++ b/src/tsolvers/LRATHandler.h
@@ -37,7 +37,7 @@ class LRATHandler : public TSolverHandler
     LRALogic& logic;
     LRASolver *lrasolver;
   public:
-    LRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap);
+    LRATHandler(SMTConfig& c, LRALogic& l, TermMapper& tmap);
     virtual ~LRATHandler();
     virtual Logic& getLogic() override;
     virtual const Logic& getLogic() const override;

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -500,7 +500,6 @@ Lit     THandler::PTRefToLit         ( PTRef tr)     { return tmap.getLit(tr); }
 
 void    THandler::getVarName         ( Var v, char** name ) { *name = getLogic().printTerm(tmap.varToPTRef(v)); }
 
-void    THandler::pushDeduction      () { getSolverHandler().deductions.push({SolverId_Undef, l_Undef}); }  // Add the deduction entry for a variable
 Var     THandler::ptrefToVar         ( PTRef r ) { return tmap.getVar(r); }
 
 void    THandler::computeModel      () { getSolverHandler().computeModel(); } // Computes a model in the solver if necessary

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -178,7 +178,7 @@ void THandler::getConflict (
 
     max_decision_level = -1;
     for (int i = 0; i < explanation.size(); ++i) {
-        PtAsgn & ei = explanation[i];
+        PtAsgn const & ei = explanation[i];
         assert(ei.sgn == l_True || ei.sgn == l_False);
         Var v = ptrefToVar(ei.tr);
         bool negate = ei.sgn == l_False;
@@ -252,41 +252,20 @@ Lit THandler::getSuggestion( ) {
 
 void THandler::getReason( Lit l, vec< Lit > & reason)
 {
-#if LAZY_COMMUNICATION
-    assert( checked_trail_size == stack.size( ) );
-    assert( static_cast< int >( checked_trail_size ) == trail.size( ) );
-#else
-#endif
-
     Var   v = var(l);
     PTRef e = tmap.varToPTRef(v);
 
-    // It must be a TAtom and already disabled
+    // It must be a TAtom and already deduced
     assert( getLogic().isTheoryTerm(e) );
-    assert(getSolverHandler().deductions[v].polarity != l_Undef);
-    TSolver* solver = getSolverHandler().tsolvers[getSolverHandler().deductions[v].deducedBy.id];
-//  assert( !e->hasPolarity( ) );
-//  assert( e->isDeduced( ) );
-//  assert( e->getDeduced( ) != l_Undef );           // Last assigned deduction
-#if LAZY_COMMUNICATION
-    assert( e->getPolarity( ) != l_Undef );          // Last assigned polarity
-    assert( e->getPolarity( ) == e->getDeduced( ) ); // The two coincide
-#else
-#endif
-
-    solver->pushBacktrackPoint( );
-
-    // Assign reversed polarity temporairly
-//  e->setPolarity( e->getDeduced( ) == l_True ? l_False : l_True );
-    // Compute reason in whatever solver
-//  const bool res = egraph.assertLit( e, true ) &&
-//                   egraph.check( true );
-    lbool res = l_Undef;
+    TSolver* solver = getSolverHandler().getSolverDeducing(e);
+    assert(solver);
+    solver->pushBacktrackPoint();
     // Assign temporarily opposite polarity
-    res = solver->assertLit(PtAsgn(e, sign(~l) ? l_False : l_True)) == false ? l_False : l_Undef;
+    PtAsgn conflictingPolarity = PtAsgn(e, sign(~l) ? l_False : l_True);
+    lbool res = solver->assertLit(conflictingPolarity) == false ? l_False : l_Undef;
 
     if ( res != l_False ) {
-        cout << endl << "unknown" << endl;
+        std::cout << std::endl << "unknown" << std::endl;
         assert(false);
     }
 
@@ -294,9 +273,6 @@ void THandler::getReason( Lit l, vec< Lit > & reason)
     vec<PtAsgn> explanation;
     solver->getConflict( true, explanation );
     assert(explanation.size() > 0);
-
-//    if ( config.certification_level > 0 )
-//        verifyExplanationWithExternalTool( explanation );
 
     // Reserve room for implied lit
     reason.push( lit_Undef );
@@ -306,14 +282,9 @@ void THandler::getReason( Lit l, vec< Lit > & reason)
         PtAsgn pa = explanation.last();
         PTRef ei  = pa.tr;
         explanation.pop();
-//        assert( ei->hasPolarity( ) );
-//        assert( ei->getPolarity( ) == l_True
-//                || ei->getPolarity( ) == l_False );
-//        bool negate = ei->getPolarity( ) == l_False;
 
         // Toggle polarity for deduced literal
         if ( e == ei ) {
-//            assert( e->getDeduced( ) != l_Undef );           // But still holds the deduced polarity
             // The deduced literal must have been pushed
             // with the the same polarity that has been deduced
             assert((pa.sgn == l_True && sign(l)) || (pa.sgn == l_False && !sign(l))); // The literal is true (sign false) iff the egraph term polarity is false
@@ -323,39 +294,10 @@ void THandler::getReason( Lit l, vec< Lit > & reason)
             assert(pa.sgn != l_Undef);
             reason.push(pa.sgn == l_True ? ~tmap.getLit(ei) : tmap.getLit(ei)); // Swap the sign for others
         }
-//        else {
-//            assert( ei->hasPolarity( ) );                    // Lit in explanation is active
-//            // This assertion might fail if in your theory solver
-//            // you do not skip deduced literals during assertLit
-//            //
-//            // TODO: check ! It could be deduced: by another solver
-//            // For instance BV found conflict and ei was deduced by EUF solver
-//            //
-//            // assert( !ei->isDeduced( ) );                     // and not deduced
-//            Lit l = Lit( v, !negate );
-//            reason.push( l );
-//        }
     }
+    solver->popBacktrackPoint();
 
-    solver->popBacktrackPoint( );
-
-    // Resetting polarity
-//    egraph.clearPolarity(e);
-//    e->resetPolarity( );
 }
-
-//
-// Inform Theory-Solvers of Theory-Atoms
-//
-//void THandler::inform( ) {
-//  for ( ; tatoms_given < tatoms_list.size_( ) ; tatoms_given ++ ) {
-//    if ( !tatoms_give[ tatoms_given ] ) continue;
-//    Enode * atm = tatoms_list[ tatoms_given ];
-//    assert( atm );
-//    assert( atm->isTAtom( ) );
-//    egraph.inform( atm );
-//  }
-//}
 
 #ifdef PEDANTIC_DEBUG
 
@@ -368,188 +310,6 @@ bool THandler::isOnTrail( Lit l, vec<Lit>& trail ) {
 
 #endif
 
-//void THandler::verifyCallWithExternalTool( bool res, size_t trail_size )
-//{
-//  // First stage: print declarations
-//  const char * name = "/tmp/verifycall.smt2";
-//  std::ofstream dump_out( name );
-//
-//  egraph.dumpHeaderToFile( dump_out );
-//
-//  dump_out << "(assert" << endl;
-//  dump_out << "(and" << endl;
-//  for ( size_t j = 0 ; j <= trail_size ; j ++ )
-//  {
-//    Var v = var( trail[ j ] );
-//
-//    if ( v == var_True || v == var_False )
-//      continue;
-//
-//    // Enode * e = var_to_enode[ v ];
-//    Enode * e = varToEnode( v );
-//    assert( e );
-//
-//    if ( !e->isTAtom( ) )
-//      continue;
-//
-//    bool negated = sign( trail[ j ] );
-//    if ( negated )
-//      dump_out << "(not ";
-//    e->print( dump_out );
-//    if ( negated )
-//      dump_out << ")";
-//
-//    dump_out << endl;
-//  }
-//  dump_out << "))" << endl;
-//  dump_out << "(check-sat)" << endl;
-//  dump_out << "(exit)" << endl;
-//  dump_out.close( );
-//
-//  // Second stage, check the formula
-//  const bool tool_res = callCertifyingSolver( name );
-//
-//  if ( res == false && tool_res == true )
-//    opensmt_error2( config.certifying_solver, " says SAT stack, but we say UNSAT" );
-//
-//  if ( res == true && tool_res == false )
-//    opensmt_error2( config.certifying_solver, " says UNSAT stack, but we say SAT" );
-//}
-
-//void THandler::verifyExplanationWithExternalTool( vector< Enode * > & expl )
-//{
-//#define MULTIPLE_FILES 1
-//#if MULTIPLE_FILES
-//  stringstream s;
-//  static int counter = 0;
-//  s << "/tmp/verifyexp_" << counter ++ << ".smt2";
-//  char name[ 64 ];
-//  strcpy( name, s.str( ).c_str( ) );
-//#else
-//  // First stage: print declarations
-//  const char * name = "/tmp/verifyexp.smt2";
-//#endif
-//  std::ofstream dump_out( name );
-//
-//  egraph.dumpHeaderToFile( dump_out );
-//
-//  dump_out << "(assert " << endl;
-//  dump_out << "(and" << endl;
-//
-//  for ( size_t j = 0 ; j < expl.size( ) ; j ++ )
-//  {
-//    Enode * e = expl[ j ];
-//    assert( e->isTAtom( ) );
-//    assert( e->getPolarity( ) != l_Undef );
-//    bool negated = e->getPolarity( ) == l_False;
-//    if ( negated )
-//      dump_out << "(not ";
-//    e->print( dump_out );
-//    if ( negated )
-//      dump_out << ")";
-//
-//    dump_out << endl;
-//  }
-//
-//  dump_out << "))" << endl;
-//  dump_out << "(check-sat)" << endl;
-//  dump_out << "(exit)" << endl;
-//  dump_out.close( );
-//  // Third stage, check the formula
-//  const bool tool_res = callCertifyingSolver( name );
-//
-//  if ( tool_res == true )
-//  {
-//    stringstream s; 
-//    s << config.certifying_solver << " says " << name << " is not an explanation";
-//    opensmt_error( s.str( ) );
-//  }
-//}
-
-//void THandler::verifyDeductionWithExternalTool( Enode * imp )
-//{
-//  assert( imp->isDeduced( ) );
-//
-//  // First stage: print declarations
-//  const char * name = "/tmp/verifydeduction.smt2";
-//  std::ofstream dump_out( name );
-//
-//  egraph.dumpHeaderToFile( dump_out );
-//
-//  dump_out << "(assert" << endl;
-//  dump_out << "(and" << endl;
-//  for ( int j = 0 ; j < trail.size( ) ; j ++ )
-//  {
-//    Var v = var( trail[ j ] );
-//
-//    if ( v == var_True || v == var_False )
-//      continue;
-//
-//    Enode * e = varToEnode( v );
-//    assert( e );
-//
-//    if ( !e->isTAtom( ) )
-//      continue;
-//
-//    bool negated = sign( trail[ j ] );
-//    if ( negated )
-//      dump_out << "(not ";
-//    e->print( dump_out );
-//    if ( negated )
-//      dump_out << ")";
-//
-//    dump_out << endl;
-//  }
-//
-//  if ( imp->getDeduced( ) == l_True )
-//    dump_out << "(not " << imp << ")" << endl;
-//  else
-//    dump_out << imp << endl;
-//
-//  dump_out << "))" << endl;
-//  dump_out << "(check-sat)" << endl;
-//  dump_out << "(exit)" << endl;
-//  dump_out.close( );
-//
-//  // Second stage, check the formula
-//  const bool tool_res = callCertifyingSolver( name );
-//
-//  if ( tool_res )
-//    opensmt_error2( config.certifying_solver, " says this is not a valid deduction" );
-//}
-
-//bool THandler::callCertifyingSolver( const char * name )
-//{
-//  bool tool_res;
-//  if ( int pid = fork() )
-//  {
-//    int status;
-//    waitpid(pid, &status, 0);
-//    switch ( WEXITSTATUS( status ) )
-//    {
-//      case 0:
-//	tool_res = false;
-//	break;
-//      case 1:
-//	tool_res = true;
-//	break;
-//      default:
-//	perror( "# Error: Certifying solver returned weird answer (should be 0 or 1)" );
-//	exit( EXIT_FAILURE );
-//    }
-//  }
-//  else
-//  {
-//    execlp( config.certifying_solver
-//	  , config.certifying_solver
-//	  , name
-//	  , NULL );
-//    perror( "# Error: Cerifying solver had some problems (check that it is reachable and executable)" );
-//    exit( EXIT_FAILURE );
-//  }
-//  return tool_res;
-//}
-//
 
 void
 THandler::dumpFormulaToFile( ostream & dump_out, PTRef formula, bool negate )

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -256,8 +256,8 @@ void THandler::getReason( Lit l, vec< Lit > & reason)
     PTRef e = tmap.varToPTRef(v);
 
     // It must be a TAtom and already deduced
-    assert( getLogic().isTheoryTerm(e) );
-    TSolver* solver = getSolverHandler().getSolverDeducing(e);
+    assert(getLogic().isTheoryTerm(e));
+    TSolver* solver = getSolverHandler().getReasoningSolverFor(e);
     assert(solver);
     solver->pushBacktrackPoint();
     // Assign temporarily opposite polarity

--- a/src/tsolvers/TSolver.cc
+++ b/src/tsolvers/TSolver.cc
@@ -31,8 +31,7 @@ void TSolver::popBacktrackPoint()
     deductions_lim.pop();
     while (th_deductions.size_() > new_deductions_size) {
         PtAsgn_reason asgn = th_deductions.last();
-        assert(deduced[getLogic().getPterm(asgn.tr).getVar()] != l_Undef);
-        deduced[getLogic().getPterm(asgn.tr).getVar()] = DedElem_Undef;
+        clearPolarity(asgn.tr);
         th_deductions.pop();
     }
     assert( deductions_next <= th_deductions.size_() );
@@ -66,17 +65,6 @@ void  TSolver::setPolarity(PTRef tr, lbool p)
 {
     if (polarityMap.has(tr)) { polarityMap[tr] = p; }
     else { polarityMap.insert(tr, p); }
-#ifdef VERBOSE_EUF
-    cerr << "Setting polarity " << getLogic().printTerm(tr) << " " << tr.x << endl;
-#endif
-}
-
-void  TSolver::clearPolarity(PTRef tr)
-{
-    polarityMap[tr] = l_Undef;
-#ifdef VERBOSE_EUF
-    cerr << "Clearing polarity " << getLogic().printTerm(tr) << " " << tr.x << endl;
-#endif
 }
 
 void TSolver::getNewSplits(vec<PTRef>&)

--- a/src/tsolvers/TSolver.cc
+++ b/src/tsolvers/TSolver.cc
@@ -75,3 +75,10 @@ void TSolver::getNewSplits(vec<PTRef>&)
 bool TSolver::hasNewSplits() {
     return splitondemand.size() > 0;
 }
+
+PtAsgn_reason TSolver::getDeduction() {
+    if (deductions_next >= th_deductions.size_()) {
+        return PtAsgn_reason_Undef;
+    }
+    return th_deductions[deductions_next++];
+}

--- a/src/tsolvers/TSolver.cc
+++ b/src/tsolvers/TSolver.cc
@@ -48,10 +48,16 @@ void TSolver::pushBacktrackPoint()
 
 bool TSolver::isKnown(PTRef tr)
 {
-    uint32_t id = Idx(getLogic().getPterm(tr).getId());
-    if (static_cast<unsigned int>(known_preds.size()) <= id)
-        return false;
-    return known_preds[id];
+    uint32_t tid = Idx(getLogic().getPterm(tr).getId());
+    return tid < known_preds.size_() && known_preds[tid];
+}
+
+void TSolver::setKnown(PTRef tr) {
+    auto tid = Idx(getLogic().getPterm(tr).getId());
+    while (known_preds.size_() <= tid) {
+        known_preds.push(false);
+    }
+    known_preds[tid] = true;
 }
 
 // MB: setPolarity and clearPolarity moved to .C file to remove the macros from the header

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -177,7 +177,7 @@ public:
     virtual void clearSolver();
 
     virtual void print(ostream& out) = 0;
-    virtual bool                assertLit           ( PtAsgn, bool = false ) = 0 ;  // Assert a theory literal
+    virtual bool                assertLit           (PtAsgn) = 0              ;  // Assert a theory literal
     virtual void                pushBacktrackPoint  ( )                       ;  // Push a backtrack point
     virtual void                popBacktrackPoint   ( )                       ;  // Backtrack to last saved point
     virtual void                popBacktrackPoints  ( unsigned int )          ;  // Backtrack given number of points
@@ -202,8 +202,7 @@ public:
 protected:
     bool                        isInformed(PTRef tr) const { return informed_PTRefs.has(tr); }
     void                        setInformed(PTRef tr) { informed_PTRefs.insert(tr, true); }
-    std::vector<PTRef>          getInformed() {std::vector<PTRef> res; vec<PTRef> tmp; informed_PTRefs.getKeys(tmp);
-                                                for(int i = 0; i < tmp.size(); ++i) {res.push_back(tmp[i]);} return res; }
+    vec<PTRef>                  getInformed() { vec<PTRef> res; informed_PTRefs.getKeys(res); return res; }
     bool                        has_explanation;  // Does the solver have an explanation (conflict detected)
     string                      name;             // Name of the solver
     SMTConfig &                 config;           // Reference to configuration

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -181,6 +181,7 @@ public:
     virtual Logic& getLogic() = 0;
     virtual bool isValid(PTRef tr) = 0;
     bool         isKnown(PTRef tr);
+    void         setKnown(PTRef tr);
 
 protected:
     bool                        isInformed(PTRef tr) const { return informed_PTRefs.has(tr); }

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -151,6 +151,12 @@ protected:
     void  clearPolarity(PTRef tr)        { polarityMap[tr] = l_Undef; }
     bool  hasPolarity(PTRef tr)          { if (polarityMap.has(tr)) { return polarityMap[tr] != l_Undef; } else return false; }
 
+    // Method for storing information about deductions (Derived solvers should use this and not manipulate fields themselves)
+    void storeDeduction(PtAsgn_reason ded) {
+        th_deductions.push(ded);
+        setPolarity(ded.tr, ded.sgn);
+    }
+
     vec<PTRef>                  splitondemand;
 
 public:
@@ -182,7 +188,7 @@ public:
     virtual void getConflict(bool, vec<PtAsgn>&) = 0;     // Return conflict
     virtual bool hasNewSplits();                          // Are there new splits?
     virtual void getNewSplits(vec<PTRef>&);               // Return new splits if any
-    virtual PtAsgn_reason getDeduction() = 0;             // Return an implied node based on the current state
+    virtual PtAsgn_reason getDeduction();                 // Return an implied literal based on the current state
 
     SolverId getId() { return id; }
     bool hasExplanation() { return has_explanation; }

--- a/src/tsolvers/TSolverHandler.cc
+++ b/src/tsolvers/TSolverHandler.cc
@@ -22,7 +22,7 @@ bool TSolverHandler::assertLit(PtAsgn asgn)
     // according to the schedule
     for (int i = 0; i < solverSchedule.size(); i++) {
         int idx = solverSchedule[i];
-        assert(tsolvers[idx] != NULL);
+        assert(tsolvers[idx] != nullptr);
         tsolvers[idx]->pushBacktrackPoint();
         if (!tsolvers[idx]->isKnown(asgn.tr)) {
             continue;
@@ -100,6 +100,18 @@ TRes TSolverHandler::check(bool complete)
     }
 
     return res_final;
+}
+
+// MB: This is currently needed to replace a common array of deduced elements with solver ID
+TSolver* TSolverHandler::getSolverDeducing(PTRef ptref) const {
+    // MB: Can we use solverSchedule? Double check this if theory combination is implemented
+    for (auto* solver : tsolvers) {
+        if (solver != nullptr && solver->isValid(ptref)) {
+            return solver;
+        }
+    }
+    assert(false);
+    return nullptr;
 }
 
 

--- a/src/tsolvers/TSolverHandler.cc
+++ b/src/tsolvers/TSolverHandler.cc
@@ -103,7 +103,8 @@ TRes TSolverHandler::check(bool complete)
 }
 
 // MB: This is currently needed to replace a common array of deduced elements with solver ID
-TSolver* TSolverHandler::getSolverDeducing(PTRef ptref) const {
+TSolver* TSolverHandler::getReasoningSolverFor(PTRef ptref) const {
+    assert(getLogic().isTheoryTerm(ptref));
     // MB: Can we use solverSchedule? Double check this if theory combination is implemented
     for (auto* solver : tsolvers) {
         if (solver != nullptr && solver->isValid(ptref)) {

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -45,16 +45,14 @@ protected:
 public:
     TermMapper    &tmap;
 protected:
-    vec<DedElem>  &deductions;
     vec<int>       solverSchedule;   // Why is this here and not in THandler?
     vec<TSolver*>  tsolvers;         // List of ordinary theory solvers
 
     Map<PTRef,PtAsgn,PTRefHash> substs;
 
-    TSolverHandler(SMTConfig & c, vec<DedElem> & d, TermMapper & tmap)
+    TSolverHandler(SMTConfig & c, TermMapper & tmap)
         : config(c)
         , tmap(tmap)
-        , deductions(d)
     {
         for (int i = 0; i < SolverDescr::getSolverList().size(); i++) {
             SolverDescr* sd = SolverDescr::getSolverList()[i];

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -79,6 +79,8 @@ public:
 //    virtual SolverId getId() const { return my_id; }
     virtual lbool getPolaritySuggestion(PTRef) const { return l_Undef; }
     TRes    check(bool);
-    TSolver* getSolverDeducing(PTRef) const;
+private:
+    // Helper method for computing reasons
+    TSolver* getReasoningSolverFor(PTRef ptref) const;
 };
 #endif

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -59,7 +59,7 @@ protected:
         for (int i = 0; i < SolverDescr::getSolverList().size(); i++) {
             SolverDescr* sd = SolverDescr::getSolverList()[i];
             SolverId id = (SolverId)(*sd);
-            while (id.id >= (unsigned)tsolvers.size()) tsolvers.push(NULL);
+            while (id.id >= (unsigned)tsolvers.size()) tsolvers.push(nullptr);
         }
     }
 public:
@@ -81,5 +81,6 @@ public:
 //    virtual SolverId getId() const { return my_id; }
     virtual lbool getPolaritySuggestion(PTRef) const { return l_Undef; }
     TRes    check(bool);
+    TSolver* getSolverDeducing(PTRef) const;
 };
 #endif

--- a/src/tsolvers/UFLRATHandler.cc
+++ b/src/tsolvers/UFLRATHandler.cc
@@ -4,17 +4,17 @@
 #include "InterpolatingEgraph.h"
 #include "Egraph.h"
 
-UFLRATHandler::UFLRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap)
-        : LRATHandler(c, l, d, tmap)
+UFLRATHandler::UFLRATHandler(SMTConfig & c, LRALogic & l, TermMapper & tmap)
+        : LRATHandler(c, l, tmap)
         , logic(l)
 {
-    lrasolver = new LRASolver(config, logic, deductions);
+    lrasolver = new LRASolver(config, logic);
     SolverId lra_id = lrasolver->getId();
     tsolvers[lra_id.id] = lrasolver;
     solverSchedule.push(lra_id.id);
 
-    ufsolver = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic, deductions)
-                                       : new Egraph(config, logic, deductions);
+    ufsolver = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic)
+                                       : new Egraph(config, logic);
 
     SolverId uf_id = ufsolver->getId();
     tsolvers[uf_id.id] = ufsolver;

--- a/src/tsolvers/UFLRATHandler.h
+++ b/src/tsolvers/UFLRATHandler.h
@@ -39,7 +39,7 @@ class UFLRATHandler : public LRATHandler
     LRASolver     *lrasolver;
     Egraph        *ufsolver;
   public:
-    UFLRATHandler(SMTConfig& c, LRALogic& l, vec<DedElem>& d, TermMapper& tmap);
+    UFLRATHandler(SMTConfig & c, LRALogic & l, TermMapper & tmap);
     virtual ~UFLRATHandler();
     virtual Logic& getLogic();
 

--- a/src/tsolvers/UFTHandler.cc
+++ b/src/tsolvers/UFTHandler.cc
@@ -3,12 +3,12 @@
 #include "InterpolatingEgraph.h"
 #include "Egraph.h"
 
-UFTHandler::UFTHandler(SMTConfig& c, Logic& l, vec<DedElem>& d, TermMapper& tmap)
-    : TSolverHandler(c, d, tmap)
+UFTHandler::UFTHandler(SMTConfig & c, Logic & l, TermMapper & tmap)
+    : TSolverHandler(c, tmap)
     , logic(l)
 {
-    egraph = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic, deductions)
-            : new Egraph(config, logic, deductions);
+    egraph = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic)
+            : new Egraph(config, logic);
 
     SolverId my_id = egraph->getId();
     tsolvers[my_id.id] = egraph;

--- a/src/tsolvers/UFTHandler.h
+++ b/src/tsolvers/UFTHandler.h
@@ -40,10 +40,8 @@ class UFTHandler : public TSolverHandler
     Logic&     logic;
   protected:
     Egraph*    egraph;
-//  protected:
-//    const vec<int>& getSolverSchedule() const;
   public:
-    UFTHandler(SMTConfig& c, Logic& l, vec<DedElem>& d, TermMapper& tmap);
+    UFTHandler(SMTConfig & c, Logic & l, TermMapper & tmap);
     virtual ~UFTHandler();
     // This is for simplification, needed to run the theory solver code
     // as if it were running inside a SAT solver.

--- a/src/tsolvers/bvsolver/BVSolver.cc
+++ b/src/tsolvers/bvsolver/BVSolver.cc
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 static SolverDescr descr_bv_solver("UF Solver", "Solver for Quantifier Free Bit Vectors");
 
 BVSolver::BVSolver (SMTConfig & c, MainSolver& s, BVLogic& l, vec<DedElem> & d)
- : TSolver ((SolverId)descr_bv_solver, (const char*)descr_bv_solver, c, d)
+ : TSolver((SolverId) descr_bv_solver, (const char *) descr_bv_solver, c)
  , mainSolver(s)
  , logic(l)
  , B(id, c, mainSolver, l, explanation, d, suggestions)
@@ -61,9 +61,10 @@ bool BVSolver::assertLit ( PtAsgn pta, bool reason )
     assert( pta.tr != PTRef_Undef );
     assert( pta.sgn != l_Undef );
 
-    Pterm& t = logic.getPterm(pta.tr);
-    if ( deduced[t.getVar()] != l_Undef && deduced[t.getVar()].polarity == pta.sgn && deduced[t.getVar()].deducedBy == id)
-        return true;
+    // MB:: todo is deduced?
+//    Pterm& t = logic.getPterm(pta.tr);
+//    if ( deduced[t.getVar()] != l_Undef && deduced[t.getVar()].polarity == pta.sgn && deduced[t.getVar()].deducedBy == id)
+//        return true;
 
     stack.push(pta);
     const bool res = B.assertLit(pta);

--- a/src/tsolvers/bvsolver/BVSolver.cc
+++ b/src/tsolvers/bvsolver/BVSolver.cc
@@ -54,9 +54,8 @@ lbool BVSolver::declareTerm(PTRef tr)
 // return false. The real consistency state will
 // be checked with "check"
 //
-bool BVSolver::assertLit ( PtAsgn pta, bool reason )
+bool BVSolver::assertLit ( PtAsgn pta )
 {
-    (void)reason;
     assert( pta.tr != PTRef_Undef );
     assert( pta.sgn != l_Undef );
 

--- a/src/tsolvers/bvsolver/BVSolver.h
+++ b/src/tsolvers/bvsolver/BVSolver.h
@@ -36,13 +36,13 @@ public:
     BVSolver(SMTConfig & c, MainSolver & s, BVLogic & l);
     ~BVSolver ( );
 
-    bool            assertLit          ( PtAsgn, bool = false );
-    void            pushBacktrackPoint ( );
-    void            popBacktrackPoint  ( );
-    TRes            check              ( bool );
-    void            computeModel       ( );
+    bool            assertLit          ( PtAsgn ) override;
+    void            pushBacktrackPoint ( )        override;
+    void            popBacktrackPoint  ( )        override;
+    TRes            check              ( bool )   override;
+    void            computeModel       ( )        override;
     virtual lbool   declareTerm        ( PTRef );
-    virtual ValPair getValue           ( PTRef );
+    virtual ValPair getValue           ( PTRef )  override;
 private:
 
     vec<PtAsgn> stack;

--- a/src/tsolvers/bvsolver/BVSolver.h
+++ b/src/tsolvers/bvsolver/BVSolver.h
@@ -33,10 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 class BVSolver : public TSolver
 {
 public:
-    BVSolver ( SMTConfig &
-             , MainSolver &
-             , BVLogic&
-             , vec<DedElem> & );
+    BVSolver(SMTConfig & c, MainSolver & s, BVLogic & l);
     ~BVSolver ( );
 
     bool            assertLit          ( PtAsgn, bool = false );
@@ -50,7 +47,7 @@ private:
 
     vec<PtAsgn> stack;
     MainSolver& mainSolver;
-    BVLogic&    logic;
+//    BVLogic&    logic; // MB: apparently not needed
     BitBlaster  B;
 };
 

--- a/src/tsolvers/bvsolver/BitBlaster.cc
+++ b/src/tsolvers/bvsolver/BitBlaster.cc
@@ -58,7 +58,7 @@ const char* BitBlaster::s_bbBvlrsh      = "s_bbBvlrsh";
 const char* BitBlaster::s_bbBvarsh      = "s_bbBvarsh";
 
 BitBlaster::BitBlaster(SolverId, SMTConfig & c, MainSolver & mainSolver, BVLogic & bvlogic, vec<PtAsgn> & ex,
-                       vec<DedElem> & d, vec<PTRef> & s)
+                       vec<PTRef> & s)
     : last_refined(0)
     , config      (c)
     , mainSolver  (mainSolver)
@@ -66,7 +66,6 @@ BitBlaster::BitBlaster(SolverId, SMTConfig & c, MainSolver & mainSolver, BVLogic
     , thandler    (mainSolver.getTHandler())
     , solverP     (mainSolver.getSMTSolver())
     , explanation (ex)
-    , deductions  (d)
     , suggestions (s)
     , has_model   (false)
     , bitwidth    (logic.getBitWidth())

--- a/src/tsolvers/bvsolver/BitBlaster.h
+++ b/src/tsolvers/bvsolver/BitBlaster.h
@@ -39,7 +39,7 @@ class BitBlaster
 public:
 
     BitBlaster(SolverId, SMTConfig & c, MainSolver & mainSolver, BVLogic & bvlogic, vec<PtAsgn> & ex,
-               vec<DedElem> & d, vec<PTRef> & s);
+               vec<PTRef> & s);
     ~BitBlaster ( );
 
     lbool inform             (PTRef); // For the interface for bitvector solver
@@ -166,7 +166,6 @@ private:
 
 
     vec<PtAsgn> &                   explanation;                   // Reference to explanation
-    vec<DedElem> &                  deductions;                    // Reference to deductions
     vec<PTRef> &                    suggestions;                   // Reference to suggestions
 
     vec<PTRef>                      variables;                     // Variables

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -210,8 +210,7 @@ private:
   static const char* s_val_false;
 
 public:
-  Egraph(SMTConfig & c , Logic& l
-          , vec<DedElem>& d);
+  Egraph(SMTConfig & c, Logic & l);
 
     virtual ~Egraph( ) {
         backtrackToStackSize( 0 );
@@ -231,9 +230,6 @@ private:
 public:
     inline const Enode& getEnode(ERef er) const { return enode_store[er]; }
     PTRef ERefToTerm(ERef er)    const    { return getEnode(er).getTerm(); }
-
-    bool  isDeduced(PTRef tr)    const    { return deduced[logic.getPterm(tr).getVar()] != l_Undef; }
-    lbool getDeduced(PTRef tr)   const    { return deduced[logic.getPterm(tr).getVar()].polarity; }
 
     bool  isConstant(ERef er)    const    {
         return (getEnode(er).isTerm() && logic.isConstant(getEnode(er).getTerm()));

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -269,7 +269,7 @@ public:
   //===========================================================================
   // Public APIs for Egraph Core Solver
 
-  bool                assertLit               (PtAsgn, bool = false);
+  bool                assertLit               (PtAsgn);
   void                pushBacktrackPoint      ( );                          // Push a backtrack point
   void                popBacktrackPoint       ( );                          // Backtrack to last saved point
   PTRef               getSuggestion           ( );                          // Return a suggested literal based on the current state

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -272,7 +272,6 @@ public:
   bool                assertLit               (PtAsgn, bool = false);
   void                pushBacktrackPoint      ( );                          // Push a backtrack point
   void                popBacktrackPoint       ( );                          // Backtrack to last saved point
-  PtAsgn_reason       getDeduction            ( );                          // Return an implied node based on the current state
   PTRef               getSuggestion           ( );                          // Return a suggested literal based on the current state
   lbool               getPolaritySuggestion   (PTRef);                      // Return a suggested polarity for a given literal
   void                getConflict             ( bool, vec<PtAsgn>& );       // Get explanation

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -1374,6 +1374,9 @@ bool Egraph::assertLit(PtAsgn pta)
 
     if (hasPolarity(pt_r) && getPolarity(pt_r) == sgn) {
         // Already known, no new information;
+        // MB: The deductions done by this TSolver are also marked using polarity.
+        //     The invariant is that TSolver will not process the literal again (when asserted from the SAT solver)
+        //     once it is marked for deduction, so the implementation must count with that.
         tsolver_stats.sat_calls ++;
         return true;
     }

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -1365,7 +1365,7 @@ bool Egraph::unmergeable (ERef x, ERef y, PtAsgn& r) const
     return false;
 }
 
-bool Egraph::assertLit(PtAsgn pta, bool)
+bool Egraph::assertLit(PtAsgn pta)
 {
     // invalidate values
     lbool sgn = pta.sgn;

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -412,10 +412,7 @@ void Egraph::declareTerm(PTRef tr) {
         enode_store.addDistClass(tr);
 
     if (logic.hasSortBool(tr)) {
-        Pterm& t = logic.getPterm(tr);
-        while (static_cast<unsigned int>(known_preds.size()) <= Idx(t.getId()))
-            known_preds.push(false);
-        known_preds[Idx(t.getId())] = true;
+        setKnown(tr);
     }
 }
 

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -161,30 +161,6 @@ void Egraph::popBacktrackPoint() {
 }
 
 //
-// Returns a deduction
-//
-PtAsgn_reason Egraph::getDeduction( ) {
-    // Communicate UF deductions
-    while ( deductions_next < th_deductions.size_( ) ) {
-        PtAsgn_reason pta = th_deductions[deductions_next++];
-        // For sure this has a deduced polarity
-        // If it has been pushed it is not a good candidate
-        // for deduction
-//        if ( hasPolarity(pta.tr) )
-//            continue;
-
-#ifdef STATISTICS
-        tsolver_stats.deductions_sent ++;
-#endif
-
-        return pta;
-    }
-
-    // We have already returned all the possible deductions
-    return PtAsgn_reason_Undef;
-}
-
-//
 // Returns a suggestion
 //
 PTRef Egraph::getSuggestion( )
@@ -1146,8 +1122,7 @@ void Egraph::deduce( ERef x, ERef y, PtAsgn reason ) {
         assert(logic.getPterm(v_tr).getVar() != -1);
         if (!hasPolarity(v_tr)) {
             assert(v_tr == enode_store.ERefToTerm[v]);
-            th_deductions.push(PtAsgn_reason(v_tr, deduced_polarity, reason.tr));
-            setPolarity(v_tr, deduced_polarity);
+            storeDeduction(PtAsgn_reason(v_tr, deduced_polarity, reason.tr));
 #ifdef VERBOSE_EUF
             cerr << "Deducing ";
             cerr << (deduced_polarity == l_False ? "not " : "");

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -1370,7 +1370,7 @@ bool Egraph::assertLit(PtAsgn pta)
     // invalidate values
     lbool sgn = pta.sgn;
     PTRef pt_r = pta.tr;
-    const Pterm& pt = logic.term_store[pt_r];
+    const Pterm& pt = logic.getPterm(pt_r);
 
     if (hasPolarity(pt_r) && getPolarity(pt_r) == sgn) {
         // Already known, no new information;

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -84,8 +84,8 @@ const char* Egraph::s_any_prefix = "a";
 const char* Egraph::s_val_true = "true";
 const char* Egraph::s_val_false = "false";
 
-Egraph::Egraph(SMTConfig & c, Logic& l , vec<DedElem>& d)
-      : TSolver            (descr_uf_solver, descr_uf_solver, c, d)
+Egraph::Egraph(SMTConfig & c, Logic& l)
+      : TSolver            (descr_uf_solver, descr_uf_solver, c)
       , logic              (l)
 #if defined(PEDANTIC_DEBUG)
       , enode_store        ( logic, forbid_allocator )
@@ -164,26 +164,17 @@ void Egraph::popBacktrackPoint() {
 // Returns a deduction
 //
 PtAsgn_reason Egraph::getDeduction( ) {
-
-#ifdef VERBOSE_EUF
-    cerr << "deductions available: " << th_deductions.size() - deductions_next << endl;
-#endif
     // Communicate UF deductions
     while ( deductions_next < th_deductions.size_( ) ) {
         PtAsgn_reason pta = th_deductions[deductions_next++];
         // For sure this has a deduced polarity
-        assert( logic.getPterm(pta.tr).getVar() == -1 || deduced[logic.getPterm(pta.tr).getVar()] != l_Undef );
         // If it has been pushed it is not a good candidate
         // for deduction
-        if ( hasPolarity(pta.tr) )
-            continue;
+//        if ( hasPolarity(pta.tr) )
+//            continue;
 
 #ifdef STATISTICS
         tsolver_stats.deductions_sent ++;
-#ifdef VERBOSE_EUF
-        cerr << "sent a deduction" << endl;
-#endif
-//    tsolvers_stats[ index ]->deductions_sent ++;
 #endif
 
         return pta;
@@ -205,9 +196,6 @@ PTRef Egraph::getSuggestion( )
     suggestions.pop();
     if ( hasPolarity(tr) )
       continue;
-    if ( logic.getPterm(tr).getVar() == -1 || deduced[logic.getPterm(tr).getVar()] != l_Undef )
-      continue;
-
     return tr;
   }
 
@@ -419,13 +407,6 @@ void Egraph::declareTerm(PTRef tr) {
 bool Egraph::addEquality(PtAsgn pa) {
     Pterm& pt = logic.getPterm(pa.tr);
     assert(pt.size() == 2);
-
-    if (pt.getVar() != -1 && deduced[pt.getVar()] != l_Undef && deduced[pt.getVar()] == pa.sgn) {
-#ifdef VERBOSE_EUF
-        cerr << "Assertion already deduced: " << logic.printTerm(pa.tr) << endl;
-#endif
-        return true;
-    }
     bool res = true;
     PTRef e = pt[0];
     for (int i = 1; i < pt.size() && res == true; i++)
@@ -462,13 +443,6 @@ bool Egraph::addDisequality(PtAsgn pa) {
     const Pterm& pt = logic.getPterm(pa.tr);
     bool res = true;
 
-    if (pt.getVar() != -1 && deduced[pt.getVar()] != l_Undef && deduced[pt.getVar()] == pa.sgn) {
-#ifdef VERBOSE_EUF
-        cerr << "Assertion already deduced: " << logic.printTerm(pa.tr) << endl;
-#endif
-        return true;
-    }
-
     if (pt.size() == 2)
         res = assertNEq(pt[0], pt[1], pa);
     else
@@ -502,12 +476,6 @@ bool Egraph::addDisequality(PtAsgn pa) {
 }
 
 bool Egraph::addTrue(PTRef term) {
-    if (logic.getPterm(term).getVar() != -1 && deduced[logic.getPterm(term).getVar()] != l_Undef && deduced[logic.getPterm(term).getVar()] == l_True) {
-#ifdef VERBOSE_EUF
-        cerr << "Assertion already deduced: " << logic.printTerm(term) << endl;
-#endif
-        return true;
-    }
     bool res = assertEq(term, logic.getTerm_true(), PtAsgn(term, l_True));
 #ifdef STATISTICS
     if (res == false)
@@ -523,12 +491,6 @@ bool Egraph::addTrue(PTRef term) {
 }
 
 bool Egraph::addFalse(PTRef term) {
-    if (logic.getPterm(term).getVar() != -1 && deduced[logic.getPterm(term).getVar()] != l_Undef && deduced[logic.getPterm(term).getVar()] == l_False) {
-#ifdef VERBOSE_EUF
-        cerr << "Assertion already deduced: " << logic.printTerm(term) << endl;
-#endif
-        return true;
-    }
     bool res = assertEq(term, logic.getTerm_false(), PtAsgn(term, l_False));
 
 
@@ -1182,12 +1144,10 @@ void Egraph::deduce( ERef x, ERef y, PtAsgn reason ) {
             continue;
         }
         assert(logic.getPterm(v_tr).getVar() != -1);
-        if (!hasPolarity(v_tr) && deduced[logic.getPterm(v_tr).getVar()] == l_Undef) {
-            if (logic.getPterm(v_tr).getVar() != -1) {
-                deduced[logic.getPterm(v_tr).getVar()] = {id, deduced_polarity};
-            }
+        if (!hasPolarity(v_tr)) {
             assert(v_tr == enode_store.ERefToTerm[v]);
             th_deductions.push(PtAsgn_reason(v_tr, deduced_polarity, reason.tr));
+            setPolarity(v_tr, deduced_polarity);
 #ifdef VERBOSE_EUF
             cerr << "Deducing ";
             cerr << (deduced_polarity == l_False ? "not " : "");
@@ -1437,46 +1397,43 @@ bool Egraph::assertLit(PtAsgn pta, bool)
     PTRef pt_r = pta.tr;
     const Pterm& pt = logic.term_store[pt_r];
 
-    assert(!hasPolarity(pt_r));
+    if (hasPolarity(pt_r) && getPolarity(pt_r) == sgn) {
+        // Already known, no new information;
+        tsolver_stats.sat_calls ++;
+        return true;
+    }
 
     bool res = true; // MB: true means NO conflict, false means conflict
     undo_stack_main.push(Undo(SET_POLARITY, pt_r));
+    setPolarity(pt_r, sgn);
 
     // Watch out here! the second argument of PtAsgn constructor is
     // in fact lbool!
     if (logic.isEquality(pt.symb()) && sgn == l_True) {
-        setPolarity(pt_r, l_True);
         res = addEquality(PtAsgn(pt_r, l_True));
     }
     else if (logic.isEquality(pt.symb()) && sgn == l_False) {
-        setPolarity(pt_r, l_False);
         res = addDisequality(PtAsgn(pt_r, l_False));
     }
     else if (logic.isDisequality(pt.symb()) && sgn == l_True) {
-        setPolarity(pt_r, l_True);
         res = addDisequality(PtAsgn(pt_r, l_True));
     }
     else if (logic.isDisequality(pt.symb()) && sgn == l_False) {
-        setPolarity(pt_r, l_False);
         res = addEquality(PtAsgn(pt_r, l_False));
     }
     else if (logic.isUP(pt_r) && sgn == l_True) {
-        setPolarity(pt_r, l_True);
         // MB: Short circuit evaluation is important, the second call should NOT happen if the first returns false
         res = addTrue(pt_r) && assertEq(boolTermToERef[logic.mkNot(pt_r)], enode_store.ERef_False, PtAsgn(pt_r, l_True));
     }
     else if (logic.isUP(pt_r) && sgn == l_False) {
-        setPolarity(pt_r, l_False);
         // MB: Short circuit evaluation is important, the second call should NOT happen if the first returns false
         res = addFalse(pt_r) && assertEq(boolTermToERef[logic.mkNot(pt_r)], enode_store.ERef_True, PtAsgn(pt_r, l_False));
     }
     else if (logic.hasSortBool(pt_r) && sgn == l_True) {
-        setPolarity(pt_r, l_True);
         // MB: Short circuit evaluation is important, the second call should NOT happen if the first returns false
         res = addTrue(pt_r) && assertEq(boolTermToERef[logic.mkNot(pt_r)], enode_store.ERef_False, PtAsgn(pt_r, l_True));
     }
     else if (logic.hasSortBool(pt_r) && sgn == l_False) {
-        setPolarity(pt_r, l_False);
         // MB: Short circuit evaluation is important, the second call should NOT happen if the first returns false
         res = addFalse(pt_r) && assertEq(boolTermToERef[logic.mkNot(pt_r)], enode_store.ERef_True, PtAsgn(pt_r, l_False));
     }

--- a/src/tsolvers/egraph/InterpolatingEgraph.h
+++ b/src/tsolvers/egraph/InterpolatingEgraph.h
@@ -10,8 +10,7 @@
 
 class InterpolatingEgraph : public Egraph {
 public:
-    InterpolatingEgraph(SMTConfig & c , Logic& l
-    , vec<DedElem>& d) : Egraph{c,l,d}
+    InterpolatingEgraph(SMTConfig & c, Logic & l) : Egraph{c, l}
             , cgraph(nullptr)
             , cgraph_( new CGraph( *this, config, l ) )
     {}

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -304,7 +304,6 @@ void LASolver::declareAtom(PTRef leq_tr)
 
     setInformed(leq_tr);
 
-
     if (status != INIT)
     {
         // Treat the PTRef as it is pushed on-the-fly
@@ -314,11 +313,7 @@ void LASolver::declareAtom(PTRef leq_tr)
     // DEBUG check
     isProperLeq(leq_tr);
 
-    const Pterm& t = logic.getPterm(leq_tr);
-
-    while (static_cast<unsigned int>(known_preds.size()) <= Idx(t.getId()))
-        known_preds.push(false);
-    known_preds[Idx(t.getId())] = true;
+    setKnown(leq_tr);
 }
 
 void LASolver::informNewSplit(PTRef tr)

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -573,9 +573,7 @@ void LASolver::getSimpleDeductions(LVRef v, LABoundRef br)
 void LASolver::deduce(LABoundRef bound_prop) {
     PtAsgn ba = getAsgnByBound(bound_prop);
     if (!hasPolarity(ba.tr)) {
-        lbool pol = ba.sgn;
-        th_deductions.push(PtAsgn_reason(ba.tr, pol, PTRef_Undef));
-        setPolarity(ba.tr, pol);
+        storeDeduction(PtAsgn_reason(ba.tr, ba.sgn, PTRef_Undef));
     }
 }
 
@@ -732,8 +730,6 @@ LASolver::~LASolver( )
      tsolver_stats.printStatistics(cerr);
 #endif // STATISTICS
 }
-
-PtAsgn_reason LASolver::getDeduction()  { if (deductions_next >= static_cast<unsigned>(th_deductions.size())) return PtAsgn_reason_Undef; else return th_deductions[deductions_next++]; }
 
 LALogic&  LASolver::getLogic()  { return logic; }
 

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -327,9 +327,8 @@ void LASolver::informNewSplit(PTRef tr)
 //
 // Push the constraint into the solver and increase the level
 //
-bool LASolver::assertLit( PtAsgn asgn, bool reason )
+bool LASolver::assertLit(PtAsgn asgn)
 {
-    ( void )reason;
     assert(asgn.sgn != l_Undef);
 
 //    printf("Assert %d\n", debug_assert_count++);

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -357,6 +357,9 @@ bool LASolver::assertLit(PtAsgn asgn)
 
     if (hasPolarity(asgn.tr) && getPolarity(asgn.tr) == asgn.sgn) {
         // already known, no new information
+        // MB: The deductions done by this TSolver are also marked using polarity.
+        //     The invariant is that TSolver will not process the literal again (when asserted from the SAT solver)
+        //     once it is marked for deduction, so the implementation must count with that.
         assert(getStatus());
         tsolver_stats.sat_calls ++;
         return getStatus();

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -113,7 +113,6 @@ public:
 
     // Return the conflicting bounds
     void          getConflict(bool, vec<PtAsgn>& e) override;
-    PtAsgn_reason getDeduction() override;
 
     LALogic&   getLogic() override;
     bool       isValid(PTRef tr) override;
@@ -138,9 +137,6 @@ protected:
     LVRef getVarForLeq(PTRef ref)  const  { return laVarMapper.getVarByLeqId(logic.getPterm(ref).getId()); }
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
     virtual void notifyVar(LVRef) {}                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
-    void getConflictingBounds( LVRef, vec<PTRef> & );       // Returns the bounds conflicting with the actual model
-    void getDeducedBounds( const Delta& c, BoundT, vec<PtAsgn_reason>& dst, SolverId solver_id ); // find possible deductions by value c
-    void getDeducedBounds( BoundT, vec<PtAsgn_reason>& dst, SolverId solver_id );                 // find possible deductions for actual bounds values
     void getSuggestions( vec<PTRef>& dst, SolverId solver_id );                                   // find possible suggested atoms
     void getSimpleDeductions(LVRef v, LABoundRef);      // find deductions from actual bounds position
     unsigned getIteratorByPTRef( PTRef e, bool );                                                 // find bound iterator by the PTRef

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -96,7 +96,7 @@ protected:
 
 public:
 
-    LASolver(SolverDescr dls, SMTConfig & c, LALogic& l, vec<DedElem>& d);
+    LASolver(SolverDescr dls, SMTConfig & c, LALogic & l);
 
     virtual ~LASolver( );                                      // Destructor ;-)
 

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -105,7 +105,7 @@ public:
     void  declareAtom        (PTRef tr) override;                // Inform the theory solver about the existence of an atom
     void  informNewSplit     (PTRef tr) override;                // Update bounds for the split variable
     bool  check_simplex      (bool);
-    bool  assertLit          ( PtAsgn , bool = false ) override; // Push the constraint into Solver
+    bool  assertLit          ( PtAsgn ) override;                // Push the constraint into Solver
     void  pushBacktrackPoint ( ) override;                       // Push a backtrack point
     void  popBacktrackPoint  ( ) override;                       // Backtrack to last saved point
     void  popBacktrackPoints ( unsigned int ) override;         // Backtrack given number of saved points

--- a/src/tsolvers/liasolver/LIASolver.cc
+++ b/src/tsolvers/liasolver/LIASolver.cc
@@ -117,8 +117,8 @@ LIASolver::getNewSplits(vec<PTRef>& splits)
     setStatus(SAT);
 }
 
-LIASolver::LIASolver(SMTConfig & c, LIALogic& l, vec<DedElem>& d)
-        : LASolver(descr_lia_solver, c, l, d)
+LIASolver::LIASolver(SMTConfig & c, LIALogic & l)
+        : LASolver(descr_lia_solver, c, l)
         , logic(l)
 
 {

--- a/src/tsolvers/liasolver/LIASolver.h
+++ b/src/tsolvers/liasolver/LIASolver.h
@@ -49,7 +49,7 @@ private:
 
 public:
 
-    LIASolver(SMTConfig & c, LIALogic& l, vec<DedElem>& d);
+    LIASolver(SMTConfig & c, LIALogic & l);
 
     ~LIASolver( );                                      // Destructor ;-)
 

--- a/src/tsolvers/lrasolver/LRASolver.cc
+++ b/src/tsolvers/lrasolver/LRASolver.cc
@@ -38,8 +38,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 static SolverDescr descr_lra_solver("LRA Solver", "Solver for Quantifier Free Linear Real Arithmetics");
 
-LRASolver::LRASolver(SMTConfig & c, LRALogic& l, vec<DedElem>& d)
-    : LASolver(descr_lra_solver, c, l, d)
+LRASolver::LRASolver(SMTConfig & c, LRALogic & l)
+    : LASolver(descr_lra_solver, c, l)
     , logic(l)
 {
     status = INIT;

--- a/src/tsolvers/lrasolver/LRASolver.h
+++ b/src/tsolvers/lrasolver/LRASolver.h
@@ -44,7 +44,7 @@ private:
 
 public:
 
-    LRASolver(SMTConfig & c, LRALogic& l, vec<DedElem>& d);
+    LRASolver(SMTConfig & c, LRALogic & l);
 
     ~LRASolver( ) ;                                      // Destructor ;-)
 


### PR DESCRIPTION
This PR removes the `deduced` array from Theory (and consequently from theory solvers). The TSolvers now use the polarity map to internally keep track of literals they already know the polarity of and asserting such literal would not change the state of the TSolver.

Additionally, some high-level methods are introduced to the base class TSolver which should be used by the derived theory solvers. This unifies the handling of deductions and marking literals as known and lifts the burden of implementing the correct behaviour from the derived theory solvers.