### PR TITLE
std::vector to minisat vec conversion

### DIFF
--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -393,13 +393,7 @@ PTRef LALogic::mkNumTimes(const std::vector<PTRef> &args) {
     for (PTRef arg : args) { tmp.push(arg); }
     return mkNumTimes(tmp);
 }
-PTRef mkNumDiv(const vec<PTRef> &, char **);
-PTRef LALogic::mkNumDiv(const vec<PTRef> &args) {
-    char *msg;
-    PTRef tr = mkNumDiv(args, &msg);
-    assert(tr != PTRef_Undef);
-    return tr;
-}
+
 PTRef LALogic::mkNumDiv(const PTRef nom, const PTRef den) {
     vec<PTRef> tmp;
     tmp.push(nom), tmp.push(den);
@@ -477,7 +471,7 @@ PTRef LALogic::mkNumPlus(const vec<PTRef>& args, char** msg)
     SimplifyConstSum simp(*this);
     vec<PTRef> args_new;
     SymRef s_new;
-    simp.simplify(get_sym_Num_PLUS(), new_args, s_new, args_new, msg);
+    simp.simplify(get_sym_Num_PLUS(), new_args, s_new, args_new);
     if (args_new.size() == 1)
         return args_new[0];
     if (s_new != get_sym_Num_PLUS()) {
@@ -541,7 +535,7 @@ PTRef LALogic::mkNumTimes(const vec<PTRef>& tmp_args, char** msg)
     SimplifyConstTimes simp(*this);
     vec<PTRef> args_new;
     SymRef s_new;
-    simp.simplify(get_sym_Num_TIMES(), args, s_new, args_new, msg);
+    simp.simplify(get_sym_Num_TIMES(), args, s_new, args_new);
     PTRef tr = mkFun(s_new, args_new);
     // Either a real term or, if we constructed a multiplication of a
     // constant and a sum, a real sum.
@@ -552,7 +546,7 @@ PTRef LALogic::mkNumTimes(const vec<PTRef>& tmp_args, char** msg)
     }
 }
 
-PTRef LALogic::mkNumDiv(const vec<PTRef>& args, char** msg)
+PTRef LALogic::mkNumDiv(const vec<PTRef>& args)
 {
     SimplifyConstDiv simp(*this);
     vec<PTRef> args_new;
@@ -561,7 +555,7 @@ PTRef LALogic::mkNumDiv(const vec<PTRef>& args, char** msg)
     if(this->isNumZero(args[1])) {
         throw LADivisionByZeroException();
     }
-    simp.simplify(get_sym_Num_DIV(), args, s_new, args_new, msg);
+    simp.simplify(get_sym_Num_DIV(), args, s_new, args_new);
     if (isNumDiv(s_new)) {
         assert((isNumTerm(args_new[0]) || isNumPlus(args_new[0])) && isConstant(args_new[1]));
         args_new[1] = mkConst(FastRational_inverse(getNumConst(args_new[1]))); //mkConst(1/getRealConst(args_new[1]));
@@ -665,19 +659,18 @@ PTRef LALogic::mkNumGt(const vec<PTRef> & args)
     }
     return mkNot(tr);
 }
-PTRef LALogic::insertTerm(SymRef sym, vec<PTRef>& terms, char **msg)
-
+PTRef LALogic::insertTerm(SymRef sym, vec<PTRef>& terms)
 {
     if (sym == get_sym_Num_NEG())
-        return mkNumNeg(terms[0], msg);
+        return mkNumNeg(terms[0]);
     if (sym == get_sym_Num_MINUS())
-        return mkNumMinus(terms, msg);
+        return mkNumMinus(terms);
     if (sym == get_sym_Num_PLUS())
-        return mkNumPlus(terms, msg);
+        return mkNumPlus(terms);
     if (sym == get_sym_Num_TIMES())
-        return mkNumTimes(terms, msg);
+        return mkNumTimes(terms);
     if (sym == get_sym_Num_DIV())
-        return mkNumDiv(terms, msg);
+        return mkNumDiv(terms);
     if (sym == get_sym_Num_LEQ())
         return mkNumLeq(terms);
     if (sym == get_sym_Num_LT())
@@ -688,8 +681,9 @@ PTRef LALogic::insertTerm(SymRef sym, vec<PTRef>& terms, char **msg)
         return mkNumGt(terms);
     if (sym == get_sym_Num_ITE())
         return mkIte(terms);
-    return Logic::insertTerm(sym, terms, msg);
+    return Logic::insertTerm(sym, terms);
 }
