### PR TITLE
Small refactoring of some operations in FastRationals

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -196,11 +196,10 @@ private:
     friend inline void substractionAssign   ( FastRational &, const FastRational & );
     friend inline void multiplicationAssign( FastRational &, const FastRational & );
     friend inline void divisionAssign      ( FastRational &, const FastRational & );
-    friend FastRational gcd(FastRational&, FastRational&);
-    friend FastRational lcm(FastRational&, FastRational&);
-    friend FastRational fastrat_fdiv_q(FastRational& n, FastRational& d);
-    friend FastRational fastrat_fdiv_q(FastRational&& n, FastRational&& d);
-    friend FastRational divexact(FastRational& n, FastRational& d);
+    friend FastRational gcd(FastRational const &, FastRational const &);
+    friend FastRational lcm(FastRational const &, FastRational const &);
+    friend FastRational fastrat_fdiv_q(FastRational const & n, FastRational const & d);
+    friend FastRational divexact(FastRational const & n, FastRational const & d);
 public:
     void print_details ( std::ostream & ) const;
     void print         ( std::ostream & ) const;
@@ -391,15 +390,9 @@ public:
         return r;
     }
 };
-// Divide n by d, forming a quotient q.
-// Rounds q down towards -infinity, and r will have the same sign as d.
-FastRational fastrat_fdiv_q(FastRational&& n, FastRational&& d);
-FastRational fastrat_fdiv_q(FastRational& n, FastRational& d);
+
+FastRational fastrat_fdiv_q(FastRational const & n, FastRational const & d);
 FastRational fastrat_round_to_int(const FastRational& n);
-
-FastRational gcd(FastRational& a, FastRational& b);
-
-FastRational lcm(FastRational& a, FastRational& b);
 
 struct FastRationalHash {
     uint32_t operator() (const FastRational& s) const {

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -223,16 +223,21 @@ private:
     mpq_t mpq;
 public:
     FastRational get_den() const {
-        if (wordPartValid() && den <= INT32_MAX)
-            return (uword)den;
-        else
+        if (wordPartValid() && den <= INT32_MAX) {
+            return FastRational((uword)den);
+        }
+        else {
+            force_ensure_mpq_valid();
             return FastRational(mpz_class(mpq_denref(mpq)));
+        }
     }
     FastRational get_num() const {
-        if (wordPartValid())
-            return num;
-        else
+        if (wordPartValid()) {
+            return FastRational(num);
+        }
+        else {
             return FastRational(mpz_class(mpq_numref(mpq)));
+        }
     }
 
     inline int compare(const FastRational& b) const;


### PR DESCRIPTION
This PR fixes a bug in FastRational::get_den() and unifies the style of methods `gdc, lcm, divexact, fastrat_fdiv_q` with the rest of operations over FastRationals