### PR TITLE
Some cleanup in comparing and sorting terms

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1984,6 +1984,6 @@ inline bool Logic::isPredef           (string&)        const { return false; };
 char* Logic::printTerm        (PTRef tr)                 const { return printTerm_(tr, false, false); }
 char* Logic::printTerm        (PTRef tr, bool l, bool s) const { return printTerm_(tr, l, s); }
 
-void Logic::termSort(vec<PTRef>& v) const { sort(v, LessThan_PTRef()); }
+void Logic::termSort(vec<PTRef>& v) const { sort(v, std::less<PTRef>{}); }
 
 void  Logic::purify     (PTRef r, PTRef& p, lbool& sgn) const {p = r; sgn = l_True; while (isNot(p)) { sgn = sgn^1; p = getPterm(p)[0]; }}

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -26,22 +26,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef OPENSMT_PTREF_H
 #define OPENSMT_PTREF_H
 
-#include "Map.h"
 #include <functional>
 
 struct PTRef {
     uint32_t x;
-//    void operator= (uint32_t v) { x = v; }
-    inline friend bool operator== (const PTRef& a1, const PTRef& a2)   { return a1.x == a2.x; }
-    inline friend bool operator!= (const PTRef& a1, const PTRef& a2)   { return a1.x != a2.x; }
-    inline friend bool operator< (const PTRef& a1, const PTRef& a2)    { return a1.x > a2.x;  }
+    inline friend bool operator== (PTRef a1, PTRef a2)   { return a1.x == a2.x; }
+    inline friend bool operator!= (PTRef a1, PTRef a2)   { return a1.x != a2.x; }
+    inline friend bool operator<  (PTRef a1, PTRef a2)   { return a1.x < a2.x;  }
 };
 
 const struct PTRef PTRef_Undef = {INT32_MAX};
 
 struct PTRefHash {
-    uint32_t operator () (const PTRef& s) const {
-        return (uint32_t)s.x; }
+    uint32_t operator () (PTRef s) const { return s.x; }
 };
 
 struct PTRefPairHash {
@@ -49,12 +46,6 @@ struct PTRefPairHash {
         std::hash<uint32_t> hasher;
         return (hasher(p.first.x) ^ hasher(p.second.x));
     }
-};
-
-
-template <>
-struct Equal<const PTRef> {
-    bool operator() (const PTRef& s1, const PTRef& s2) const { return s1 == s2; }
 };
 
 #endif //OPENSMT_PTREF_H

--- a/src/pterms/PtStructs.cc
+++ b/src/pterms/PtStructs.cc
@@ -11,10 +11,6 @@ uint32_t PtAsgnHash::operator () (const PtAsgn& s) const {
 }
 
 
