### PR TITLE
Providing support for building shared libraries/static libraries/target executables in isolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ include_directories(
 )
 
 if (BUILD_EXECUTABLES AND NOT BUILD_STATIC_LIBS)
-  message(FATAL_ERROR "Cannot build executables without also building shared libraries")
+  message(FATAL_ERROR "Cannot build executables without also building static libraries")
 endif()
 
 if (ITP_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ option(LADEBUG "Debug lookahead" OFF)
 option(PRINT_DECOMPOSED_STATS "Print statistics about decomposed interpolants" OFF)
 option(STATISTICS "Compute and print solver's statistics" OFF)
 option(USE_READLINE "Use readline over libedit" OFF)
+option(BUILD_STATIC_LIBS "Build static library" ON)
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+option(BUILD_EXECUTABLES "Build executables" ON)
 
 if (NOT USE_READLINE)
   find_package(LibEdit REQUIRED)
@@ -70,6 +73,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/proof
     ${GMP_INCLUDE_DIR}
 )
+
+if (BUILD_EXECUTABLES AND NOT BUILD_STATIC_LIBS)
+  message(FATAL_ERROR "Cannot build executables without also building shared libraries")
+endif()
 
 if (ITP_DEBUG)
     add_definitions(-DITP_DEBUG)
@@ -112,6 +119,9 @@ add_subdirectory(${CMAKE_SOURCE_DIR})
 ################# TESTING #############################################
 option(PACKAGE_TESTS "Build the tests" ON)
 if(PACKAGE_TESTS)
+    if (NOT BUILD_STATIC_LIBS)
+      message(FATAL_ERROR "Building tests requires static libraries")
+    endif()
     if(CMAKE_VERSION VERSION_LESS 3.11)
         MESSAGE(WARNING "Minimum CMAKE version for building tests is 3.11")
     else(CMAKE_VERSION VERSION_LESS 3.11)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ The default build type is RELEASE. Different build type can be configured using 
 $ cmake -DCMAKE_BUILD_TYPE=Debug ..
 ```
 
+### Restricting components to build
+
+By default, when building OpenSMT, an executable, a static library, and a shared library are created. However, in certain circumstances, it is desirable not to build components you do not need. In these instances, you *turn off* building components:
+
+- Passing `-DBUILD_STATIC_LIBS:BOOL=OFF` will *turn off* building the static archive for OpenSMT (`libapi_static.a`)
+
+- Passing `-DBUILD_SHARED_LIBS:BOOL=OFF` will *turn off* building the shared library for OpenSMT (`libopensmt2.so`)
+
+- Passing `-DBUILD_EXECUTABLES:BOOL=OFF` will *turn off* building the OpenSMT executable (`opensmt`)
+
+Given how the `opensmt` executable is built, you cannot build the executable (i.e., with the default value of `-DBUILD_EXECUTABLES:BOOL=ON`) with the static archive *off* (i.e., with `-DBUILD_STATIC_LIBS:BOOL=OFF`).
+
 
 ## Unit tests
 
@@ -52,8 +64,7 @@ $ ctest
 ```
 
 ## Installing OpenSMT2
