### PR TITLE
A more macos filesystem friendly name for our IntTypes wrapper

### DIFF
--- a/src/common/Alloc.h
+++ b/src/common/Alloc.h
@@ -20,7 +20,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #ifndef Minisat_Alloc_h
 #define Minisat_Alloc_h
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include "XAlloc.h"
 #include "Vec.h"
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(common
     "${CMAKE_CURRENT_LIST_DIR}/Global.h"
     "${CMAKE_CURRENT_LIST_DIR}/Integer.h"
     "${CMAKE_CURRENT_LIST_DIR}/Number.h"
-    "${CMAKE_CURRENT_LIST_DIR}/IntTypes.h"
+    "${CMAKE_CURRENT_LIST_DIR}/osmtinttypes.h"
     "${CMAKE_CURRENT_LIST_DIR}/SigMap.h"
     "${CMAKE_CURRENT_LIST_DIR}/StringMap.h"
     "${CMAKE_CURRENT_LIST_DIR}/Timer.h"
@@ -20,7 +20,7 @@ target_sources(common
 )
 
 install(FILES 
-    Global.h Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h SigMap.h Timer.h IntTypes.h
+    Global.h Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h SigMap.h Timer.h osmtinttypes.h
     Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 

--- a/src/common/osmtinttypes.h
+++ b/src/common/osmtinttypes.h
@@ -1,4 +1,4 @@
-/**************************************************************************************[IntTypes.h]
+/**************************************************************************************[osmtinttypes.h]
 Copyright (c) 2009-2010, Niklas Sorensson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -24,7 +24,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <assert.h>
 
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include "Alg.h"
 #include "Vec.h"
 #include "Map.h"

--- a/src/minisat/mtl/Map.h
+++ b/src/minisat/mtl/Map.h
@@ -20,7 +20,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_Map_h
 #define Minisat_Map_h
 
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include "Vec.h"
 
 

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -27,7 +27,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <initializer_list>
 #include <vector>
 #include <utility>
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include "XAlloc.h"
 
 

--- a/src/minisat/utils/Options.h
+++ b/src/minisat/utils/Options.h
@@ -26,7 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <string.h>
 
 #include <inttypes.h>
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include "Vec.h"
 #include "ParseUtils.h"
 

--- a/src/minisat/utils/System.h
+++ b/src/minisat/utils/System.h
@@ -25,7 +25,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <fpu_control.h>
 #endif
 
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 
 //-------------------------------------------------------------------------------------------------
 

--- a/src/tsolvers/lasolver/LARefs.h
+++ b/src/tsolvers/lasolver/LARefs.h
@@ -1,6 +1,6 @@
 #ifndef LABOUNDREFS_H
 #define LABOUNDREFS_H
-#include "IntTypes.h"
+#include "osmtinttypes.h"
 #include <ostream>
 #include <cassert>
 


### PR DESCRIPTION
This PR fixes a problem where on case-insensitive systems the opensmt's installed header called IntTypes.h gets confused with the system header inttypes.h causing builds to fail.  The suggested fix is to change the name of the header file.