### PR TITLE
Refactoring of colouring information in Theory Interpolation

### DIFF
--- a/src/smtsolvers/TheoryInterpolator.h
+++ b/src/smtsolvers/TheoryInterpolator.h
@@ -3,7 +3,139 @@
 
 #include "Global.h"
 #include "PtStore.h"
-#include <PartitionManager.h>
+#include "PartitionManager.h"
+#include "OsmtInternalException.h"
+
+#include <memory>
+#include <algorithm>
+
+class TermColorInfo {
+public:
+    virtual icolor_t getColorFor(PTRef term) = 0;
+    virtual ~TermColorInfo() = default;
+
+};
+
+class GlobalTermColorInfo : public TermColorInfo {
+public:
+    GlobalTermColorInfo(PartitionManager & pmanager, ipartitions_t mask) : pmanager(pmanager), mask(std::move(mask)) {}
+
+    icolor_t getColorFor(PTRef term) override {
+        auto const & termMask = pmanager.getIPartitions(term);
+        auto res = getColorForMask(termMask);
+        if (res == I_UNDEF) {
+            throw OsmtInternalException("No color detected for term");
+        }
+        return res;
+    }
+
+private:
+    PartitionManager & pmanager;
+    ipartitions_t mask;
+
+    icolor_t getColorForMask(ipartitions_t const & otherMask) {
+        bool isInA = (otherMask & mask) != 0;
+        bool isInB = (otherMask & ~mask) != 0;
+        if (isInA and not isInB) { return I_A; }
+        if (isInB and not isInA) { return I_B; }
+        if (isInA and isInB) { return I_AB; }
+        return I_UNDEF;
+    }
+};
+
+/*
+ * Stores color information for a set of terms given the colors of top-level term.
+ *
+ * Terms can be A-local, B-local, or AB-shared.
+ * Note: If a term f(x) is local, but both the function symbol and all the arguments are AB-shared,
+ *       then f(x) will also be stored as shared.
+ */
+class LocalTermColorInfo : public TermColorInfo {
+public:
+
+    template<typename TMap>
+    LocalTermColorInfo(TMap const & topLevelMap, Logic const & logic) {
+        termColors[logic.getTerm_true()] = I_AB;
+        termColors[logic.getTerm_false()] = I_AB;
+        computeColorsForAllSubterms(topLevelMap, logic);
+    }
+
+    icolor_t getColorFor(PTRef term) override {
+        auto it = termColors.find(term);
+        if (it == termColors.end()) {
+            throw OsmtInternalException("No color detected for term");
+        }
+        return it->second;
+    }
+
+private:
+    std::unordered_map<PTRef, icolor_t, PTRefHash> termColors;
+
+    template<typename TMap>
+    void computeColorsForAllSubterms(TMap const & topLevelColors, Logic const & logic) {
+        // MB: NOTE! If P(a) is A-local, but both symbols P and a are shared, than P(a) should be shared and not A-local
+        using entry_t = std::pair<const PTRef, icolor_t>;
+        auto colorUnion = [](icolor_t f, icolor_t s) { return static_cast<opensmt::icolor_t>(f | s); };
+        std::vector<entry_t> queue;
+        for (auto entry : topLevelColors) {
+            queue.push_back(entry);
+        }
+        std::unordered_map<SymRef, icolor_t, SymRefHash> symbolColors;
+        while (not queue.empty()) {
+            auto const & entry = queue.back();
+            icolor_t colorToAssign = entry.second;
+            PTRef term = entry.first;
+            queue.pop_back();
+            auto it = termColors.find(term);
+            if (it != termColors.end()) {
+                icolor_t assignedColor = it->second;
+                if (assignedColor == colorToAssign || assignedColor == I_AB) { // already processed, color does not change
+                    continue;
+                } else { // assigning new color
+                    assert(assignedColor == I_A or assignedColor == I_B);
+                    colorToAssign = colorUnion(colorToAssign, assignedColor);
+                    assert(colorToAssign == I_AB);
+                }
+            }
+            // if we reach here, we need to propagate colorToAssign to the whole term subtree of `term`
+            termColors[term] = colorToAssign;
+            for (PTRef child : logic.getPterm(term)) {
+                queue.emplace_back(child, colorToAssign);
+            }
+            // add symbol information
+            auto insertRes = symbolColors.insert(std::make_pair(logic.getSymRef(term), colorToAssign));
+            if (not insertRes.second) { // there was entry for this symbol already
+                auto entryIt = insertRes.first;
+                entryIt->second = colorUnion(entryIt->second, colorToAssign);
+            }
+        }
+        // Make sure complex terms have correct color assigned
+        vec<PTRef> terms;
+        for (auto const & entry : termColors) {
+            PTRef term = entry.first;
+            if (entry.second != I_AB and (logic.isUF(term) or logic.isUP(term)) and
+                symbolColors.at(logic.getSymRef(term)) == I_AB) {
+                terms.push(term);
+            }
+        }
+
+        sort(terms, [](PTRef p, PTRef q) { return p.x > q.x; }); // to process children before parents
+
+        for (PTRef term : terms) {
+            auto & color = termColors.at(term);
+            assert(color != I_AB and (logic.isUF(term) or logic.isUP(term)));
+            assert(symbolColors.at(logic.getSymRef(term)) == I_AB);
+            // if symbol is AB and all children are AB, this term should also be AB
+            Pterm const & pterm = logic.getPterm(term);
+            bool hasLocalChild = std::any_of(pterm.begin(), pterm.end(),
+                                             [this](PTRef child) { return termColors.at(child) != I_AB; });
+            if (not hasLocalChild) {
+                // everything is AB -> update
+                color = I_AB;
+            }
+        }
+    }
+};
 
 class TheoryInterpolator
 {

--- a/src/smtsolvers/TheoryInterpolator.h
+++ b/src/smtsolvers/TheoryInterpolator.h
@@ -82,7 +82,7 @@ private:
         }
         std::unordered_map<SymRef, icolor_t, SymRefHash> symbolColors;
         while (not queue.empty()) {
-            auto const & entry = queue.back();
+            auto const entry = queue.back();
             icolor_t colorToAssign = entry.second;
             PTRef term = entry.first;
             queue.pop_back();
@@ -111,7 +111,7 @@ private:
         }
         // Make sure complex terms have correct color assigned
         vec<PTRef> terms;
