### PR TITLE
Fix google-benchmark options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ before_script:
     - export FLAGS="-Wall -Werror"
     - export INSTALL=${TRAVIS_BUILD_DIR}/install
     - mkdir build && mkdir ${INSTALL}
+    - cmake --version
 
 script:
     - ./ci/run_travis_commands.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,8 +157,12 @@ endif()
 ################# BENCHMARKING ##########################################
 option(PACKAGE_BENCHMARKS "Build the benchmarks" OFF)
 if (PACKAGE_BENCHMARKS)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
-endif ()
+    if(CMAKE_VERSION VERSION_LESS 3.11)
+        MESSAGE(WARNING "Minimum CMAKE version for building benchmarking is 3.11")
+    else()
+        add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
+    endif()
+endif()
 
 #########################################################################
 install(FILES ${CMAKE_SOURCE_DIR}/opensmt2.h DESTINATION ${INSTALL_HEADERS_DIR})

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -10,9 +10,9 @@ FetchContent_GetProperties(googlebenchmark)
 
 if (NOT benchmark_POPULATED)
   FetchContent_Populate(googlebenchmark)
-  set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
-  set(BENCHMARK_ENABLE_INSTALL OFF)
-  set(BENCHMARK_ENABLE_TESTING OFF)
+  set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE INTERNAL "")
+  set(BENCHMARK_ENABLE_INSTALL OFF CACHE INTERNAL "")
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE INTERNAL "")
   add_subdirectory(${googlebenchmark_SOURCE_DIR} ${googlebenchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif ()
 


### PR DESCRIPTION
Fixed settings to force the disabling of building unit tests in google-benchmark also for the first configuration.
Also, at least CMake 3.11 is required for fetching the external project the way we do.