### PR TITLE
Fixing warning about the use of a deprecated interface (sys_errlist)

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -57,9 +57,6 @@ bool stop;
 
 uint32_t LetFrame::id_cnt = 0;
 
-// how big of a buffer do we want for obtain error strings?
-const int err_str_buf_size = 256;
-
 
 /***********************************************************
  * Class defining interpreter
@@ -1166,11 +1163,8 @@ int Interpret::interpPipe() {
         if (bts_rd < 0) {
             done = true;
 
-            // buffer to obtaining the error text in a thread-safe way
-            char err_buf[err_str_buf_size];
-
             // obtain the error string
-            char const * err_str = strerror_r(errno, err_buf, err_str_buf_size);
+            char const * err_str = strerror(errno);
 
             // format the error
             notify_formatted(true, err_str);

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -57,6 +57,9 @@ bool stop;
 
 uint32_t LetFrame::id_cnt = 0;
 
+// how big of a buffer do we want for obtain error strings?
+const int err_str_buf_size = 256;
+
 
 /***********************************************************
  * Class defining interpreter
@@ -1162,7 +1165,15 @@ int Interpret::interpPipe() {
         }
         if (bts_rd < 0) {
             done = true;
-            notify_formatted(true, sys_errlist[errno]);
+
+            // buffer to obtaining the error text in a thread-safe way
+            char err_buf[err_str_buf_size];
+
+            // obtain the error string
+            char const * err_str = strerror_r(errno, err_buf, err_str_buf_size);
+
+            // format the error
+            notify_formatted(true, err_str);
             continue;
         }
 


### PR DESCRIPTION
## Issue

When compiling, I see these _warnings_:

```
[12/16] Linking CXX shared library src/api/libopensmt2.so
src/api/CMakeFiles/api.dir/Interpret.cc.o: In function `Interpret::interpPipe()':
Interpret.cc:(.text+0x856c): warning: `sys_errlist' is deprecated; use `strerror' or `strerror_r' instead
[16/16] Linking CXX executable src/bin/opensmt
src/api/libapi_static.a(Interpret.cc.o): In function `Interpret::interpPipe()':
Interpret.cc:(.text+0x856c): warning: `sys_errlist' is deprecated; use `strerror' or `strerror_r' instead
```

Compiler (stock CentOS 8):

```
$ gcc --version
gcc (GCC) 8.3.1 20190507 (Red Hat 8.3.1-4)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Resolution

This PR updates the OpenSMT code to use one of the suggested alternatives. I have opted for `strerror_r` [because it is the "thread-safe" version](https://linux.die.net/man/3/strerror_r).

There's some discussion about the size of the static buffer to use when calling `strerror_r`:

- https://stackoverflow.com/questions/423248/what-size-should-i-allow-for-strerror-r

(`256` is the value from the second-highest answer, which is what I have used)



Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>