### PR TITLE
Moving some expensive debugging checks in Simplex solver behind a special macro that is OFF by default

### DIFF
--- a/src/tsolvers/lasolver/CMakeLists.txt
+++ b/src/tsolvers/lasolver/CMakeLists.txt
@@ -18,5 +18,10 @@ target_sources(tsolvers
     PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Simplex.cc"
     )
 
+option(SIMPLEX_DEBUG "Deeper debugging of Simplex" OFF)
+
+if (SIMPLEX_DEBUG)
+    add_definitions(-DSIMPLEX_DEBUG)
+endif (SIMPLEX_DEBUG)
 
 

--- a/src/tsolvers/lasolver/Simplex.cc
+++ b/src/tsolvers/lasolver/Simplex.cc
@@ -7,6 +7,12 @@
 #include <limits>
 #include <algorithm>
 
+#ifdef SIMPLEX_DEBUG
+#define simplex_assert(x) assert(x)
+#else
+#define simplex_assert(x)
+#endif // SIMPLEX_DEBUG
+
 // MB: helper functions
 namespace{
     bool isBoundSatisfied(Delta const & val, LABound const & bound ) {
@@ -256,7 +262,7 @@ void Simplex::eraseCandidate(LVRef candidateVar) {
 void Simplex::pivot(const LVRef bv, const LVRef nv){
     assert(tableau.isBasic(bv));
     assert(tableau.isNonBasic(nv));
-    assert(valueConsistent(bv));
+    simplex_assert(valueConsistent(bv));
 //    tableau.print();
     updateValues(bv, nv);
     tableau.pivot(bv, nv);
@@ -272,8 +278,8 @@ void Simplex::pivot(const LVRef bv, const LVRef nv){
         }
     }
 //    tableau.print();
-    assert(checkTableauConsistency());
-    assert(checkValueConsistency());
+    simplex_assert(checkTableauConsistency());
+    simplex_assert(checkValueConsistency());
 }
 
 void Simplex::changeValueBy(LVRef var, const Delta & diff) {

--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -5,6 +5,12 @@
 #include "Tableau.h"
 #include <iostream>
 
+#ifdef SIMPLEX_DEBUG
+#define simplex_assert(x) assert(x)
+#else
+#define simplex_assert(x)
+#endif // SIMPLEX_DEBUG
+
 using namespace opensmt;
 namespace {
     template<class C, class E>
@@ -284,7 +290,7 @@ void Tableau::quasiToBasic(LVRef v) {
     }
     varTypes[getVarId(v)] = VarType::BASIC;
     assert(isBasic(v));
-    assert(checkConsistency());
+    simplex_assert(checkConsistency());
 }
 
 void Tableau::basicToQuasi(LVRef v) {
@@ -297,7 +303,7 @@ void Tableau::basicToQuasi(LVRef v) {
         assert(isNonBasic(term.var));
         removeRowFromColumn(v, term.var);
     }
-    assert(checkConsistency());
+    simplex_assert(checkConsistency());
 }
 
 void Tableau::ensureTableauReadyFor(LVRef v) {


### PR DESCRIPTION
The reason is to improve the runtime for common debugging of LA examples since some of the checks in Simplex are very expensive and are called very often.