### PR TITLE
enabling MacOS build in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: cpp
 branches:
     only:
         - master
-
 os:
   - linux
 
@@ -35,6 +34,9 @@ matrix:
     - os: linux
       dist: bionic
       compiler: clang
+    - os: osx
+      compiler: clang
+      env: CMAKE_BUILD_TYPE=Debug
 
 addons:
   apt:
@@ -47,7 +49,13 @@ addons:
       - bison
       - flex
 
-install: true
+before_install:
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        brew install bison;
+        export PATH="/usr/local/opt/bison/bin:$PATH";
+      fi
+
+install: skip
 
 before_script:
     - FLAGS="-Wall -Werror"
@@ -55,7 +63,6 @@ before_script:
     - mkdir build && mkdir ${INSTALL}
 
 script:
-  - set -e
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS="$FLAGS" -DUSE_READLINE:BOOL=${USE_READLINE} -DCMAKE_INSTALL_PREFIX=${INSTALL} ..
   - make


### PR DESCRIPTION
This PR add a MacOS build to Travis CI.
We add only a single configuration for MacOS using Debug build and Clang compiler, because the MacOS is slower than Linux build. This is caused by the need to upgrade Bison, which requires an update of the Homebrew in the VM of the build.