### PR TITLE
Fixing undefined behaviour in absVal

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -63,11 +63,15 @@ inline State& operator |= (State& lhs, State rhs)
 }
 
 inline uword absVal(word x) {
-    return x>=0 ? x : -x;
+    // Taking just (- WORD_MIN) is undefined behaviour, changed according to https://stackoverflow.com/questions/12231560/correct-way-to-take-absolute-value-of-int-min
+    return x < 0 ? -((uword)(x))
+                 : +((uword)(x));
 }
 
 inline ulword absVal(lword x) {
-    return x>=0 ? x : -x;
+    // Taking just (- LWORD_MIN) is undefined behaviour
+    return x < 0 ? -((ulword)(x))
+                 : +((ulword)(x));
 }
 
 class FastRational

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -106,7 +106,7 @@ public:
     FastRational( ) : state{State::WORD_VALID}, num(0), den(1) { }
     FastRational( word x ) : state{State::WORD_VALID}, num(x), den(1) { }
     FastRational(uint32_t);
-    FastRational(word num, word den) : state{State::WORD_VALID}, num(num), den(den) { }
+    inline FastRational(word n, uword d);
     explicit FastRational(const char* s, const int base = 10);
     inline FastRational( const FastRational & );
     inline FastRational(FastRational&& other) noexcept;
@@ -206,7 +206,6 @@ public:
     inline FastRational operator-() const;
     inline void negate();
 private:
-    inline FastRational(word n, uword d);
     void print_(std::ostream& out) const;
     static inline int compare(lword a, lword b) {
         if (a < b) return -1;

--- a/test/unit/test_Rationals.cpp
+++ b/test/unit/test_Rationals.cpp
@@ -26,6 +26,12 @@ TEST(Rationals_test, test_abs_val_int32min)
     ASSERT_EQ(absVal(x), 2147483648);
 }
 
+TEST(Rationals_test, test_normalized)
+{
+    FastRational toNormalize(2,4);
+    EXPECT_EQ(toNormalize.get_num(), 1);
+    EXPECT_EQ(toNormalize.get_den(), 2);
+}
 
 TEST(Rationals_test, test_hash_function)
 {


### PR DESCRIPTION
Fixes #159 
For INT32_MIN in type int32_t the negation operation cannot be represented and `- INT32_MIN` is undefined behaviour if the type of the variable is int32_t.
For the discussion and proposed solution see [this post](https://stackoverflow.com/questions/12231560/correct-way-to-take-absolute-value-of-int-min).

Additionally, the constructor of FastRational that was not normalizing the numerator and denumerator has been removed since could break the invariant of the type.