-After a successful build, an executable, a static library, and a shared library are created.
-The path to the executable is `<BUILD_DIR>/src/bin/opensmt`, the libraries are located in `<BUILD_DIR>/src/api`.
+As long as you haven't disabled building them, the path to the OpenSMT executable is `<BUILD_DIR>/src/bin/opensmt`, the OpenSMT libraries are located in `<BUILD_DIR>/src/api`.
 To install OpenSMT in your system simply run
 ```
 $ make install

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 By default, when building OpenSMT, an executable, a static library, and a shared library are created. However, in certain circumstances, it is desirable not to build components you do not need. In these instances, you *turn off* building components:
 
-- Passing `-DBUILD_STATIC_LIBS:BOOL=OFF` will *turn off* building the static archive for OpenSMT (`libapi_static.a`)
+- Passing `-DBUILD_STATIC_LIBS:BOOL=OFF` will *turn off* building the static archive for OpenSMT (`libopensmt2.a`)
 
 - Passing `-DBUILD_SHARED_LIBS:BOOL=OFF` will *turn off* building the shared library for OpenSMT (`libopensmt2.so`)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,5 +12,6 @@ add_subdirectory(tsolvers)
 add_subdirectory(simplifiers)
 add_subdirectory(smtsolvers)
 add_subdirectory(parsers)
-add_subdirectory(bin)
-
+if (BUILD_EXECUTABLES)
+  add_subdirectory(bin)
+endif()

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -38,29 +38,29 @@ PUBLIC ${PUBLIC_SOURCES_TO_ADD}
 
 set(OBJECTS_TO_ADD $<TARGET_OBJECTS:api> ${OBJECTS_TO_ADD})
 
-add_library(api_shared SHARED ${OBJECTS_TO_ADD})
-add_library(api_static STATIC ${OBJECTS_TO_ADD})
-
-
 if (NOT USE_READLINE)
   set(line_library ${LibEdit_LIBRARIES})
-  target_include_directories(api_shared
-                             PRIVATE
-                             ${LibEdit_INCLUDE_DIRS})
-  target_include_directories(api_static
-                             PRIVATE
-                             ${LibEdit_INCLUDE_DIRS})
 else()
   set(line_library ${Readline_LIBRARY})
 endif()
 
-target_link_libraries(api_shared ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
+if (BUILD_SHARED_LIBS)
+  add_library(api_shared SHARED ${OBJECTS_TO_ADD})
+  target_link_libraries(api_shared ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
+  set_target_properties(api_shared PROPERTIES OUTPUT_NAME opensmt2)
+  target_include_directories(api_shared
+                             PRIVATE
+                             ${LibEdit_INCLUDE_DIRS})
+  install(TARGETS api_shared DESTINATION lib)
+endif()
 
-target_link_libraries(api_static ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
-
-set_target_properties(api_shared PROPERTIES OUTPUT_NAME opensmt2)
-
-install(TARGETS api_shared DESTINATION lib)
+if (BUILD_STATIC_LIBS)
+  add_library(api_static STATIC ${OBJECTS_TO_ADD})
+  target_link_libraries(api_static ${line_library} ${GMP_LIBRARIES} ${GMPXX_LIBRARIES} Threads::Threads)
+  target_include_directories(api_static
+                             PRIVATE
+                             ${LibEdit_INCLUDE_DIRS})
+endif()
 
 install(FILES Opensmt.h smt2tokens.h MainSolver.h Interpret.h
 DESTINATION ${INSTALL_HEADERS_DIR})

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -60,6 +60,7 @@ if (BUILD_STATIC_LIBS)
   target_include_directories(api_static
                              PRIVATE
                              ${LibEdit_INCLUDE_DIRS})
+  set_target_properties(api_static PROPERTIES OUTPUT_NAME opensmt2)
 endif()
 
 install(FILES Opensmt.h smt2tokens.h MainSolver.h Interpret.h


### PR DESCRIPTION
## Problem

Issue #132 requested the ability to build "only" the static libraries.

## Resolution

This PR adds support to:

- *turning off* building static libraries (`-DBUILD_STATIC_LIBS:BOOL=OFF`)

- *turning off* building shared libraries (`-DBUILD_SHARED_LIBS:BOOL=OFF`)

- *turning off* building the final executable (`-DBUILD_EXECUTABLES:BOOL=OFF`)

By default, *all* are `ON`, which means that the current behaviour is unchanged. You *cannot* build executables *without* building static libraries -- this will error-out when running `cmake`.

## Examples

### Build only static

```
cmake \
    -G Ninja \
    -DBUILD_STATIC_LIBS:BOOL=ON \
    -DBUILD_SHARED_LIBS:BOOL=OFF \
    -DBUILD_EXECUTABLES:BOOL=OFF \
    -DPACKAGE_TESTS:BOOL=OFF ..
```

### Build only shared

```
cmake \
    -G Ninja \
    -DBUILD_STATIC_LIBS:BOOL=OFF \
    -DBUILD_SHARED_LIBS:BOOL=ON \
    -DBUILD_EXECUTABLES:BOOL=OFF \
    -DPACKAGE_TESTS:BOOL=OFF ..
```

### Build executables (no shared)

Explicit:

```
cmake \
    -G Ninja \
    -DBUILD_STATIC_LIBS:BOOL=ON \
    -DBUILD_SHARED_LIBS:BOOL=OFF \
    -DBUILD_EXECUTABLES:BOOL=ON \
    -DPACKAGE_TESTS:BOOL=OFF ..
```

Alternative (static and executables default to `ON`):

```
cmake \
    -G Ninja \
    -DBUILD_SHARED_LIBS:BOOL=OFF \
    -DPACKAGE_TESTS:BOOL=OFF ..
```


Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>