### PR TITLE
Disabling OSX build on Travis, because of the new Travis policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,10 @@ matrix:
     - os: linux
       dist: bionic
       compiler: clang
-    - os: osx
-      compiler: clang
-      env: CMAKE_BUILD_TYPE=Debug
+    # Commented out temporarily until we figure out Travis price plan
+    #- os: osx
+      #compiler: clang
+      #env: CMAKE_BUILD_TYPE=Debug
 
 addons:
   apt:


### PR DESCRIPTION
Temporary solution, until we figure out how to continue with CI.
Reaction to this: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing