### PR TITLE
Fail gracefully when (get-interpolants) command is encountered in an SMT-LIB script, but the solver is not in UNSAT state.

### DIFF
--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -1161,6 +1161,10 @@ void Interpret::getInterpolants(const ASTNode& n)
         }
         partitionings.push_c(p);
     }
+    if (main_solver->getStatus() != s_False) {
+        notify_formatted(true, "Cannot interpolate, solver is not in UNSAT state!");
+        return;
+    }
     auto interpolationContext = main_solver->getInterpolationContext();
 //        cerr << "Computing interpolant with mask " << p << endl;
     vec<PTRef> itps;


### PR DESCRIPTION
Currently the solver throws an exception if an interpolation is attempted but the solver is not in UNSAT state. In the interpreter we can check this and report an error to the user instead of throwing the exception.

Resolves #96 (when the option to produce interpolants is set properly before the set-logic command).