### PR TITLE
Normalizing LIA inequalities with bound tightening already in Logic

### DIFF
--- a/src/common/OsmtInternalException.h
+++ b/src/common/OsmtInternalException.h
@@ -5,7 +5,12 @@
 #pragma once
 
 class OsmtInternalException : public std::exception {
-
+    std::string msg;
+public:
+    OsmtInternalException(const std::string & msg) : msg(msg) {}
+    OsmtInternalException(const char * msg) : msg(msg) {}
+    OsmtInternalException() : msg("Unknown internal error") {}
+    virtual const char* what() const noexcept override { return msg.c_str(); }
 };
 
 

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -5,6 +5,7 @@
 #include "LA.h"
 #include "LALogic.h"
 #include "FastRational.h"
+#include "OsmtInternalException.h"
 
 #include <memory>
 
@@ -134,11 +135,11 @@ PTRef LALogic::normalizeMul(PTRef mul)
     PTRef v = PTRef_Undef;
     PTRef c = PTRef_Undef;
     splitTermToVarAndConst(mul, v, c);
-    opensmt::Number r = getNumConst(c); //PS. shall I add opensmt::Integer j = getNumConst(c)
-    if (r < 0) //PS. OR (l < 0)
+    if (getNumConst(c).sign() < 0) {
         return mkNumNeg(v);
-    else
+    } else {
         return v;
+    }
 }
 lbool LALogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Map<PTRef, PtAsgn, PTRefHash> & substitutions)
 {
@@ -586,52 +587,28 @@ PTRef LALogic::mkNumLeq(PTRef lhs, PTRef rhs)
     // Should be in the form that on one side there is a constant
     // and on the other there is a sum
     PTRef sum_tmp = [&](){
-       if (lhs == getTerm_NumZero()) {return rhs;}
-       if (rhs == getTerm_NumZero()) {return mkNumNeg(lhs);}
+       if (lhs == getTerm_NumZero()) { return rhs; }
+       if (rhs == getTerm_NumZero()) { return mkNumNeg(lhs); }
        vec<PTRef> sum_args;
        sum_args.push(rhs);
        sum_args.push(mkNumNeg(lhs));
        return mkNumPlus(sum_args);
-    }();
+    }(); // now the inequality is "0 <= sum_tmp" where "sum_tmp = rhs - lhs"
     if (isConstant(sum_tmp)) {
         opensmt::Number const & v = this->getNumConst(sum_tmp);
         return v.sign() < 0 ? getTerm_false() : getTerm_true();
-    } if (isNumTimes(sum_tmp)) {
-        sum_tmp = normalizeMul(sum_tmp);
+    } if (isNumVarOrIte(sum_tmp) || isNumTimes(sum_tmp)) { // "sum_tmp = c * v", just scale to "v" or "-v" without changing the sign
+        sum_tmp = isNumTimes(sum_tmp) ? normalizeMul(sum_tmp) : sum_tmp;
+        vec<PTRef> args;
+        args.push(getTerm_NumZero());
+        args.push(sum_tmp);
+        return mkFun(get_sym_Num_LEQ(), args);
     } else if (isNumPlus(sum_tmp)) {
         // Normalize the sum
-        sum_tmp = normalizeSum(sum_tmp); //Now the sum is normalized by dividing with the "first" factor.
+        return sumToNormalizedInequality(sum_tmp);
     }
-    vec<PTRef> args;
-    args.push(getTerm_NumZero());
-    args.push(sum_tmp);
-    // Otherwise no operation, already normalized
-    if (isNumPlus(sum_tmp)) {
-        vec<PTRef> nonconst_args;
-        PTRef c = PTRef_Undef;
-        const Pterm& t = getPterm(sum_tmp);
-        nonconst_args.capacity(t.size());
-        for (int i = 0; i < t.size(); i++) {
-            if (!isConstant(t[i]))
-                nonconst_args.push(t[i]);
-            else {
-                assert(c == PTRef_Undef);
-                c = t[i];
-            }
-        }
-        if (c == PTRef_Undef) {
-            assert(args[1] == mkNumPlus(nonconst_args));
-            // The correct arguments are set up already
-        } else {
-            args[0] = mkNumNeg(c);
-            args[1] = nonconst_args.size() == 1 ? nonconst_args[0] : mkFun(get_sym_Num_PLUS(), nonconst_args);
-            assert(mkNumPlus(nonconst_args) == args[1]);
-        }
-    } else {
-        assert(isNumVarOrIte(sum_tmp) || isNumTimes(sum_tmp));
-    }
-    PTRef r = mkFun(get_sym_Num_LEQ(), args);
-    return r;
+    assert(false);
+    throw OsmtInternalException{"Unexpected situation in LALogic::mkNumLeq"};
 }
 
 PTRef LALogic::mkNumGeq(const vec<PTRef> & args)