-        for (auto const & entry : termColors) {
+        for (auto const entry : termColors) {
             PTRef term = entry.first;
             if (entry.second != I_AB and (logic.isUF(term) or logic.isUP(term)) and
                 symbolColors.at(logic.getSymRef(term)) == I_AB) {

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -126,17 +126,14 @@ public:
     void printAsDotty(ostream &);
 
 private:
-
-    void computeAndStoreColors(std::map<PTRef, icolor_t> const & literalColors);
-
-    icolor_t getLitColor (PTRef term) const {
+    icolor_t getLitColor(PTRef term) const {
         assert(litColors.find(term) != litColors.end());
         return litColors.at(term);
     }
 
     icolor_t getTermColor (PTRef term) const {
-        assert(termColors.find(term) != termColors.end());
-        return termColors.at(term);
+        assert(colorInfo);
+        return colorInfo->getColorFor(term);
     }
 
     void colorCGraph();
@@ -182,10 +179,10 @@ private:
     SMTConfig & config;
     Logic & logic;
     CGraph & cgraph;
-    std::unordered_map<PTRef, icolor_t, PTRefHash> termColors;
-    std::unordered_map<PTRef, icolor_t, PTRefHash> litColors;
+    std::map<PTRef, icolor_t> litColors; // MB: this is needed because edges need to be colored exactly as the literals in the conflict
     std::set<CNode *> colored_nodes;
     std::set<CEdge *> colored_edges;
+    std::unique_ptr<TermColorInfo> colorInfo;
     std::map<path_t, icolor_t> L;
 
 };

--- a/src/tsolvers/lrasolver/FarkasInterpolator.h
+++ b/src/tsolvers/lrasolver/FarkasInterpolator.h
@@ -9,6 +9,7 @@
 #include <PtStructs.h>
 #include <Global.h>
 #include <Real.h>
+#include <TheoryInterpolator.h>
 
 class LALogic;
 class PartitionManager;
@@ -41,14 +42,17 @@ struct DecomposedStatistics {
 
 class FarkasInterpolator {
 public:
-    FarkasInterpolator(LALogic & logic, PartitionManager & pmanager, vec<PtAsgn> const & explanations, std::vector<opensmt::Real> const & coeffs,
-                       ipartitions_t const & mask, std::map<PTRef, icolor_t> * labels)
+    FarkasInterpolator(LALogic & logic, vec<PtAsgn> const & explanations, std::vector<opensmt::Real> const & coeffs,
+                       std::map<PTRef, icolor_t> & labels) : FarkasInterpolator(logic, explanations, coeffs, &labels,
+                                                                                nullptr) {}
+
+    FarkasInterpolator(LALogic & logic, vec<PtAsgn> const & explanations, std::vector<opensmt::Real> const & coeffs,
+                       std::map<PTRef, icolor_t> * labels, std::unique_ptr<TermColorInfo> colorInfo)
         : logic(logic),
-          pmanager(pmanager),
           explanations(explanations),
           explanation_coeffs(coeffs),
-          mask(mask),
-          labels(labels)
+          labels(labels),
+          termColorInfo(std::move(colorInfo))
     {}
 
     PTRef getFarkasInterpolant();
@@ -82,17 +86,18 @@ private:
         return getGlobalColorFor(term);
     }
 
+    bool ensureHasColorForAllTerms();
+
     icolor_t getGlobalColorFor(PTRef term) const;
 
     PTRef weightedSum(std::vector<std::pair<PtAsgn, opensmt::Real>> const & system);
 
 private:
     LALogic & logic;
-    PartitionManager & pmanager;
     const vec<PtAsgn> & explanations;
     const std::vector<opensmt::Real> & explanation_coeffs;
-    const ipartitions_t & mask;
     std::map<PTRef, icolor_t> * labels;
+    std::unique_ptr<TermColorInfo> termColorInfo;
 };
 
 #endif //OPENSMT_FARKASINTERPOLATOR_H

--- a/src/tsolvers/lrasolver/LRASolver.cc
+++ b/src/tsolvers/lrasolver/LRASolver.cc
@@ -103,7 +103,8 @@ lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
 PTRef
 LRASolver::getInterpolant( const ipartitions_t & mask , map<PTRef, icolor_t> *labels, PartitionManager &pmanager) {
     assert(status == UNSAT);
-    FarkasInterpolator interpolator(logic, pmanager, explanation, explanationCoefficients, mask, labels);
+    FarkasInterpolator interpolator(logic, explanation, explanationCoefficients, labels,
+                                    std::unique_ptr<TermColorInfo>(new GlobalTermColorInfo(pmanager, mask)));
     auto itpAlgorithm = config.getLRAInterpolationAlgorithm();
     if (itpAlgorithm == itp_lra_alg_strong) { return interpolator.getFarkasInterpolant(); }
     else if (itpAlgorithm == itp_lra_alg_weak) { return interpolator.getDualFarkasInterpolant(); }

--- a/test/unit/test_LRAInterpolation.cc
+++ b/test/unit/test_LRAInterpolation.cc
@@ -51,9 +51,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothNonstrict){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.printTerm(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
@@ -82,9 +80,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Astrict){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.printTerm(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
@@ -113,9 +109,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Bstrict){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.printTerm(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
@@ -144,9 +138,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothStrict){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     std::cout << logic.printTerm(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
@@ -174,9 +166,7 @@ TEST_F(LRAInterpolationTest, test_AllInA){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_A}, {conflict[3].tr, I_A}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3, leq4}), logic.getTerm_true(), farkasItp));
     EXPECT_EQ(farkasItp, logic.getTerm_false());
@@ -210,9 +200,7 @@ TEST_F(LRAInterpolationTest, test_AllInB){
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
     std::vector<opensmt::Real> coeffs {1,1,1,1};
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_B}, {conflict[1].tr, I_B}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
-    PartitionManager dummy(logic);
-    ipartitions_t dummyMask;
-    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.getTerm_true(), logic.mkAnd({leq1, leq2, leq3, leq4}), farkasItp));
     EXPECT_EQ(farkasItp, logic.getTerm_true());
@@ -230,37 +218,69 @@ TEST_F(LRAInterpolationTest, test_AllInB){
     EXPECT_EQ(dualDecomposedFarkasItp, logic.getTerm_true());
 }
 
-//TEST_F(LRAInterpolationTest, test_Decomposition_NonStrict){
-//    /*
-//     * A:   x1 >= 0
-//     *      x2 - x1 >= 0
-//     *      -x3 - x1 >= 0
-//     * B:
-//     *      x3 - x4 >= 0
-//     *      -x4 - x2 >= 0
-//     *      x4 >= 1
-//     */
-//    PTRef zero = logic.getTerm_NumZero();
-//    PTRef leq1 = logic.mkNumGeq(x1, zero);
-//    PTRef leq2 = logic.mkNumGeq(logic.mkNumMinus(x2,x1), zero);
-//    PTRef leq3 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x3,x1)), zero);
-//
-//    PTRef leq4 = logic.mkNumGeq(logic.mkNumMinus(x3,x4), zero);
-//    PTRef leq5 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x4,x2)), zero);
-//    PTRef leq6 = logic.mkNumGeq(x4, logic.getTerm_NumOne());
-//    vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True),
-//                          PtAsgn(leq4, l_True), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
-//    ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-//    std::vector<opensmt::Real> coeffs {2,1,1,1,1,2};
-//    std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_A},
-//                                      {conflict[3].tr, I_B}, {conflict[4].tr, I_B}, {conflict[5].tr, I_B}};
-//    PartitionManager dummy(logic);
-//    ipartitions_t dummyMask;
-//    FarkasInterpolator interpolator(logic, dummy, conflict, coeffs, dummyMask, &labels);
-//    PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();
-//    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), decomposedFarkasItp));
-//    ASSERT_TRUE(logic.isAnd(decomposedFarkasItp));
-//    EXPECT_EQ(decomposedFarkasItp, logic.mkAnd(logic.mkNumLeq(zero, x2), logic.mkNumLeq(zero, logic.mkNumNeg(x3))));
-//    PTRef dualDecomposedFarkasItp = interpolator.getDualDecomposedInterpolant();
-//    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), dualDecomposedFarkasItp));
-//}
+TEST_F(LRAInterpolationTest, test_Decomposition_NonStrict){
+    /*
+     * A:   x1 >= 0
+     *      x2 - x1 >= 0
+     *      -x3 - x1 >= 0
+     * B:
+     *      x3 - x4 >= 0
+     *      -x4 - x2 >= 0
+     *      x4 >= 1
+     */
+    PTRef zero = logic.getTerm_NumZero();
+    PTRef leq1 = logic.mkNumGeq(x1, zero);
+    PTRef leq2 = logic.mkNumGeq(logic.mkNumMinus(x2,x1), zero);
+    PTRef leq3 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x3,x1)), zero);
+
+    PTRef leq4 = logic.mkNumGeq(logic.mkNumMinus(x3,x4), zero);
+    PTRef leq5 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x4,x2)), zero);
+    PTRef leq6 = logic.mkNumGeq(x4, logic.getTerm_NumOne());
+    vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True),
+                          PtAsgn(leq4, l_True), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
+    ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
+    std::vector<opensmt::Real> coeffs {2,1,1,1,1,2};
+    std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_A},
+                                      {conflict[3].tr, I_B}, {conflict[4].tr, I_B}, {conflict[5].tr, I_B}};
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
+    PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();
+    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), decomposedFarkasItp));
+    ASSERT_TRUE(logic.isAnd(decomposedFarkasItp));
+    EXPECT_EQ(decomposedFarkasItp, logic.mkAnd(logic.mkNumLeq(zero, x2), logic.mkNumLeq(zero, logic.mkNumNeg(x3))));
+    PTRef dualDecomposedFarkasItp = interpolator.getDualDecomposedInterpolant();
+    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), dualDecomposedFarkasItp));
+}
+
+TEST_F(LRAInterpolationTest, test_Decomposition_Strict){
+    /*
+     * A:   x1 >= 0
+     *      x2 - x1 > 0
+     *      -x3 - x1 >= 0
+     * B:
+     *      x3 - x4 > 0
+     *      -x4 - x2 >= 0
+     *      x4 >= 0
+     */
+    PTRef zero = logic.getTerm_NumZero();
+    PTRef leq1 = logic.mkNumGeq(x1, zero);
+    PTRef leq2 = logic.mkNumGt(logic.mkNumMinus(x2,x1), zero);
+    PTRef leq3 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x3,x1)), zero);
+
+    PTRef leq4 = logic.mkNumGt(logic.mkNumMinus(x3,x4), zero);
+    PTRef leq5 = logic.mkNumGeq(logic.mkNumNeg(logic.mkNumPlus(x4,x2)), zero);
+    PTRef leq6 = logic.mkNumGeq(x4, logic.getTerm_NumOne());
+    vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(logic.mkNot(leq2), l_False), PtAsgn(leq3, l_True),
+                          PtAsgn(logic.mkNot(leq4), l_False), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
+    ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
+    std::vector<opensmt::Real> coeffs {2,1,1,1,1,2};
+    std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_A},
+                                      {conflict[3].tr, I_B}, {conflict[4].tr, I_B}, {conflict[5].tr, I_B}};
+    FarkasInterpolator interpolator(logic, conflict, coeffs, labels);
+    PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();
+    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), decomposedFarkasItp));
+    ASSERT_TRUE(logic.isAnd(decomposedFarkasItp));
+    EXPECT_EQ(decomposedFarkasItp, logic.mkAnd(logic.mkNumLt(zero, x2), logic.mkNumLeq(zero, logic.mkNumNeg(x3))));
+    PTRef dualDecomposedFarkasItp = interpolator.getDualDecomposedInterpolant();
+    EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), dualDecomposedFarkasItp));
+//    std::cout << logic.printTerm(dualDecomposedFarkasItp) << std::endl;
+}


### PR DESCRIPTION
This PR is a follow-up of #183 and aims to better define how information about partitioning of terms is passed to the Theory Interpolators. 

This partitioning information can be global, derived from the partitioning of the whole SMT query, or it can be local, derived just from the partitioning of the theory conflict passed to the interpolator.
These can be different, as terms that are shared globally across partitions can be local within a single theory conflict.

This PR includes just refactoring of the current code, with no change in the functionality, but it better separates the Interpolator classes from the rest of the code, which allows for easier unit testing.

In the future we could also change how the partitioning information is computed---the global partitioning information can be delayed until the interpolation phase and does not need to be maintained fully from the beginning of the solving process.