-
-bool LessThan_PTRef::operator () (PTRef& x, PTRef& y) { return x.x < y.x; }
-
-
 ValPair::~ValPair() {
     if (val != NULL)
         free(val);

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -65,10 +65,6 @@ public:
 
 static class PtAsgn_reason PtAsgn_reason_Undef(PTRef_Undef, l_Undef, PTRef_Undef);
 
-struct LessThan_PTRef {
-    bool operator () (PTRef& x, PTRef& y);// { return x.x < y.x; }
-};
-
 struct LessThan_PtAsgn {
     bool operator () (PtAsgn x, PtAsgn y) {
         return x.tr.x < y.tr.x;

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -85,7 +85,6 @@ class Pterm {
 
 
     friend class PtermAllocator;
-    friend void  ptermSort(Pterm&);
   public:
     // forbid any copies or moves
     Pterm() = delete;
@@ -247,17 +246,4 @@ class PtermAllocator : public RegionAllocator<uint32_t>
     }*/
     friend class PtStore;
 };
-
-inline void ptermSort(Pterm& t) { sort(t.args, t.size(), LessThan_PTRef()); }
-
-inline bool isSorted(vec<PTRef>& args) {
-    LessThan_PTRef lt;
-    if (args.size() == 0) return true;
-    PTRef c = args[0];
-    for (int i = 1; i < args.size(); i++) {
-        if (!lt.operator()(c, args[i])) return false;
-        c = args[i];
-    }
-    return true;
-}
 #endif

--- a/src/simplifiers/LA.h
+++ b/src/simplifiers/LA.h
@@ -64,7 +64,7 @@ public:
   inline bool              isTrue     ( ) { return polynome.size( ) == 1 && ( r == EQ ? polynome[ PTRef_Undef ] == 0 : polynome[ PTRef_Undef ] >= 0 ); }
   inline bool              isFalse    ( ) { return polynome.size( ) == 1 && ( r == EQ ? polynome[ PTRef_Undef ] != 0 : polynome[ PTRef_Undef ] < 0 ); }
 
-  typedef map< PTRef, opensmt::Real >    polynome_t;
+  using polynome_t = std::map<PTRef, opensmt::Real>;
 
   void                     initialize   (PTRef, bool canonize = true);      // Initialize
   PTRef                    solve        ();           // Solve w.r.t. some variable

--- a/src/tsolvers/bvsolver/BVStore.h
+++ b/src/tsolvers/bvsolver/BVStore.h
@@ -29,6 +29,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "Bvector.h"
 
+#include "Map.h"
+
 class BVStore
 {
     BvectorAllocator bva;

--- a/src/tsolvers/bvsolver/Bvector.h
+++ b/src/tsolvers/bvsolver/Bvector.h
@@ -44,10 +44,6 @@ struct BVRefHash {
         return (uint32_t)s.x; }
 };
 
-template <>
-struct Equal<const BVRef> {
-    bool operator() (const BVRef& s1, const BVRef& s2) const { return s1 == s2; }
-};
 typedef uint32_t BVId; // Used as an array index
 
 struct NameAsgn {

--- a/test/unit/test_LogicMkTerms.cc
+++ b/test/unit/test_LogicMkTerms.cc
@@ -3,6 +3,8 @@
 //
 #include <gtest/gtest.h>
 #include <Logic.h>
+#include <LIALogic.h>
+#include <LRALogic.h>
 
 class LogicMkTermsTest: public ::testing::Test {
 public:
@@ -145,4 +147,51 @@ TEST_F(LogicMkTermsTest, testIteration) {
             ASSERT_TRUE(found);
         }
     }
+}
+
+/*
+ *  LA specific terms
+ */
+
+class LALogicMkTermsTest: public ::testing::Test {
+public:
+    LIALogic lialogic;
+    LRALogic lralogic;
+    LALogicMkTermsTest() {}
+};
+
+TEST_F(LALogicMkTermsTest, testNormalizationOfInequalitiesLRA) {
+    auto & logic = lralogic;
+    auto x = logic.mkNumVar("x");
+    auto y = logic.mkNumVar("y");
+    auto zero = logic.getTerm_NumZero();
+    auto two = logic.mkConst(2);
+    auto four = logic.mkConst(4);
+    auto twoy = logic.mkNumTimes(two, y);
+    auto foury = logic.mkNumTimes(four, y);
+    auto twox = logic.mkNumTimes(two, x);
+
+    auto term1 = logic.mkNumPlus(x, twoy);
+    auto term2 = logic.mkNumPlus(foury, twox);
+    auto ineq1 = logic.mkNumLeq(zero, term1);
+    auto ineq2 = logic.mkNumLeq(zero, term2);
+    ASSERT_EQ(ineq1, ineq2);
+}
+
+TEST_F(LALogicMkTermsTest, testNormalizationOfInequalitiesLIA) {
+    auto & logic = lialogic;
+    auto x = logic.mkNumVar("x");
+    auto y = logic.mkNumVar("y");
+    auto zero = logic.getTerm_NumZero();
+    auto two = logic.mkConst(2);
+    auto four = logic.mkConst(4);
+    auto twoy = logic.mkNumTimes(two, y);
+    auto foury = logic.mkNumTimes(four, y);
+    auto twox = logic.mkNumTimes(two, x);
+
+    auto term1 = logic.mkNumPlus(x, twoy);
+    auto term2 = logic.mkNumPlus(foury, twox);
+    auto ineq1 = logic.mkNumLeq(zero, term1);
+    auto ineq2 = logic.mkNumLeq(zero, term2);
+    ASSERT_EQ(ineq1, ineq2);
 }


### PR DESCRIPTION
Resolves #105 
The main change is using more natural implementation of operator< on PTRefs, which in turn renders the class LessThan_PTRef redundant.
Other changes are some related cleanup, including taking PTRefs argument in functions by value instead of by reference, since PTRefs are basically just 32-bit numbers, so potentially they can better fit in registers than 64-bit references.