### PR TITLE
Refactoring in LASolver

### DIFF
--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -272,7 +272,6 @@ LVRef LASolver::exprToLVar(PTRef expr) {
         // Case (1), (2a), and (2b)
         PTRef v;
         PTRef c;
-
         logic.splitTermToVarAndConst(expr, v, c);
         assert(logic.isNumVarOrIte(v) || (logic.isNegated(v) && logic.isNumVarOrIte(logic.mkNumNeg(v))));
         x = getLAVar_single(v);
@@ -460,8 +459,6 @@ void LASolver::popBacktrackPoints(unsigned int count) {
         PtAsgn dec = popTermBacktrackPoint();
         if (dec != PtAsgn_Undef) {
             clearPolarity(dec.tr);
-            LVRef it = getVarForLeq(dec.tr);
-            simplex.boundDeactivated(it);
         }
 
         TSolver::popBacktrackPoint();

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -87,7 +87,7 @@ protected:
     //opensmt::Real delta; // The size of one delta.  Set through computeModel()
     LASolverStats tsolver_stats;
     void setBound(PTRef leq);
-    bool assertBoundOnVar(LVRef it, LABoundRef itBound_ref);
+    bool assertBound(LABoundRef bound_ref);
 
 protected:
     PTRef getVarPTRef(LVRef v) const {
@@ -138,11 +138,10 @@ protected:
 
     LVRef getLAVar_single(PTRef term);                      // Initialize a new LA var if needed, otherwise return the old var
     bool hasVar(PTRef expr);
-    LVRef getVarForLeq(PTRef ref)  const  { return laVarMapper.getVarByLeqId(logic.getPterm(ref).getId()); }
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
     virtual void notifyVar(LVRef) {}                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
     void getSuggestions( vec<PTRef>& dst, SolverId solver_id );                                   // find possible suggested atoms
-    void getSimpleDeductions(LVRef v, LABoundRef);      // find deductions from actual bounds position
+    void getSimpleDeductions(LABoundRef);      // find deductions from actual bounds position
     unsigned getIteratorByPTRef( PTRef e, bool );                                                 // find bound iterator by the PTRef
     inline bool getStatus( );                               // Read the status of the solver in lbool
     bool setStatus( LASolverStatus );               // Sets and return status of the solver

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -37,20 +37,7 @@ void LAVarMapper::registerNewMapping(LVRef lv, PTRef e_orig) {
     ptermToLavar[Idx(id_neg)] = lv;
 }
 
-void LAVarMapper::addLeqVar(PTRef leq_tr, LVRef v)
-{
-    Pterm const & leq_t = logic.getPterm(leq_tr);
-    int idx = Idx(leq_t.getId());
-    for (int i = leqToLavar.size(); i <= idx; i++) {
-        leqToLavar.push(LVRef_Undef);
-    }
-    assert(leqToLavar[idx] == LVRef_Undef);
-    leqToLavar[idx] = v;
-}
-
 LVRef  LAVarMapper::getVarByPTId(PTId i) const { return ptermToLavar[Idx(i)]; }
-
-LVRef  LAVarMapper::getVarByLeqId(PTId i) const { return leqToLavar[Idx(i)]; }
 
 bool LAVarMapper::hasVar(PTRef tr) const { return hasVar(logic.getPterm(tr).getId()); }
 
@@ -59,7 +46,6 @@ bool   LAVarMapper::hasVar(PTId i) const {
 }
 
 void LAVarMapper::clear() {
-    this->leqToLavar.clear();
     this->laVarToPTRef.clear();
     this->ptermToLavar.clear();
 }

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -24,9 +24,6 @@ class LALogic;
  */
 class LAVarMapper {
 private:
-    /** Convenience mapping of inequalities to LVRef representing the linear term without constant in the inequality*/
-    vec<LVRef>      leqToLavar;
-
     /** Mapping of linear Pterms to LVRefs */
     vec<LVRef>      ptermToLavar;
 
@@ -39,10 +36,7 @@ public:
 
     void   registerNewMapping(LVRef lv, PTRef e_orig);
 
-    void   addLeqVar(PTRef leq_tr, LVRef v); // Adds a binding from leq_tr to the "slack var" v
-
     LVRef  getVarByPTId(PTId i) const;
-    LVRef  getVarByLeqId(PTId i) const;
 
     bool   hasVar(PTId i) const;
     bool   hasVar(PTRef tr) const;

--- a/src/tsolvers/lasolver/Simplex.h
+++ b/src/tsolvers/lasolver/Simplex.h
@@ -86,7 +86,7 @@ public:
 
     void quasiToBasic(LVRef it);
 
-    Explanation assertBoundOnVar(LVRef it, LABoundRef itBound_ref);
+    Simplex::Explanation assertBound(LABoundRef bound_ref);
     bool isProcessedByTableau  (LVRef var) const;
     inline bool isModelOutOfBounds    (LVRef v) const { return isModelOutOfUpperBound(v) || isModelOutOfLowerBound(v); }
     inline bool isModelOutOfUpperBound(LVRef v) const { return ( model->hasUBound(v) && model->read(v) > model->Ub(v) ); }
@@ -116,7 +116,7 @@ public:
 
     // Keeping track of activated bounds
 private:
-    std::vector<std::pair<LVRef, LABoundRef>> bufferOfActivatedBounds;
+    vec<LABoundRef> bufferOfActivatedBounds;
 
     void newVar(LVRef v) {
         // MB: is this needed for something?
@@ -138,7 +138,9 @@ private:
 
 public:
 
-    lbool getPolaritySuggestion(LVRef var, LABoundRef pos, LABoundRef neg) const {
+    lbool chooseBoundPolarity(LABoundRef pos, LABoundRef neg) const {
+        LVRef var = boundStore[pos].getLVRef();
+        assert(var == boundStore[neg].getLVRef());
         if (tableau.isQuasiBasic(var)) {
             (const_cast<Simplex*>(this))->quasiToBasic(var);
         }

--- a/src/tsolvers/lrasolver/LRAModel.cc
+++ b/src/tsolvers/lrasolver/LRAModel.cc
@@ -86,18 +86,20 @@ bool LRAModel::isEquality(LVRef v) const {
         && Lb(v) == Ub(v);
 }
 bool LRAModel::isUnbounded(LVRef v) const { return bs.isUnbounded(v); }
-bool LRAModel::boundTriviallySatisfied(LVRef v, LABoundRef b) const
+bool LRAModel::boundTriviallySatisfied(LABoundRef b) const
 {
     const LABound& bound = bs[b];
+    LVRef v = bound.getLVRef();
     assert(bound.getType() == bound_l || bound.getType() == bound_u);
     const bool is_lower = bound.getType() == bound_l;
     if ((is_lower && !hasLBound(v)) || (!is_lower && !hasUBound(v))) { return false; }
     const LABound& toCompare = is_lower ? readLBound(v) : readUBound(v);
     return ((!is_lower && bound.getIdx().x >= toCompare.getIdx().x) || (is_lower && bound.getIdx().x <= toCompare.getIdx().x));
 }
-bool LRAModel::boundTriviallyUnsatisfied(LVRef v, LABoundRef b) const
+bool LRAModel::boundTriviallyUnsatisfied(LABoundRef b) const
 {
     const LABound& bound = bs[b];
+    LVRef v = bound.getLVRef();
     assert(bound.getType() == bound_l || bound.getType() == bound_u);
     const bool is_lower = bound.getType() == bound_l;
     if ((is_lower && !hasUBound(v)) || (!is_lower && !hasLBound(v))) { return false; }

--- a/src/tsolvers/lrasolver/LRAModel.h
+++ b/src/tsolvers/lrasolver/LRAModel.h
@@ -22,9 +22,6 @@ protected:
     vec<vec<LABoundRef> > int_lbounds;
     vec<vec<LABoundRef> > int_ubounds;
 
-    vec<int> bound_limits;
-    vec<LABoundRef> bound_trace;
-
     vec<Delta>  current_assignment;
     vec<Delta>  last_consistent_assignment;
     nat_set     changed_vars_set;
@@ -33,11 +30,10 @@ protected:
     LABoundStore &bs;
     int n_vars_with_model;
     Map<LVRef,bool,LVRefHash> has_model;
-    int          backtrackLevel();
     void         popBounds();
 
 public:
-    LRAModel(LABoundStore & bs) : bs(bs), n_vars_with_model(0) { bound_limits.push(0); }
+    LRAModel(LABoundStore & bs) : bs(bs), n_vars_with_model(0) { }
     void init();
     int addVar(LVRef v); // Adds a variable.  Returns the total number of variables
     inline int   nVars() { return n_vars_with_model; }
@@ -54,7 +50,9 @@ private:
     inline const Delta& readBackupValue (LVRef v) const { return last_consistent_assignment[getVarId(v)]; }
 public:
 
+    bool hasActiveBounds(LVRef v) const { return hasLBound(v) || hasUBound(v); }
     void pushBound(const LABoundRef br);
+    void popBound(LVRef var, BoundT type);
     bool hasLBound(LVRef v) const { return int_lbounds[getVarId(v)].size() != 0; }
     const LABound& readLBound(const LVRef &v) const;
     LABoundRef readLBoundRef(LVRef v) const;
@@ -63,9 +61,6 @@ public:
     LABoundRef readUBoundRef(LVRef v) const;
     inline const Delta& Lb(LVRef v) const { return readLBound(v).getValue(); }
     inline const Delta& Ub(LVRef v) const { return readUBound(v).getValue(); }
-    void pushBacktrackPoint();
-    void popBacktrackPoint();
-    int  getBacktrackSize() const ;
 
     bool isEquality(LVRef v) const;
     bool isUnbounded(LVRef v) const;

--- a/src/tsolvers/lrasolver/LRAModel.h
+++ b/src/tsolvers/lrasolver/LRAModel.h
@@ -64,8 +64,8 @@ public:
 
     bool isEquality(LVRef v) const;
     bool isUnbounded(LVRef v) const;
-    bool boundTriviallySatisfied(LVRef v, LABoundRef b) const;
-    bool boundTriviallyUnsatisfied(LVRef v, LABoundRef b) const;
+    bool boundTriviallySatisfied(LABoundRef b) const;
+    bool boundTriviallyUnsatisfied(LABoundRef b) const;
 
     void saveAssignment() {
         for (int i = 0; i < changed_vars_vec.size(); ++i) {

--- a/src/tsolvers/lrasolver/LRASolver.cc
+++ b/src/tsolvers/lrasolver/LRASolver.cc
@@ -89,10 +89,9 @@ LRALogic&  LRASolver::getLogic() { return logic; }
 
 lbool LRASolver::getPolaritySuggestion(PTRef ptref) const {
     if (!this->isInformed(ptref)) { return l_Undef; }
-    LVRef var = this->getVarForLeq(ptref);
     LABoundRefPair bounds = getBoundRefPair(ptref);
     assert( bounds.pos != LABoundRef_Undef && bounds.neg != LABoundRef_Undef );
-    return simplex.getPolaritySuggestion(var, bounds.pos, bounds.neg);
+    return simplex.chooseBoundPolarity(bounds.pos, bounds.neg);
 }
 
 

--- a/test/unit/test_Simplex.cc
+++ b/test/unit/test_Simplex.cc
@@ -65,13 +65,13 @@ TEST(Simplex_test, test_ops_in_Simplex)
     Delta sum = s.getValuation(y_minus_x);
     cout << sum.R() + sum.D() * d << endl;
 
-    s.assertBoundOnVar(x, x_strict_0.lb);
-    s.assertBoundOnVar(y, y_strict_0.lb);
+    s.assertBound(x_strict_0.lb);
+    s.assertBound(y_strict_0.lb);
 
     s.pushBacktrackPoint();
 
-    s.assertBoundOnVar(x, x_strict_1.ub);
-    s.assertBoundOnVar(y, y_strict_1.ub);
+    s.assertBound(x_strict_1.ub);
+    s.assertBound(y_strict_1.ub);
 
     ex = s.checkSimplex();
     ASSERT_EQ(ex.size(), 0);
@@ -83,7 +83,7 @@ TEST(Simplex_test, test_ops_in_Simplex)
     sum = s.getValuation(y_minus_x);
     cout << sum.R() + sum.D() * d << endl;
 
-    ex = s.assertBoundOnVar(y_minus_x, y_minus_x_nostrict_1.lb);
+    ex = s.assertBound(y_minus_x_nostrict_1.lb);
     ASSERT_EQ(ex.size(), 0); // not detectable at this point
     ex = s.checkSimplex();
     ASSERT_EQ(ex.size(), 3);
@@ -91,9 +91,9 @@ TEST(Simplex_test, test_ops_in_Simplex)
     s.popBacktrackPoint();
     s.finalizeBacktracking();
 
-    ex = s.assertBoundOnVar(y_minus_x, y_minus_x_nostrict_0.lb);
-    s.assertBoundOnVar(x, x_nostrict_1.lb);
-    s.assertBoundOnVar(y, y_nostrict_1.lb);
+    ex = s.assertBound(y_minus_x_nostrict_0.lb);
+    s.assertBound(x_nostrict_1.lb);
+    s.assertBound(y_nostrict_1.lb);
     ex = s.checkSimplex();
     ASSERT_EQ(ex.size(), 0);
     d = s.computeDelta();
@@ -137,11 +137,11 @@ TEST(Simplex_test, test_Assignment)
     s.newRow(y_minus_x, std::move(p_y_plus_x));
 
     s.initModel();
-    s.assertBoundOnVar(x_nostrict_1.v, x_nostrict_1.ub);
-    s.assertBoundOnVar(x_strict_m5.v, x_strict_m5.lb);
-    s.assertBoundOnVar(y_strict_0.v, y_strict_0.ub);
-    s.assertBoundOnVar(y_minus_x_strict_0.v, y_minus_x_strict_0.lb);
-    s.assertBoundOnVar(y_minus_x_nostrict_0.v, y_minus_x_nostrict_0.ub);
+    s.assertBound(x_nostrict_1.ub);
+    s.assertBound(x_strict_m5.lb);
+    s.assertBound(y_strict_0.ub);
+    s.assertBound(y_minus_x_strict_0.lb);
+    s.assertBound(y_minus_x_nostrict_0.ub);
 
     Simplex::Explanation ex = s.checkSimplex();
     ASSERT_EQ(ex.size(), 0);


### PR DESCRIPTION
Moves the responsibility for keeping track of backtracking points from `LRAModel` to `Simplex`.

Removes the unnecessary mapping `leqtoLavar` in `LAVarMapper`.