+
 PTRef LALogic::mkConst(const char *name, const char **msg)
 {
     return mkConst(getSort_num(), name);
@@ -724,7 +718,7 @@ PTRef LALogic::mkConst(SRef s, const char* name)
 // corresponding simplifications.  Examples include 0 with
 // multiplication and summation, e.g.
 //
-void SimplifyConst::simplify(const SymRef& s, const vec<PTRef>& args, SymRef& s_new, vec<PTRef>& args_new, char** msg)
+void SimplifyConst::simplify(const SymRef& s, const vec<PTRef>& args, SymRef& s_new, vec<PTRef>& args_new)
 {
     vec<int> const_idx;
     for (int i = 0; i < args.size(); i++) {
@@ -744,10 +738,8 @@ void SimplifyConst::simplify(const SymRef& s, const vec<PTRef>& args, SymRef& s_
             for (int i = 0; i < const_idx.size(); i++)
                 const_terms.push(args[const_idx[i]]);
             PTRef tr = simplifyConstOp(const_terms);
-            if (tr == PTRef_Undef) {
-                printf("%s\n", *msg);
-                assert(false);
-            }
+            assert(tr != PTRef_Undef);
+
             vec<PTRef> args_new_2;
             args_new_2.capacity((args.size() - const_terms.size()) + 1);
             int i, k;

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -49,8 +49,8 @@ protected:
 public:
     LALogic();
     ~LALogic() { for(int i = 0; i < numbers.size(); ++i) {delete numbers[i];}}
-    virtual bool     isBuiltinFunction(SymRef sr) const override;
-    virtual PTRef    insertTerm       (SymRef sym, vec<PTRef>& terms, char** msg) override;
+    bool             isBuiltinFunction(SymRef sr) const override;
+    PTRef            insertTerm       (SymRef sym, vec<PTRef>& terms) override;
     virtual SRef     getSort_num      () const;
     virtual PTRef    mkConst          (const char* name, const char **msg) override;
     virtual PTRef    mkConst          (SRef s, const char* name) override;
@@ -137,7 +137,6 @@ public:
     virtual PTRef mkNumTimes(const vec<PTRef> &args);
     virtual PTRef mkNumTimes(const PTRef p1, const PTRef p2);
     virtual PTRef mkNumTimes(const std::vector<PTRef> &args);
-    virtual PTRef mkNumDiv(const vec<PTRef> &, char **);
     virtual PTRef mkNumDiv(const vec<PTRef> &args);
     virtual PTRef mkNumDiv(const PTRef nom, const PTRef den);
     virtual PTRef mkNumLeq(const vec<PTRef> &args);
@@ -200,7 +199,7 @@ protected:
     virtual void constSimplify(const SymRef& s, const vec<PTRef>& terms, SymRef& s_new, vec<PTRef>& terms_new) const = 0;
 public:
     SimplifyConst(LALogic& log) : l(log) {}
-    void simplify(const SymRef& s, const vec<PTRef>& terms, SymRef& s_new, vec<PTRef>& terms_new, char** msg);
+    void simplify(const SymRef& s, const vec<PTRef>& terms, SymRef& s_new, vec<PTRef>& terms_new);
 };
 
 class SimplifyConstSum : public SimplifyConst {

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -52,13 +52,13 @@ public:
     bool             isBuiltinFunction(SymRef sr) const override;
     PTRef            insertTerm       (SymRef sym, vec<PTRef>& terms) override;
     virtual SRef     getSort_num      () const;
-    virtual PTRef    mkConst          (const char* name, const char **msg) override;
-    virtual PTRef    mkConst          (SRef s, const char* name) override;
+    PTRef            mkConst          (const char* name, const char **msg) override;
+    PTRef            mkConst          (SRef s, const char* name) override;
     virtual PTRef    mkConst          (const opensmt::Number& c);
     virtual PTRef    mkConst          (const char* num);
     virtual PTRef    mkNumVar         (const char* name);
-    virtual bool     isBuiltinSort    (SRef sr) const override;
-    virtual bool     isBuiltinConstant(SymRef sr) const override;
+    bool             isBuiltinSort    (SRef sr) const override;
+    bool             isBuiltinConstant(SymRef sr) const override;
 
     virtual bool  isNumConst     (SymRef sr)     const;
     virtual bool  isNumConst     (PTRef tr)      const;
@@ -66,13 +66,13 @@ public:
     virtual bool   hasSortNum(SymRef sr) const;
     virtual bool   hasSortNum(PTRef tr)  const;
     virtual const opensmt::Number& getNumConst(PTRef tr) const;
-    virtual bool        isUFEquality(PTRef tr) const override;
-    virtual bool        isTheoryEquality(PTRef tr) const override;
-    virtual bool isAtom(PTRef tr) const override;
-    virtual bool        isUF(PTRef tr) const override;
-    virtual bool        isUF(SymRef sr) const override;
-    virtual const char* getDefaultValue(const PTRef tr) const override;
-    virtual PTRef getDefaultValuePTRef(const SRef sref) const override;
+    bool           isUFEquality(PTRef tr) const override;
+    bool           isTheoryEquality(PTRef tr) const override;
+    bool           isAtom(PTRef tr) const override;
+    bool           isUF(PTRef tr) const override;
+    bool           isUF(SymRef sr) const override;
+    const char*    getDefaultValue(const PTRef tr) const override;
+    PTRef          getDefaultValuePTRef(const SRef sref) const override;
 
 
     virtual const SymRef get_sym_Num_TIMES () const =0;
@@ -158,16 +158,16 @@ public:
                                         Map<PTRef, PtAsgn, PTRefHash> & substitutions);
     virtual void simplifyAndSplitEq(PTRef, PTRef &);
 
-    virtual void visit(PTRef, Map<PTRef, PTRef, PTRefHash> &) override;
-    virtual lbool retrieveSubstitutions(const vec<PtAsgn> &facts, Map<PTRef, PtAsgn, PTRefHash> &substs) override;
-    virtual void termSort(vec<PTRef> &v) const override;
-    virtual bool okToPartition(PTRef tr) const override; // Partitioning hints from logic
-    virtual char *printTerm_(PTRef tr, bool ext, bool s) const override;
-    virtual char *printTerm(PTRef tr) const override;
-    virtual char *printTerm(PTRef tr, bool l, bool s) const override;
+    void visit(PTRef, Map<PTRef, PTRef, PTRefHash> &) override;
+    lbool retrieveSubstitutions(const vec<PtAsgn> &facts, Map<PTRef, PtAsgn, PTRefHash> &substs) override;
+    void termSort(vec<PTRef> &v) const override;
+    bool okToPartition(PTRef tr) const override; // Partitioning hints from logic
+    char *printTerm_(PTRef tr, bool ext, bool s) const override;
+    char *printTerm(PTRef tr) const override;
+    char *printTerm(PTRef tr, bool l, bool s) const override;
 
     // MB: In pure LA, there are never nested boolean terms
-    virtual vec<PTRef> getNestedBoolRoots (PTRef)  const override { return vec<PTRef>(); }
+    vec<PTRef> getNestedBoolRoots (PTRef)  const override { return vec<PTRef>(); }
 
 };
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -497,7 +497,7 @@ void Logic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
 {
     Pterm& p = getPterm(tr);
     vec<PTRef> newargs(p.size());
-    char *msg;
+
     bool changed = false;
     for (int i = 0; i < p.size(); ++i) {
         PTRef tr = p[i];
@@ -509,7 +509,7 @@ void Logic::visit(PTRef tr, Map<PTRef,PTRef,PTRefHash>& tr_map)
             newargs[i] = tr;
     }
     if (!changed) {return;}
-    PTRef trp = insertTerm(p.symb(), newargs, &msg);
+    PTRef trp = insertTerm(p.symb(), newargs);
     if (trp != tr) {
         if (tr_map.has(tr))
             assert(tr_map[tr] == trp);
@@ -606,8 +606,8 @@ PTRef Logic::resolveTerm(const char* s, vec<PTRef>& args, char** msg) {
     }
     assert(sref != SymRef_Undef);
     PTRef rval;
-    char** msg2 = NULL;
-    rval = insertTerm(sref, args, msg2);
+
+    rval = insertTerm(sref, args);
     if (rval == PTRef_Undef)
         printf("Error in resolveTerm\n");
 
@@ -1082,29 +1082,29 @@ bool Logic::defineFun(const char* fname, const vec<PTRef>& args, SRef rsort, PTR
     return true;
 }
 
-PTRef Logic::insertTerm(SymRef sym, vec<PTRef>& terms, char** msg)
+PTRef Logic::insertTerm(SymRef sym, vec<PTRef>& terms)
 {
-    if(sym == getSym_and())
+    if (sym == getSym_and())
         return mkAnd(terms);
-    if(sym == getSym_or())
+    if (sym == getSym_or())
         return mkOr(terms);
-    if(sym == getSym_xor())
+    if (sym == getSym_xor())
         return mkXor(terms);
-    if(sym == getSym_not())
+    if (sym == getSym_not())
         return mkNot(terms[0]);
-    if(isEquality(sym))
+    if (isEquality(sym))
         return mkEq(terms);
-    if(isDisequality(sym))
+    if (isDisequality(sym))
         return mkDistinct(terms);
-    if(isIte(sym))
+    if (isIte(sym))
         return mkIte(terms);
-    if(sym == getSym_implies())
+    if (sym == getSym_implies())
         return mkImpl(terms);
-    if(sym == getSym_true())
+    if (sym == getSym_true())
         return getTerm_true();
-    if(sym == getSym_false())
+    if (sym == getSym_false())
         return getTerm_false();
-    if(isVar(sym)) {
+    if (isVar(sym)) {
         assert(terms.size() == 0);
         return mkFun(sym, terms);
     }
@@ -1360,8 +1360,8 @@ bool Logic::varsubstitute(PTRef root, const Map<PTRef, PtAsgn, PTRefHash> & subs
                     printf("  %s -> %s\n", printTerm(t[i]), printTerm(gen_sub[t[i]]));
 #endif
                 }
-                char* msg;
-                result = changed ? insertTerm(t.symb(), args_mapped, &msg) : tr;
+
+                result = changed ? insertTerm(t.symb(), args_mapped) : tr;
 #ifdef SIMPLIFY_DEBUG
                 printf("  -> %s\n", printTerm(result));
 #endif

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -631,7 +631,7 @@ Logic::getDefaultValuePTRef(const SRef sref) const {
 }
 
 PTRef
-Logic::mkIte(vec<PTRef>& args)
+Logic::mkIte(const vec<PTRef>& args)
 {
     if (!hasSortBool(args[0])) return PTRef_Undef;
     if (args.size() != 3) throw OsmtApiException("ITE needs to have 3 arguments");
@@ -654,7 +654,7 @@ Logic::mkIte(vec<PTRef>& args)
 
 // Check if arguments contain trues or a false and return the simplified
 // term
-PTRef Logic::mkAnd(vec<PTRef>& args) {
+PTRef Logic::mkAnd(const vec<PTRef>& args) {
     if (args.size() == 0) { return getTerm_true(); }
     // Remove duplicates
     vec<PtAsgn> tmp_args;
@@ -699,7 +699,7 @@ PTRef Logic::mkAnd(vec<PTRef>& args) {
     return mkFun(getSym_and(), newargs);
 }
 
-PTRef Logic::mkOr(vec<PTRef>& args) {
+PTRef Logic::mkOr(const vec<PTRef>& args) {
     if (args.size() == 0) { return getTerm_false(); }
     // Remove duplicates
     vec<PtAsgn> tmp_args;
@@ -744,7 +744,7 @@ PTRef Logic::mkOr(vec<PTRef>& args) {
     return mkFun(getSym_or(), newargs);
 }
 
-PTRef Logic::mkXor(vec<PTRef>& args) {
+PTRef Logic::mkXor(const vec<PTRef>& args) {
     PTRef tr = PTRef_Undef;
 
     for (int i = 0; i < args.size(); i++)
@@ -785,7 +785,7 @@ Logic::mkImpl(PTRef _a, PTRef _b)
     return mkImpl(args);
 }
 
-PTRef Logic::mkImpl(vec<PTRef>& args) {
+PTRef Logic::mkImpl(const vec<PTRef>& args) {
 
     for (int i = 0; i < args.size(); i++)
         if (!hasSortBool(args[i]))
@@ -815,7 +815,7 @@ PTRef Logic::mkImpl(vec<PTRef>& args) {
         return tr;
 }
 
-PTRef Logic::mkEq(vec<PTRef>& args) {
+PTRef Logic::mkEq(const vec<PTRef>& args) {
     if (args.size() < 2) { return PTRef_Undef; }
     if (args.size() > 2) { // split to chain of equalities with 2 arguments
         vec<PTRef> binaryEqualities;
@@ -2002,20 +2002,6 @@ SRef        Logic::getSortRef    (const SymRef sr)       const { return getSym(s
 Sort*       Logic::getSort       (const SRef s)                { return sort_store[s]; }
 const char* Logic::getSortName   (const SRef s)                { return sort_store.getName(s); }
 
-
-PTRef       Logic::mkAnd         (PTRef a1, PTRef a2) { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkAnd(tmp); }
-PTRef      Logic::mkAnd         (const std::vector<PTRef> & v) { vec<PTRef> tmp; for(PTRef ref : v) {tmp.push(ref);} return mkAnd(tmp); }
-
-PTRef      Logic::mkOr          (PTRef a1, PTRef a2) { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkOr(tmp); }
-PTRef      Logic::mkOr          (const std::vector<PTRef> & v) { vec<PTRef> tmp; for(PTRef ref : v) {tmp.push(ref);} return mkOr(tmp); }
-
-PTRef       Logic::mkXor         (PTRef a1, PTRef a2) { vec <PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkXor(tmp); }
-
-PTRef       Logic::mkIte         (PTRef c, PTRef t, PTRef e) { vec<PTRef> tmp; tmp.push(c); tmp.push(t); tmp.push(e); return mkIte(tmp); }
-
-
-PTRef       Logic::mkEq          (PTRef a1, PTRef a2) { vec<PTRef> v; v.push(a1); v.push(a2); return mkEq(v); }
-
 void Logic::dumpFunctions(ostream& dump_out) { vec<const char*> names; defined_functions.getKeys(names); for (int i = 0; i < names.size(); i++) dumpFunction(dump_out, names[i]); }
 void Logic::dumpFunction(ostream& dump_out, const char* tpl_name) { if (defined_functions.has(tpl_name)) dumpFunction(dump_out, defined_functions[tpl_name]); else printf("; Error: function %s is not defined\n", tpl_name); }
 void Logic::dumpFunction(ostream& dump_out, const std::string s) { dumpFunction(dump_out, s.c_str()); }
@@ -2026,12 +2012,12 @@ SymRef        Logic::getSym_false     ()              const { return sym_FALSE; 
 SymRef        Logic::getSym_and       ()              const { return sym_AND;      }
 SymRef        Logic::getSym_or        ()              const { return sym_OR;       }
 SymRef        Logic::getSym_xor       ()              const { return sym_XOR;      }
-SymRef       Logic::getSym_not       ()              const { return sym_NOT;      }
-SymRef       Logic::getSym_eq        ()              const { return sym_EQ;       }
-SymRef       Logic::getSym_ite       ()              const { return sym_ITE;      }
-SymRef       Logic::getSym_implies   ()              const { return sym_IMPLIES;  }
-SymRef       Logic::getSym_distinct  ()              const { return sym_DISTINCT; }
-SRef         Logic::getSort_bool     ()              const { return sort_BOOL;    }
+SymRef        Logic::getSym_not       ()              const { return sym_NOT;      }
+SymRef        Logic::getSym_eq        ()              const { return sym_EQ;       }
+SymRef        Logic::getSym_ite       ()              const { return sym_ITE;      }
+SymRef        Logic::getSym_implies   ()              const { return sym_IMPLIES;  }
+SymRef        Logic::getSym_distinct  ()              const { return sym_DISTINCT; }
+SRef          Logic::getSort_bool     ()              const { return sort_BOOL;    }
 
 PTRef         Logic::getTerm_true     ()              const { return term_TRUE;  }
 PTRef         Logic::getTerm_false    ()              const { return term_FALSE; }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -440,9 +440,9 @@ class Logic {
     void        simplifyTree       (PTRef tr, PTRef& root_out);
 
     PTRef       resolveTerm        (const char* s, vec<PTRef>& args, char** msg);
-    // XXX There's a need for non msg giving version
-    virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>& terms, char** msg);
-    virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>&& terms) { return insertTerm(sym, terms, nullptr); }
+
+    virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>& terms);
+    virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>&& terms) { return insertTerm(sym, terms); }
 
 
     // Top-level equalities based substitutions

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -248,25 +248,23 @@ class Logic {
 
     PTRef       mkUninterpFun (SymRef f, const vec<PTRef>& args);
     // Boolean term generation
-    PTRef       mkAnd         (vec<PTRef>&);
-    PTRef       mkAnd         (PTRef a1, PTRef a2);// { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkAnd(tmp); }
-    PTRef       mkAnd         (const std::vector<PTRef> & v);// { vec<PTRef> tmp; for(PTRef ref : v) {tmp.push(ref);} return mkAnd(tmp); }
-    PTRef       mkOr          (vec<PTRef>&);
-    PTRef       mkOr          (PTRef a1, PTRef a2);// { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkOr(tmp); }
-    PTRef       mkOr          (const std::vector<PTRef> & v);// { vec<PTRef> tmp; for(PTRef ref : v) {tmp.push(ref);} return mkOr(tmp); }
-    PTRef       mkXor         (vec<PTRef>&);
-    PTRef       mkXor         (PTRef a1, PTRef a2);// { vec <PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkXor(tmp); }
-    PTRef       mkImpl        (vec<PTRef>&);
+    PTRef       mkAnd         (const vec<PTRef>&);
+    PTRef       mkAnd         (PTRef a1, PTRef a2) { return mkAnd({a1, a2}); }
+    PTRef       mkOr          (const vec<PTRef>&);
+    PTRef       mkOr          (PTRef a1, PTRef a2) { return mkOr({a1, a2}); }
+    PTRef       mkXor         (const vec<PTRef>&);
+    PTRef       mkXor         (PTRef a1, PTRef a2) { return mkXor({a1, a2}); }
+    PTRef       mkImpl        (const vec<PTRef>&);
     PTRef       mkImpl        (PTRef _a, PTRef _b);
     PTRef       mkNot         (PTRef);
     PTRef       mkNot         (vec<PTRef>&);
-    PTRef       mkIte         (vec<PTRef>&);
-    PTRef       mkIte         (PTRef c, PTRef t, PTRef e);// { vec<PTRef> tmp; tmp.push(c); tmp.push(t); tmp.push(e); return mkIte(tmp); }
+    PTRef       mkIte         (const vec<PTRef>&);
+    PTRef       mkIte         (PTRef c, PTRef t, PTRef e) { return mkIte({c, t, e}); }
 
 
     // Generic equalities
-    PTRef       mkEq          (vec<PTRef>& args);
-    PTRef       mkEq          (PTRef a1, PTRef a2);// { vec<PTRef> v; v.push(a1); v.push(a2); return mkEq(v); }
+    PTRef       mkEq          (const vec<PTRef>& args);
+    PTRef       mkEq          (PTRef a1, PTRef a2) { return mkEq({a1, a2}); }
 
     // General disequalities
     PTRef       mkDistinct    (vec<PTRef>& args);
@@ -444,6 +442,7 @@ class Logic {
     PTRef       resolveTerm        (const char* s, vec<PTRef>& args, char** msg);
     // XXX There's a need for non msg giving version
     virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>& terms, char** msg);
+    virtual PTRef       insertTerm         (SymRef sym, vec<PTRef>&& terms) { return insertTerm(sym, terms, nullptr); }
 
 
     // Top-level equalities based substitutions

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -205,6 +205,7 @@ class Logic {
     // Fetching sorts
     bool        containsSort  (const char* name)      const;// { return sort_store.containsSort(name); }
   protected:
+    SymRef      newSymb       (const char* name, vec<SRef> const & sort_args) { return sym_store.newSymb(name, sort_args); }
     SRef        newSort       (IdRef idr, const char* name, vec<SRef>& tmp);// { return sort_store.newSort(idr, name, tmp); }
     PTRef       mkFun         (SymRef f, const vec<PTRef>& args);
     void        markConstant  (PTRef ptr);
@@ -218,8 +219,6 @@ class Logic {
     const char* getSortName   (const SRef s)  ;//              { return sort_store.getName(s); }
 
     // Symbols
-    SymRef      newSymb       (const char* name, vec<SRef>& sort_args)
-                                                            { return sym_store.newSymb(name, sort_args); }
     Symbol& getSym              (const SymRef s)        { return sym_store[s]; }
     const Symbol& getSym        (const SymRef s)        const { return sym_store[s]; }
     const Symbol& getSym        (const PTRef tr)        const { return getSym(getPterm(tr).symb()); }

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -57,7 +57,7 @@ public:
     explicit vec(int size)      : data(NULL) , sz(0)   , cap(0)    { growTo(size); }
     vec(int size, const T& pad) : data(NULL) , sz(0)   , cap(0)    { growTo(size, pad); }
     vec(const std::initializer_list<T> &iList);
-    vec(const std::vector<T>& v) : vec(v.size()) { for (int i = 0; i < v.size(); i++) { operator[](i) = v[i]; } };
+    vec(const std::vector<T>& v) : vec(v.size()) { for (unsigned i = 0; i < v.size(); i++) { operator[](i) = v[i]; } };
     vec(vec&& o)                : data(NULL) , sz(0)   , cap(0)    { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); }
    ~vec()                                                          { clear(true); }
     vec<T>& operator = (vec<T>&& o) { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); return *this; }

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -25,6 +25,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <cassert>
 #include <new>
 #include <initializer_list>
+#include <vector>
 #include <utility>
 #include "IntTypes.h"
 #include "XAlloc.h"
@@ -56,6 +57,7 @@ public:
     explicit vec(int size)      : data(NULL) , sz(0)   , cap(0)    { growTo(size); }
     vec(int size, const T& pad) : data(NULL) , sz(0)   , cap(0)    { growTo(size, pad); }
     vec(const std::initializer_list<T> &iList);
+    vec(const std::vector<T>& v) : vec(v.size()) { for (int i = 0; i < v.size(); i++) { operator[](i) = v[i]; } };
     vec(vec&& o)                : data(NULL) , sz(0)   , cap(0)    { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); }
    ~vec()                                                          { clear(true); }
     vec<T>& operator = (vec<T>&& o) { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); return *this; }

--- a/src/models/Model.cc
+++ b/src/models/Model.cc
@@ -30,8 +30,7 @@ PTRef Model::evaluate(PTRef term) {
             PTRef narg = evaluate(t[i]);
             nargs.push(narg);
         }
-        char* msg;
-        PTRef val = logic.insertTerm(symbol, nargs, &msg);
+        PTRef val = logic.insertTerm(symbol, nargs);
         assert(val != PTRef_Undef);
         addDerivedVal(term, val);
         return val;

--- a/test/unit/test_TheorySimplifications.cc
+++ b/test/unit/test_TheorySimplifications.cc
@@ -76,10 +76,8 @@ protected:
         y = logic.mkVar(ufsort, "y");
         z = logic.mkVar(ufsort, "z");
         c = logic.mkConst(ufsort, "c");
-        vec<SRef> args;
-        args.push(ufsort);
-        args.push(ufsort);
-        f = logic.newSymb("f", args);
+        char* msg;
+        f = logic.declareFun("f", ufsort, {ufsort}, &msg, false);
     }
     Logic logic;
     SRef ufsort;
@@ -152,10 +150,8 @@ protected:
         y = logic.mkVar(ufsort, "y");
         z = logic.mkVar(ufsort, "z");
         c = logic.mkConst(ufsort, "c");
-        vec<SRef> args;
-        args.push(ufsort);
-        args.push(ufsort);
-        f = logic.newSymb("f", args);
+        char* msg;
+        f = logic.declareFun("f", ufsort, {ufsort}, &msg, false);
     }
     Logic logic;
     SRef ufsort;


### PR DESCRIPTION
This PR moves the code used in the Logic API `std::vector` =>  minisat `vec` conversion  directly to minisat `vec`'s constructor.