@@ -993,6 +970,42 @@ LALogic::printTerm_(PTRef tr, bool ext, bool safe) const
     else
         out = Logic::printTerm_(tr, ext, safe);
     return out;
+}
+
+PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
+    assert(isNumPlus(sum));
+    vec<PTRef> varFactors;
+    PTRef constant = PTRef_Undef;
+    Pterm const & s = getPterm(sum);
+    for (int i = 0; i < s.size(); i++) {
+        if (isConstant(s[i])) {
+            assert(constant == PTRef_Undef);
+            constant = s[i];
+        } else {
+            assert(isLinearFactor(s[i]));
+            varFactors.push(s[i]);
+        }
+    }
+
+    if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
+    opensmt::Number constantVal = getNumConst(constant);
+    assert(varFactors.size() > 0);
+    termSort(varFactors);
+    PTRef leadingFactor = varFactors[0];
+    // normalize the sum according to the leading factor
+    PTRef var, coeff;
+    splitTermToVarAndConst(leadingFactor, var, coeff);
+    opensmt::Number normalizationCoeff = abs(getNumConst(coeff));
+    // varFactors come from a normalized sum, no need to call normalization code again
+    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : insertTermHash(get_sym_Num_PLUS(), varFactors);
+    if (normalizationCoeff != 1) {
+        // normalize the whole sum
+         normalizedSum = mkNumTimes(normalizedSum, mkConst(normalizationCoeff.inverse()));
+        // DON'T forget to update also the constant factor!
+        constantVal /= normalizationCoeff;
+    }
+    constantVal.negate(); // moving the constant to the LHS of the inequality
+    return insertTermHash(get_sym_Num_LEQ(), {mkConst(constantVal), normalizedSum});
 }
 
 void SimplifyConstSum::Op(opensmt::Number& s, const opensmt::Number& v) const { s += v; }

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -1000,7 +1000,7 @@ PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
     PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : insertTermHash(get_sym_Num_PLUS(), varFactors);
     if (normalizationCoeff != 1) {
         // normalize the whole sum
-         normalizedSum = mkNumTimes(normalizedSum, mkConst(normalizationCoeff.inverse()));
+        normalizedSum = mkNumTimes(normalizedSum, mkConst(normalizationCoeff.inverse()));
         // DON'T forget to update also the constant factor!
         constantVal /= normalizationCoeff;
     }

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -6,6 +6,7 @@
 #include "LALogic.h"
 #include "FastRational.h"
 #include "OsmtInternalException.h"
+#include "OsmtApiException.h"
 
 #include <memory>
 
@@ -1006,6 +1007,28 @@ PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
     }
     constantVal.negate(); // moving the constant to the LHS of the inequality
     return insertTermHash(get_sym_Num_LEQ(), {mkConst(constantVal), normalizedSum});
+}
+
+PTRef LALogic::getConstantFromLeq(PTRef leq) {
+    Pterm const & term = getPterm(leq);
+    if (not isNumLeq(term.symb())) {
+        throw OsmtApiException("LALogic::getConstantFromLeq called on a term that is not less-or-equal inequality");
+    }
+    return term[0];
+}
+
+PTRef LALogic::getTermFromLeq(PTRef leq) {
+    Pterm const & term = getPterm(leq);
+    if (not isNumLeq(term.symb())) {
+        throw OsmtApiException("LALogic::getConstantFromLeq called on a term that is not less-or-equal inequality");
+    }
+    return term[1];
+}
+
+std::pair<PTRef, PTRef> LALogic::leqToConstantAndTerm(PTRef leq) {
+    Pterm const & term = getPterm(leq);
+    assert(isNumLeq(term.symb()));
+    return std::make_pair(term[0], term[1]);
 }
 
 void SimplifyConstSum::Op(opensmt::Number& s, const opensmt::Number& v) const { s += v; }

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -155,6 +155,8 @@ public:
     virtual void splitTermToVarAndConst(const PTRef &term, PTRef &var, PTRef &fac) const;
     virtual PTRef normalizeSum(PTRef sum);
     virtual PTRef normalizeMul(PTRef mul);
+    // Given a sum term 't' returns a normalized inequality 'c <= s' equivalent to '0 <= t'
+    virtual PTRef sumToNormalizedInequality(PTRef sum);
     virtual lbool arithmeticElimination(const vec<PTRef> & top_level_arith,
                                         Map<PTRef, PtAsgn, PTRefHash> & substitutions);
     virtual void simplifyAndSplitEq(PTRef, PTRef &);

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -169,6 +169,15 @@ public:
     virtual char *printTerm(PTRef tr) const override;
     virtual char *printTerm(PTRef tr, bool l, bool s) const override;
 
