### PR TITLE
Restricting dependency on Readline/Editline to the situation when executable is needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,13 @@ option(BUILD_STATIC_LIBS "Build static library" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(BUILD_EXECUTABLES "Build executables" ON)
 
-if (NOT USE_READLINE)
-  find_package(LibEdit REQUIRED)
-else()
-  find_package(Readline REQUIRED)
-endif()
+if (BUILD_EXECUTABLES)
+    if (NOT USE_READLINE)
+      find_package(LibEdit REQUIRED)
+    else()
+      find_package(Readline REQUIRED)
+    endif()
+endif(BUILD_EXECUTABLES)
 
 find_package(GMP REQUIRED)
 

--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -107,7 +107,6 @@ class Interpret {
     void                        exit();
     void                        getInterpolants(const ASTNode& n);
     void                        interp (ASTNode& n);
-    void                        execute(const ASTNode* n);
 
     void                        notify_formatted(bool error, const char* s, ...);
     void                        notify_success();
@@ -141,11 +140,16 @@ class Interpret {
 
     int interpFile(FILE* in);
     int interpFile(char *content);
-    int interpInteractive(FILE* in);
     int interpPipe();
+
+    void    execute(const ASTNode* n);
+    bool    gotExit() const { return f_exit; }
+
 
     ValPair getValue       (PTRef tr) const;
     bool    getAssignment  ();
+
+    void    reportError(char const * msg) { notify_formatted(true, msg); }
 
 
     PTRef getParsedFormula();

--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -33,6 +33,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <csignal>
 #include <iostream>
 
+#if !defined(USE_READLINE)
+#include <editline/readline.h>
+#else
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif
+
 #if defined(__linux__)
 #include <fpu_control.h>
 #endif
@@ -48,6 +55,8 @@ void        catcher            ( int );
  *                                  MAIN                                     *
  *                                                                           *
 \*****************************************************************************/
+
+void interpretInteractive(Interpret & interpret, FILE* input);
 
 int main( int argc, char * argv[] )
 {
@@ -116,7 +125,7 @@ int main( int argc, char * argv[] )
         }
         else {
             fin = stdin;
-            interpreter.interpInteractive(fin);
+            interpretInteractive(interpreter, fin);
         }
     }
     else {
@@ -145,6 +154,72 @@ int main( int argc, char * argv[] )
     }
 
     return 0;
+}
+
+void interpretInteractive(Interpret & interpret, FILE* input) {
+    char* line_read = nullptr;
+    bool done = false;
+    int par = 0;
+    int pb_cap = 1;
+    int pb_sz = 0;
+    char *parse_buf = (char *) malloc(pb_cap);
+
+    while (!done) {
+        if (line_read) {
+            free(line_read);
+            line_read = nullptr;
+        }
+        if (par == 0)
+            line_read = readline("> ");
+        else if (par > 0)
+            line_read = readline("... ");
+        else {
+            interpret.reportError("interactive reader: unbalanced parentheses");
+            parse_buf[pb_sz-1] = 0; // replace newline with end of string
+            add_history(parse_buf);
+            pb_sz = 0;
+            par = 0;
+        }
+
+        if (line_read && *line_read) {
+            for (int i = 0; line_read[i] != '\0'; i++) {
+                char c = line_read[i];
+                if (c == '(') par ++;
+                if (c == ')') par --;
+                while (pb_cap - 2 < pb_sz) { // the next char and terminating zero
+                    pb_cap *= 2;
+                    parse_buf = (char*) realloc(parse_buf, pb_cap);
+                }
+                parse_buf[pb_sz ++] = c;
+            }
+            if (par == 0) {
+                parse_buf[pb_sz] = '\0';
+                // Parse starting from the command nonterminal
+                // Parsing should be done from a string that I get from the readline
+                // library.
+                Smt2newContext context(parse_buf);
+                int rval = smt2newparse(&context);
+                if (rval != 0)
+                    interpret.reportError("scanner");
+                else {
+                    const ASTNode* r = context.getRoot();
+                    interpret.execute(r);
+                    done = interpret.gotExit();
+                }
+                add_history(parse_buf);
+                pb_sz = 0;
+            }
+            else { // add the line break
+                while (pb_cap - 2 < pb_sz) { // the next char and terminating zero
+                    pb_cap *= 2;
+                    parse_buf = (char*) realloc(parse_buf, pb_cap);
+                }
+                parse_buf[pb_sz ++] = '\n';
+            }
+        }
+    }
+    if (parse_buf) free(parse_buf);
+    if (line_read) free(line_read);
 }
 
 namespace opensmt {


### PR DESCRIPTION
This PR addresses issue #135 

Since the command line interaction library (Readline or Editline) is needed only when executable is being built, we can remove the dependency in situations where executable is not required.