+    // Helper methods
+
+    // Given an inequality 'c <= t', return the constant c; checked version
+    PTRef getConstantFromLeq(PTRef);
+    // Given an inequality 'c <= t', return the term t; checked version
+    PTRef getTermFromLeq(PTRef);
+    // Given an inequality 'c <= t', return the pair <c,t> for a constant c and term t; unchecked version, for internal use
+    std::pair<PTRef, PTRef> leqToConstantAndTerm(PTRef);
+
     // MB: In pure LA, there are never nested boolean terms
     virtual vec<PTRef> getNestedBoolRoots (PTRef)  const override { return vec<PTRef>(); }
 

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -163,3 +163,89 @@ const SymRef LIALogic::get_sym_Num_ZERO () const {return sym_Int_ZERO;}
 const SymRef LIALogic::get_sym_Num_ONE () const {return sym_Int_ONE;}
 const SymRef LIALogic::get_sym_Num_ITE () const {return sym_Int_ITE;}
 const SRef LIALogic::get_sort_NUM () const {return sort_INTEGER;}
+
+PTRef LIALogic::sumToNormalizedInequality(PTRef sum) {
+    vec<PTRef> varFactors;
+    PTRef constant = PTRef_Undef;
+    Pterm const & s = getPterm(sum);
+    for (int i = 0; i < s.size(); i++) {
+        if (isConstant(s[i])) {
+            assert(constant == PTRef_Undef);
+            constant = s[i];
+        } else {
+            assert(isLinearFactor(s[i]));
+            varFactors.push(s[i]);
+        }
+    }
+    if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
+    auto constantValue = getNumConst(constant);
+    termSort(varFactors);
+    vec<PTRef> vars; vars.capacity(varFactors.size());
+    std::vector<opensmt::Number> coeffs; coeffs.reserve(varFactors.size());
+    for (PTRef factor : varFactors) {
+        PTRef var;
+        PTRef coeff;
+        splitTermToVarAndConst(factor, var, coeff);
+        assert(isNumVarOrIte(var) and isNumConst(coeff));
+        vars.push(var);
+        coeffs.push_back(getNumConst(coeff));
+    }
+    bool changed = false; // Keep track if any change to varFactors occurs
+
+    bool allIntegers = std::all_of(coeffs.begin(), coeffs.end(),
+                                   [](opensmt::Number const & coeff) { return coeff.isInteger(); });
+    if (not allIntegers) {
+        // first ensure that all coeffs are integers
+        using Integer = FastRational; // TODO: change when we have FastInteger
+        auto lcmOfDenominators = Integer(1);
+        auto accumulateLCMofDenominators = [&lcmOfDenominators](FastRational const & next) {
+            if (next.isInteger()) {
+                // denominator is 1 => lcm of denominators stays the same
+                return;
+            }
+            Integer den = next.get_den();
+            if (lcmOfDenominators == 1) {
+                lcmOfDenominators = std::move(den);
+                return;
+            }
+            lcmOfDenominators = lcm(lcmOfDenominators, den);
+        };
+        std::for_each(coeffs.begin(), coeffs.end(), accumulateLCMofDenominators);
+        for (auto & coeff : coeffs) {
+            coeff *= lcmOfDenominators;
+            assert(coeff.isInteger());
+        }
+        // DONT forget to update also the constant factor
+        constantValue *= lcmOfDenominators;
+        changed = true;
+    }
+    assert(std::all_of(coeffs.begin(), coeffs.end(), [](opensmt::Number const & coeff) { return coeff.isInteger(); }));
+    // Now make sure all coeffs are coprime
+    auto coeffs_gcd = abs(coeffs[0]);
+    for (std::size_t i = 1; i < coeffs.size() && coeffs_gcd != 1; ++i) {
+        coeffs_gcd = gcd(coeffs_gcd, abs(coeffs[i]));
+        assert(coeffs_gcd.isInteger());
+    }
+    if (coeffs_gcd != 1) {
+        for (auto & coeff : coeffs) {
+            coeff /= coeffs_gcd;
+            assert(coeff.isInteger());
+        }
+        // DONT forget to update also the constant factor
+        constantValue /= coeffs_gcd;
+        changed = true;
+    }
+    // update the factors
+    if (changed) {
+        for (int i = 0; i < varFactors.size(); ++i) {
+            varFactors[i] = mkNumTimes(vars[i], mkConst(coeffs[i]));
+        }
+    }
+    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), varFactors);
+    // 0 <= normalizedSum + constatValue
+    // in LIA we can strengthen the inequality to
+    // ceiling(-constantValue) <= normalizedSum
+    constantValue.negate();
+    constantValue = constantValue.ceil();
+    return mkFun(get_sym_Num_LEQ(), {mkConst(constantValue), normalizedSum});
+}

--- a/src/logics/LIALogic.h
+++ b/src/logics/LIALogic.h
@@ -100,6 +100,8 @@ public:
     virtual const SymRef get_sym_Num_ONE () const override;
     virtual const SymRef get_sym_Num_ITE () const override;
     virtual const SRef get_sort_NUM () const override;
+
+    virtual PTRef sumToNormalizedInequality(PTRef sum) override;
 };
 
 #endif

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -10,10 +10,9 @@ PtAsgn LASolver::getAsgnByBound(LABoundRef br) const {
 }
 
 LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
-//    printf(" -> bound store gets %s\n", logic.pp(leq_ref));
-    const Pterm& leq = logic.getPterm(leq_tr);
-    PTRef const_tr = leq[0];
-    PTRef sum_tr = leq[1];
+    auto constTermPair = logic.leqToConstantAndTerm(leq_tr);
+    PTRef const_tr = constTermPair.first;
+    PTRef sum_tr = constTermPair.second;
     assert(logic.isNumConst(const_tr) && logic.isLinearTerm(sum_tr));
 
     bool sum_term_is_negated = logic.isNegated(sum_tr);
@@ -77,9 +76,9 @@ void LASolver::isProperLeq(PTRef tr)
 {
     assert(logic.isAtom(tr));
     assert(logic.isNumLeq(tr));
-    Pterm& leq_t = logic.getPterm(tr);
-    PTRef cons = leq_t[0];
-    PTRef sum  = leq_t[1];
+    auto constTermPair = logic.leqToConstantAndTerm(tr);
+    PTRef cons = constTermPair.first;
+    PTRef sum  = constTermPair.second;
     assert(logic.isConstant(cons));
     assert(logic.isNumVarOrIte(sum) || logic.isNumPlus(sum) || logic.isNumTimes(sum));
     assert(!logic.isNumTimes(sum) || ((logic.isNumVarOrIte(logic.getPterm(sum)[0]) && (logic.mkNumNeg(logic.getPterm(sum)[1])) == logic.getTerm_NumOne()) ||

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -136,3 +136,12 @@ target_sources(IteTest
 
 target_link_libraries(IteTest api_static gtest gtest_main)
 gtest_add_tests(TARGET IteTest)
+
+add_executable(LIAStrengtheningTest)
+target_sources(LIAStrengtheningTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LIAStrengthening.cc"
+        )
+
+
+target_link_libraries(LIAStrengtheningTest api_static gtest gtest_main)
+gtest_add_tests(TARGET LIAStrengtheningTest)

--- a/test/unit/test_LIAStrengthening.cc
+++ b/test/unit/test_LIAStrengthening.cc
@@ -22,6 +22,6 @@ TEST_F(LIAStrengthening, test_LIAStrengthening) {
     PTRef y = logic.mkNumVar("y");
     PTRef sum = logic.mkNumTimes(c2, logic.mkNumPlus(x, y));
     PTRef ineq = logic.mkNumGeq(sum, c3);
-    const Pterm& ineq_tm = logic.getPterm(ineq);
-    ASSERT_EQ(ineq_tm[0], logic.mkConst("2"));
+    ASSERT_EQ(logic.getConstantFromLeq(ineq), logic.mkConst("2"));
+    ASSERT_EQ(logic.getTermFromLeq(ineq), logic.mkNumPlus(x,y));
 }

--- a/test/unit/test_LIAStrengthening.cc
+++ b/test/unit/test_LIAStrengthening.cc
@@ -1,0 +1,27 @@
+//
+// Created by prova on 30.09.20.
+//
+#include <gtest/gtest.h>
+#include <Real.h>
+#include <stdlib.h>
+#include <Vec.h>
+#include <Sort.h>
+#include <SMTConfig.h>
+#include <LIALogic.h>
+
+class LIAStrengthening: public ::testing::Test {
+public:
+    LIALogic logic;
+    LIAStrengthening() : logic{} {}
+};
+
+TEST_F(LIAStrengthening, test_LIAStrengthening) {
+    PTRef c2 = logic.mkConst(2);
+    PTRef c3 = logic.mkConst(3);
+    PTRef x = logic.mkNumVar("x");
+    PTRef y = logic.mkNumVar("y");
+    PTRef sum = logic.mkNumTimes(c2, logic.mkNumPlus(x, y));
+    PTRef ineq = logic.mkNumGeq(sum, c3);
+    const Pterm& ineq_tm = logic.getPterm(ineq);
+    ASSERT_EQ(ineq_tm[0], logic.mkConst("2"));
+}


### PR DESCRIPTION
This is my attempt at creating strengthened bounds for LIA already during the term creation.
Part of it is also a refactoring of the normalization of sums in LRA Logic.
