### PR TITLE
Cleanup for undefined behaviour

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -258,7 +258,7 @@ std::unique_ptr<InterpolationContext> MainSolver::getInterpolationContext() {
                                                                           getSMTSolver().getProof(), pmanager, getSMTSolver().nVars()));
 }
 
-void MainSolver::addToConj(std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const
+void MainSolver::addToConj(const std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const
 {
     for (const auto & constr : in) {
         vec<PTRef> disj_vec;

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -306,15 +306,16 @@ bool MainSolver::writeSolverState_smtlib2(const char* file, char** msg) const
 
 bool MainSolver::writeSolverSplits_smtlib2(const char* file, char** msg) const
 {
-    vec<SplitData>& splits = ts.solver.splits;
-    for (int i = 0; i < splits.size(); i++) {
+    std::vector<SplitData>& splits = ts.solver.splits;
+    int i = 0;
+    for (const auto & split : splits) {
         vec<PTRef> conj_vec;
         std::vector<vec<PtAsgn> > constraints;
-        splits[i].constraintsToPTRefs(constraints, thandler);
+        split.constraintsToPTRefs(constraints, thandler);
         addToConj(constraints, conj_vec);
 
         std::vector<vec<PtAsgn> > learnts;
-        splits[i].learntsToPTRefs(learnts, thandler);
+        split.learntsToPTRefs(learnts, thandler);
         addToConj(learnts, conj_vec);
 
         if (config.smt_split_format_length() == spformat_full)
@@ -323,7 +324,7 @@ bool MainSolver::writeSolverSplits_smtlib2(const char* file, char** msg) const
         PTRef problem = logic.mkAnd(conj_vec);
 
         char* name;
-        int written = asprintf(&name, "%s-%02d.smt2", file, i);
+        int written = asprintf(&name, "%s-%02d.smt2", file, i ++);
         assert(written >= 0);
         (void)written;
         std::ofstream file;

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -232,13 +232,13 @@ ValPair MainSolver::getValue(PTRef tr) const
     }
 }
 
-void MainSolver::getValues(const vec<PTRef>& trs, vec<ValPair>& vals) const
+void MainSolver::getValues(const vec<PTRef>& trs, std::vector<ValPair>& vals) const
 {
     vals.clear();
     for (int i = 0; i < trs.size(); i++)
     {
         PTRef tr = trs[i];
-        vals.push(getValue(tr));
+        vals.emplace_back(getValue(tr));
     }
 }
 

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -258,7 +258,7 @@ std::unique_ptr<InterpolationContext> MainSolver::getInterpolationContext() {
                                                                           getSMTSolver().getProof(), pmanager, getSMTSolver().nVars()));
 }
 
-void MainSolver::addToConj(vec<vec<PtAsgn> >& in, vec<PTRef>& out) const
+void MainSolver::addToConj(std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const
 {
     for (int i = 0; i < in.size(); i++) {
         vec<PtAsgn>& constr = in[i];
@@ -309,11 +309,11 @@ bool MainSolver::writeSolverSplits_smtlib2(const char* file, char** msg) const
     vec<SplitData>& splits = ts.solver.splits;
     for (int i = 0; i < splits.size(); i++) {
         vec<PTRef> conj_vec;
-        vec<vec<PtAsgn> > constraints;
+        std::vector<vec<PtAsgn> > constraints;
         splits[i].constraintsToPTRefs(constraints, thandler);
         addToConj(constraints, conj_vec);
 
-        vec<vec<PtAsgn> > learnts;
+        std::vector<vec<PtAsgn> > learnts;
         splits[i].learntsToPTRefs(learnts, thandler);
         addToConj(learnts, conj_vec);
 

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -260,11 +260,10 @@ std::unique_ptr<InterpolationContext> MainSolver::getInterpolationContext() {
 
 void MainSolver::addToConj(std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const
 {
-    for (int i = 0; i < in.size(); i++) {
-        vec<PtAsgn>& constr = in[i];
+    for (const auto & constr : in) {
         vec<PTRef> disj_vec;
-        for (int k = 0; k < constr.size(); k++)
-            disj_vec.push(constr[k].sgn == l_True ? constr[k].tr : logic.mkNot(constr[k].tr));
+        for (PtAsgn pta : constr)
+            disj_vec.push(pta.sgn == l_True ? pta.tr : logic.mkNot(pta.tr));
         out.push(logic.mkOr(disj_vec));
     }
 }

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -206,7 +206,7 @@ class MainSolver
     bool  writeSolverState_smtlib2 (const char* file, char** msg) const;
     bool  writeFuns_smtlib2 (const char* file) const;
     bool  writeSolverSplits_smtlib2(const char* file, char** msg) const;
-    void  addToConj(std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const; // Add the contents of in as disjuncts to out
+    void  addToConj(const std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const; // Add the contents of in as disjuncts to out
 
     // Values
     lbool   getTermValue   (PTRef tr) const { return ts.getTermValue(tr); }

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -213,7 +213,7 @@ class MainSolver
 
     // DEPRECATED. use the new Model structure
     ValPair getValue       (PTRef tr) const;
-    void    getValues      (const vec<PTRef>&, vec<ValPair>&) const;
+    void    getValues      (const vec<PTRef>&, std::vector<ValPair>&) const;
 
     // Returns model of the last query (must be in satisfiable state)
     std::unique_ptr<Model> getModel();

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -206,7 +206,7 @@ class MainSolver
     bool  writeSolverState_smtlib2 (const char* file, char** msg) const;
     bool  writeFuns_smtlib2 (const char* file) const;
     bool  writeSolverSplits_smtlib2(const char* file, char** msg) const;
-    void  addToConj(vec<vec<PtAsgn> >& in, vec<PTRef>& out) const; // Add the contents of in as disjuncts to out
+    void  addToConj(std::vector<vec<PtAsgn> >& in, vec<PTRef>& out) const; // Add the contents of in as disjuncts to out
 
     // Values
     lbool   getTermValue   (PTRef tr) const { return ts.getTermValue(tr); }

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -673,13 +673,13 @@ bool Interpret::getAssignment() {
 void Interpret::getValue(const std::vector<ASTNode*>* terms)
 {
     Logic& logic = main_solver->getLogic();
-    vec<ValPair> values;
+    std::vector<ValPair> values;
     for (auto term_it = terms->begin(); term_it != terms->end(); ++term_it) {
         const ASTNode& term = **term_it;
         LetRecords tmp;
         PTRef tr = parseTerm(term, tmp);
         if (tr != PTRef_Undef) {
-            values.push(main_solver->getValue(tr));
+            values.emplace_back(main_solver->getValue(tr));
             char* pt_str = logic.printTerm(tr);
             comment_formatted("Found the term %s", pt_str);
             free(pt_str);
@@ -1152,7 +1152,7 @@ void Interpret::getInterpolants(const ASTNode& n)
         opensmt_error("Cannot interpolate");
 
     assert(grouping.size() >= 2);
-    vec<ipartitions_t> partitionings;
+    std::vector<ipartitions_t> partitionings;
     ipartitions_t p = 0;
     // We assume that together the groupings cover all query, so we ignore the last argument, since that should contain all that was missing at that point
     for (int i = 0; i < grouping.size() - 1; i++)
@@ -1183,7 +1183,7 @@ void Interpret::getInterpolants(const ASTNode& n)
                 return;
             }
         }
-        partitionings.push_c(p);
+        partitionings.emplace_back(p);
     }
     if (main_solver->getStatus() != s_False) {
         notify_formatted(true, "Cannot interpolate, solver is not in UNSAT state!");

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -687,9 +687,9 @@ void Interpret::getValue(const std::vector<ASTNode*>* terms)
             comment_formatted("Error parsing the term %s", (**(term.children->begin())).getValue());
     }
     printf("(");
-    for (int i = 0; i < values.size(); i++) {
-        char* name = logic.printTerm(values[i].tr);
-        printf("(%s %s)", name, values[i].val);
+    for (const ValPair & valPair : values) {
+        char* name = logic.printTerm(valPair.tr);
+        printf("(%s %s)", name, valPair.val);
         free(name);
     }
     printf(")\n");

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -956,7 +956,7 @@ void Interpret::notify_formatted(bool error, const char* fmt_str, ...) {
         cout << "\")" << endl;
 //    else
 //        cout << ")" << endl;
-        cout << endl;
+    cout << endl;
 }
 
 void Interpret::notify_success() {

--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -440,7 +440,7 @@ bool Cnfizer::addClause(const vec<Lit> & c_in)
     }
 
 #endif
-    std::pair<CRef, CRef> iorefs{CRef_Undef, CRef_Undef};
+    opensmt::pair<CRef, CRef> iorefs{CRef_Undef, CRef_Undef};
     bool res = solver.addOriginalSMTClause(c, iorefs);
     if (keepPartitionInfo()) {
         CRef ref = iorefs.first;

--- a/src/common/FastRational.cc
+++ b/src/common/FastRational.cc
@@ -177,7 +177,7 @@ FastRational divexact(FastRational const & n, FastRational const & d) {
 FastRational get_multiplicand(const std::vector<FastRational>& reals)
 {
     std::vector<FastRational> dens;
-    for (auto & r : reals) {
+    for (const auto & r : reals) {
         if (!r.isInteger()) {
             dens.push_back(r.get_den());
         }
@@ -188,7 +188,8 @@ FastRational get_multiplicand(const std::vector<FastRational>& reals)
     while (dens.size() > 0) {
         // Unique denominators
         std::sort(dens.begin(), dens.end());
-        std::unique(dens.begin(), dens.end());
+        auto last = std::unique(dens.begin(), dens.end());
+        dens.erase(last, dens.end());
 #ifdef PRINTALOT
         char *buf = (char*) malloc(1);
         buf[0] = '\0';

--- a/src/common/FastRational.cc
+++ b/src/common/FastRational.cc
@@ -6,7 +6,7 @@ Copyright (c) 2008, 2009 Centre national de la recherche scientifique (CNRS)
  */
 #include "FastRational.h"
 #include <sstream>
-#include <Sort.h>
+#include <algorithm>
 
 FastRational::FastRational( const char * s, const int base )
 {
@@ -174,19 +174,21 @@ FastRational divexact(FastRational const & n, FastRational const & d) {
 }
 
 // Given as input the sequence Reals, return the smallest number m such that for each r in Reals, r*m is an integer
-FastRational get_multiplicand(const vec<FastRational>& reals)
+FastRational get_multiplicand(const std::vector<FastRational>& reals)
 {
-    vec<FastRational> dens;
-    for (int i = 0; i < reals.size(); i++)
-        if (!reals[i].isInteger())
-            dens.push_c(reals[i].get_den());
+    std::vector<FastRational> dens;
+    for (auto & r : reals) {
+        if (!r.isInteger()) {
+            dens.push_back(r.get_den());
+        }
+    }
 
     // Iterate until dens is not empty
     FastRational mult = 1; // Collect here the number I need to multiply the polynomial to get rid of all denominators
     while (dens.size() > 0) {
         // Unique denominators
-        sort(dens);
-        uniq(dens);
+        std::sort(dens.begin(), dens.end());
+        std::unique(dens.begin(), dens.end());
 #ifdef PRINTALOT
         char *buf = (char*) malloc(1);
         buf[0] = '\0';
@@ -210,13 +212,12 @@ FastRational get_multiplicand(const vec<FastRational>& reals)
             int k = 0;
             FastRational m = lcm(dens[dens.size()-1], dens[dens.size()-2]);
             mult *= m;
-            int orig_sz = dens.size();
-            for (int j = 0; j < dens.size()-2; j++) {
+            for (size_t j = 0; j < dens.size()-2; j++) {
                 FastRational n = (m/dens[j]).get_den();
                 if (n != 1)
                     dens[k++] = n;
             }
-            dens.shrink(orig_sz-k);
+            dens.resize(k);
         }
     }
 #ifdef PRINTALOT

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -1041,8 +1041,6 @@ inline FastRational FastRational_inverse(const FastRational& x) {
     return x.inverse();
 }
 
-FastRational get_multiplicand(const vec<FastRational>& reals);
-
 inline bool isNegative(FastRational const& num) {
     return num.sign() < 0;
 }
@@ -1058,4 +1056,6 @@ inline bool isNonNegative(FastRational const& num) {
 inline bool isNonPositive(FastRational const& num) {
     return num.sign() <= 0;
 }
+
+FastRational get_multiplicand(const std::vector<FastRational>& reals);
 #endif

--- a/src/common/Global.h
+++ b/src/common/Global.h
@@ -279,6 +279,7 @@ namespace opensmt {
         return true;
     }
 
+    // std::pair is not trivially copyable.  This version seems to allow on current compilers faster implementations.
     template <class T, class U> struct pair { T first; U second; };
 
 #define Pair(T) pair< T, T >

--- a/src/common/Global.h
+++ b/src/common/Global.h
@@ -279,6 +279,7 @@ namespace opensmt {
         return true;
     }
 
+    template <class T, class U> struct pair { T first; U second; };
 
 #define Pair(T) pair< T, T >
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -885,7 +885,7 @@ PTRef Logic::mkDistinct(vec<PTRef>& args) {
     else {
         if (distinctClassCount < maxDistinctClasses) {
             PTRef res = term_store.newTerm(diseq_sym, args);
-            term_store.addToCplxMap(key, res);
+            term_store.addToCplxMap(std::move(key), res);
             distinctClassCount++;
             return res;
         }
@@ -1151,7 +1151,7 @@ Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms)
             res = term_store.getFromCplxMap(k);
         else {
             res = term_store.newTerm(sym, k.args);
-            term_store.addToCplxMap(k, res);
+            term_store.addToCplxMap(std::move(k), res);
         }
     }
     else {
@@ -1169,7 +1169,7 @@ Logic::insertTermHash(SymRef sym, const vec<PTRef>& terms)
         }
         else {
             res = term_store.newTerm(sym, terms);
-            term_store.addToBoolMap(k, res); //bool_map.insert(k, res);
+            term_store.addToBoolMap(std::move(k), res);
 #ifdef SIMPLIFY_DEBUG
             char* ts = printTerm(res);
             cerr << "new: " << ts << endl;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -51,9 +51,9 @@ class Logic {
             args_.copyTo(args);
         }
         TFun() : ret_sort(SRef_Undef), tr_body(PTRef_Undef), name(NULL) {}
-        TFun(TFun& other) : ret_sort(other.ret_sort), tr_body(other.tr_body), name(other.name) { other.args.copyTo(args); }
+        TFun(const TFun& other) : ret_sort(other.ret_sort), tr_body(other.tr_body), name(other.name) { other.args.copyTo(args); }
         ~TFun() { free(name); }
-        TFun& operator=(TFun& other) {
+        TFun& operator=(TFun&& other) {
             if (&other != this) {
                 free(name);
                 ret_sort = other.ret_sort;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -102,7 +102,7 @@ class Logic {
         void insert(const char* name, TFun const & templ) {
             assert(not has(name));
             defined_functions_names.push();
-            defined_functions_names.last() = strdup(std::string(name).c_str());
+            defined_functions_names.last() = strdup(name);
             defined_functions[defined_functions_names.last()] = templ;
         }
 
@@ -113,7 +113,7 @@ class Logic {
 
         void getKeys(vec<const char*> & keys_out) {
             for (auto k : defined_functions_names) {
-                defined_functions_names.push(strdup(k));
+                keys_out.push(strdup(k));
             }
         }
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -93,17 +93,17 @@ class Logic {
     int distinctClassCount;
 
     class DefinedFunctions {
-        Map<const char*,TFun,StringHash,Equal<const char*> > defined_functions;
+        std::map<std::string,TFun> defined_functions;
         vec<char*> defined_functions_names;
 
     public:
-        bool has(const char* name) const { return defined_functions.has(name); }
+        bool has(const char* name) const { return defined_functions.find(name) != defined_functions.end(); }
 
         void insert(const char* name, TFun const & templ) {
             assert(not has(name));
             defined_functions_names.push();
-            defined_functions_names.last() = strdup(name);
-            defined_functions.insert(defined_functions_names.last(), templ);
+            defined_functions_names.last() = strdup(std::string(name).c_str());
+            defined_functions[defined_functions_names.last()] = templ;
         }
 
         TFun & operator[](const char* name) {
@@ -112,7 +112,9 @@ class Logic {
         }
 
         void getKeys(vec<const char*> & keys_out) {
-            defined_functions.getKeys(keys_out);
+            for (auto k : defined_functions_names) {
+                defined_functions_names.push(strdup(k));
+            }
         }
 
         ~DefinedFunctions() {

--- a/src/logics/SubstLoopBreaker.cc
+++ b/src/logics/SubstLoopBreaker.cc
@@ -257,7 +257,7 @@ Map<PTRef,PtAsgn,PTRefHash> SubstLoopBreaker::operator() (Map<PTRef,PtAsgn,PTRef
 vec<SNRef> SubstLoopBreaker::breakLoops(const std::vector<vec<SNRef>>& loops) {
     // Break the found loops.  Return the orphaned children as new start nodes
     vec<SNRef> orphans;
-    for (auto & loop : loops) {
+    for (const auto & loop : loops) {
         int last_idx = loop.size()-1;
         assert(last_idx >= 0);
         for (int j = 0; j < sna[loop[last_idx]].nChildren(); j++) {

--- a/src/logics/SubstLoopBreaker.h
+++ b/src/logics/SubstLoopBreaker.h
@@ -167,7 +167,7 @@ class TarjanAlgorithm {
   public:
     TarjanAlgorithm(SubstNodeAllocator &sna) : sna(sna), index(0) {}
     ~TarjanAlgorithm() { sna.clearTarjan(); }
-    vec<vec<SNRef>> getLoops(SNRef startNode);
+    std::vector<vec<SNRef>> getLoops(SNRef startNode);
 };
 
 class SubstLoopBreaker {
@@ -182,9 +182,9 @@ public:
     SubstLoopBreaker(const Logic& l) : logic(l), tvla(1024), sna(tvla, logic, 1024) {}
     Map<PTRef,PtAsgn,PTRefHash> operator() (Map<PTRef,PtAsgn,PTRefHash>&& substs);
     vec<SNRef> constructSubstitutionGraph(const Map<PTRef,PtAsgn,PTRefHash>& substKeysAndVals);
-    vec<vec<SNRef>> findLoops(vec<SNRef>& startNodes);
-    vec<SNRef> breakLoops(const vec<vec<SNRef>>& loops);
-    std::string printGraphAndLoops(const vec<SNRef>& startNodes, const vec<vec<SNRef>>& loops);
+    std::vector<vec<SNRef>> findLoops(vec<SNRef>& startNodes);
+    vec<SNRef> breakLoops(const std::vector<vec<SNRef>>& loops);
+    std::string printGraphAndLoops(const vec<SNRef>& startNodes, const std::vector<vec<SNRef>>& loops);
     vec<SNRef> minimizeRoots(vec<SNRef>&& roots) { return std::move(roots); }// nothing here, maybe do some attempt?
     Map<PTRef,PtAsgn,PTRefHash> constructLooplessSubstitution(Map<PTRef,PtAsgn,PTRefHash>&& substs);
 };

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -272,15 +272,15 @@ class ClauseAllocator : public RegionAllocator<uint32_t>
 template<class Idx, class Vec, class Deleted>
 class OccLists
 {
-    vec<Vec>  occs;
-    vec<char> dirty;
-    vec<Idx>  dirties;
-    Deleted   deleted;
+    std::vector<Vec>  occs;
+    vec<char>         dirty;
+    vec<Idx>          dirties;
+    Deleted           deleted;
 
  public:
     OccLists(const Deleted& d) : deleted(d) {}
 
-    void  init      (const Idx& idx){ occs.growTo(toInt(idx)+1); dirty.growTo(toInt(idx)+1, 0); }
+    void  init      (const Idx& idx){ occs.resize(toInt(idx)+1); dirty.growTo(toInt(idx)+1, 0); }
     Vec&  operator[](const Idx& idx){ return occs[toInt(idx)]; }
     Vec&  lookup    (const Idx& idx){ if (dirty[toInt(idx)]) clean(idx); return occs[toInt(idx)]; }
 
@@ -293,8 +293,8 @@ class OccLists
         }
     }
 
-    void  clear(bool free = true){
-        occs   .clear(free);
+    void  clear(bool free = true) {
+        occs   .clear();
         dirty  .clear(free);
         dirties.clear(free);
     }

--- a/src/minisat/mtl/Map.h
+++ b/src/minisat/mtl/Map.h
@@ -297,9 +297,11 @@ class VecMap {
         table = new std::vector<Pair>[newsize];
         cap   = newsize;
 
-        for (int i = 0; i < old_cap; i++){
-            for (int j = 0; j < old[i].size(); j++){
-                _insert(old[i][j].key, old[i][j].data); }}
+        for (int i = 0; i < old_cap; i++) {
+            for (const auto & pair : old[i]) {
+                _insert(pair.key, pair.data);
+            }
+        }
 
         delete [] old;
 
@@ -319,9 +321,9 @@ class VecMap {
         assert(size != 0);
         const vec<D>*    res = NULL;
         const std::vector<Pair>& ps  = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
-                res = &ps[i].data;
+        for (const Pair& p : ps)
+            if (equals(p.key, k))
+                res = &p.data;
         assert(res != NULL);
         return *res;
     }
@@ -332,9 +334,9 @@ class VecMap {
         assert(size != 0);
         vec<D>*    res = NULL;
         std::vector<Pair>& ps  = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
-                res = &ps[i].data;
+        for (Pair & p : ps)
+            if (equals(p.key, k))
+                res = &p.data;
         assert(res != NULL);
         return *res;
     }
@@ -354,8 +356,8 @@ class VecMap {
     bool has(const K& k) const {
         if (size == 0) return false;
         const std::vector<Pair>& ps = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
+        for (const Pair& p : ps)
+            if (equals(p.key, k))
                 return true;
         return false;
     }
@@ -363,17 +365,18 @@ class VecMap {
     const vec<D>* getOrNull(const K& k) const {
         if (size == 0) return nullptr;
         const std::vector<Pair>& ps = table[index(k)];
-        for (int i = 0; i < ps.size(); i++)
-            if (equals(ps[i].key, k))
-                return &ps[i].data;
+        for (const Pair & p : ps)
+            if (equals(p.key, k))
+                return &p.data;
         return nullptr;
     }
 
     void getKeys(vec<K>& out) const {
         if (size == 0) return;
-        for (int i = 0; i < cap; i++) {
-            for (int j = 0; j < table[i].size(); j++)
-                out.push(table[i][j].key);
+        for (auto i = 0; i < cap; i++) {
+            for (const auto & pair : table[i]) {
+                out.push(pair.key);
+            }
         }
     }
 

--- a/src/minisat/mtl/Map.h
+++ b/src/minisat/mtl/Map.h
@@ -263,8 +263,9 @@ class Map {
 
 template<class K, class D, class H, class E = Equal<K> >
 class VecMap {
- public:
-    struct Pair { static_assert(std::is_trivially_copyable<D>::value, "elements of mtl::VecMap vectors need to be trivially copyable"); K key; vec<D> data; };
+    static_assert(std::is_trivially_copyable<D>::value, "elements of mtl::VecMap vectors need to be trivially copyable");
+public:
+    struct Pair { K key; vec<D> data; };
 
  private:
     H          hash;

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -108,71 +108,6 @@ public:
 };
 
 template<class T>
-class vec<vec<T> > {
-    vec<T>*  data;
-    int sz;
-    int cap;
-
-    // Don't allow copying (error prone):
-    vec<vec<T> >&  operator = (vec<vec<T> >& other) = delete;
-                   vec        (vec<vec<T> >& other) = delete;
-
-
-    // Helpers for calculating next capacity:
-    static inline int  imax   (int x, int y) { int mask = (y-x) >> (sizeof(int)*8-1); return (x&mask) + (y&(~mask)); }
-    //static inline void nextCap(int& cap){ cap += ((cap >> 1) + 2) & ~1; }
-    static inline void nextCap(int& cap){ cap += ((cap >> 1) + 2) & ~1; }
-
-public:
-    // Constructors:
-    vec()                            : data(NULL) , sz(0)   , cap(0)    { }
-    explicit vec(int size)           : data(NULL) , sz(0)   , cap(0)    { growTo(size); }
-    vec(int size, const vec<T>& pad) : data(NULL) , sz(0)   , cap(0)    { growTo(size, pad); }
-    vec(const std::initializer_list<std::initializer_list<T> > &iList);
-    vec(vec<vec<T>>&& o)                : data(NULL) , sz(0)   , cap(0)    { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); }
-    vec<vec<T>>& operator = (vec<vec<T>>&& o) { std::swap(data, o.data); std::swap(sz, o.sz); std::swap(cap, o.cap); return *this; }
-    ~vec()                                                          { clear(true); }
-
-    // Pointer to first element:
-    operator vec<T>*  (void)           { return data; }
-
-    // Size operations:
-    int      size     (void) const     { return sz; }
-    uint32_t size_    (void) const     { assert(sz >= 0); return (uint32_t) sz; }
-    void     shrink   (int nelems)     { assert(nelems <= sz); for (int i = 0; i < nelems; i++) sz--, data[sz].~vec<T>(); }
-    void     shrink_  (int nelems)     { assert(nelems <= sz); sz -= nelems; }
-    int      capacity (void) const     { return cap; }
-    void     capacity (int min_cap);
-    void     growTo   (int size);
-    void     growTo   (int size, const vec<T>& pad);
-    void     clear    (bool dealloc = false);
-    void     reset    ();
-
-    // Stack interface:
-    void     push  (void)               { if (sz == cap) capacity(sz+1); new (&data[sz]) vec<T>(); sz++; }
-    void     push  (vec<T>&& elem)      { if (sz == cap) capacity(sz+1); new (&data[sz]) vec<T>(); data[sz++] = std::move(elem); }
-    void     push  (const vec<T>& elem) { if (sz == cap) capacity(sz+1); data[sz++] = elem; }
-
-    void     push_ (const T& elem)      { assert(sz < cap); data[sz++] = elem; }
-    void     pop   (void)               { assert(sz > 0); sz--, data[sz].~vec<T>(); }
-    // NOTE: it seems possible that overflow can happen in the 'sz+1' expression of 'push()', but
-    // in fact it can not since it requires that 'cap' is equal to INT_MAX. This in turn can not
-    // happen given the way capacities are calculated (below). Essentially, all capacities are
-    // even, but INT_MAX is odd.
-
-    const vec<T>& last  (void) const        { return data[sz-1]; }
-    vec<T>&       last  (void)              { return data[sz-1]; }
-
-    // Vector interface:
-    const vec<T>& operator [] (int index) const { return data[index]; }
-    vec<T>&       operator [] (int index)       { return data[index]; }
-
-    // Duplicatation (preferred instead):
-    void copyTo(vec<vec<T> >& copy) const { copy.clear(); copy.growTo(sz); for (int i = 0; i < sz; i++) data[i].copyTo(copy[i]); }
-    void moveTo(vec<vec<T> >& dest) { dest.clear(true); dest.data = data; dest.sz = sz; dest.cap = cap; data = NULL; sz = 0; cap = 0; }
-};
-
-template<class T>
 vec<T>::vec(const std::initializer_list<T> &iList) : data(NULL), sz(0), cap(0) {
     this->growTo(iList.size());
     int i = 0;
@@ -191,15 +126,6 @@ void vec<T>::capacity(int min_cap) {
  }
 
 template<class T>
-void vec<vec<T> >::capacity(int min_cap) {
-    if (cap >= min_cap) return;
-    int add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
-    if (add > INT_MAX - cap || (((data = (vec<T>*)::realloc(data, (cap += add) * sizeof(vec<T>))) == NULL) && errno == ENOMEM))
-        throw OutOfMemoryException();
-}
-
-
-template<class T>
 void vec<T>::growTo(int size, const T& pad) {
     if (sz >= size) return;
     capacity(size);
@@ -207,27 +133,11 @@ void vec<T>::growTo(int size, const T& pad) {
     sz = size; }
 
 template<class T>
-void vec<vec<T> >::growTo(int size, const vec<T>& pad) {
-    if (sz >= size) return;
-    capacity(size);
-    for (int i = sz; i < size; i++) data[i] = pad;
-    sz = size; }
-
-
-template<class T>
 void vec<T>::growTo(int size) {
     if (sz >= size) return;
     capacity(size);
     for (int i = sz; i < size; i++) new (&data[i]) T();
     sz = size; }
-
-template<class T>
-void vec<vec<T> >::growTo(int size) {
-    if (sz >= size) return;
-    capacity(size);
-    for (int i = sz; i < size; i++) new (&data[i]) vec<T>();
-    sz = size; }
-
 
 template<class T>
 void vec<T>::clear(bool dealloc) {
@@ -242,21 +152,6 @@ void vec<T>::reset() {
     sz = 0;
     cap = 0;
 }
-
-template<class T>
-void vec<vec<T> >::clear(bool dealloc) {
-    if (data != NULL){
-        for (int i = 0; i < sz; i++) data[i].~vec<T>();
-        sz = 0;
-        if (dealloc) free(data), data = NULL, cap = 0; } }
-
-template<class T>
-void vec<vec<T> >::reset() {
-    data = 0;
-    sz = 0;
-    cap = 0;
-}
-
 
 //=================================================================================================
 

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -22,12 +22,12 @@ void InterpolationContext::printProofDotty() {
 }
 
 // Create interpolants with each A consisting of the specified partitions
-void InterpolationContext::getInterpolants(const vec<vec<int> > & partitions, vec<PTRef> & interpolants) {
+void InterpolationContext::getInterpolants(const std::vector<vec<int> > & partitions, vec<PTRef> & interpolants) {
     assert(proof_graph);
     proof_graph->produceConfigMatrixInterpolants(partitions, interpolants);
 }
 
-void InterpolationContext::getInterpolants(const vec<ipartitions_t> & partitions, vec<PTRef> & interpolants) {
+void InterpolationContext::getInterpolants(const std::vector<ipartitions_t> & partitions, vec<PTRef> & interpolants) {
     assert(proof_graph);
     proof_graph->produceMultipleInterpolants(partitions, interpolants);
 }
@@ -51,7 +51,7 @@ void InterpolationContext::getSingleInterpolant(std::vector<PTRef> & interpolant
     for (int i = 0; i < itps.size(); i++) interpolants.push_back(itps[i]);
 }
 
-bool InterpolationContext::getPathInterpolants(vec<PTRef> & interpolants, const vec<ipartitions_t> & A_masks) {
+bool InterpolationContext::getPathInterpolants(vec<PTRef> & interpolants, const std::vector<ipartitions_t> & A_masks) {
     assert(proof_graph);
     return proof_graph->producePathInterpolants(interpolants, A_masks);
 }

--- a/src/proof/InterpolationContext.h
+++ b/src/proof/InterpolationContext.h
@@ -23,9 +23,9 @@ public:
     void printProofDotty();
 
     // Create interpolants with each A consisting of the specified partitions
-    void getInterpolants(const vec<vec<int> > & partitions, vec<PTRef> & interpolants);
+    void getInterpolants(const std::vector<vec<int> > & partitions, vec<PTRef> & interpolants);
 
-    void getInterpolants(const vec<ipartitions_t> & partitions, vec<PTRef> & interpolants);
+    void getInterpolants(const std::vector<ipartitions_t> & partitions, vec<PTRef> & interpolants);
 
     void setColoringSuggestions(vec<std::map<PTRef, icolor_t> *> * mp);
 
@@ -35,7 +35,7 @@ public:
 
     void getSingleInterpolant(std::vector<PTRef>& interpolants, const ipartitions_t& A_mask);
 
-    bool getPathInterpolants(vec<PTRef> & interpolants, const vec<ipartitions_t> & A_masks);
+    bool getPathInterpolants(vec<PTRef> & interpolants, const std::vector<ipartitions_t> & A_masks);
 
     bool getPathInterpolants(vec<PTRef> & interpolants);
 

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -297,7 +297,7 @@ public:
     bool verifyPartialInterpolantA(ProofNode*, const ipartitions_t&);
     bool verifyPartialInterpolantB(ProofNode*, const ipartitions_t&);
 
-    bool producePathInterpolants            ( vec<PTRef>& interpolants, const vec<ipartitions_t>& A_mask);
+    bool producePathInterpolants            ( vec<PTRef>& interpolants, const std::vector<ipartitions_t>& A_mask);
     bool producePathInterpolants            ( vec< PTRef > & );
     bool verifyPathInterpolantsFromLeaves   ( vec< PTRef > & );
     bool produceSimultaneousAbstraction     ( vec< PTRef > & );
@@ -306,11 +306,10 @@ public:
     bool verifyStateTransitionInterpolants  ( vec< PTRef > & );
     bool produceGenSimultaneousAbstraction  ( vec< PTRef > & );
     bool verifyGenSimultaneousAbstraction   ( vec< PTRef > & );
-    void produceConfigMatrixInterpolants    ( const vec<vec<int> > &,vec<PTRef> &);
+    void produceConfigMatrixInterpolants    ( const std::vector<vec<int> > &,vec<PTRef> &);
     bool produceTreeInterpolants            ( opensmt::InterpolationTree*, vec<PTRef> &);
     bool verifyTreeInterpolantsFromLeaves   ( opensmt::InterpolationTree*, vec<PTRef> &);
 
-    void produceMultipleInterpolants        ( const vec< ipartitions_t >&, vec<PTRef> &);
     void produceMultipleInterpolants        ( const std::vector< ipartitions_t >&, vec<PTRef> &);
     void produceSingleInterpolant           (vec<PTRef>& interpolants);
     void produceSingleInterpolant           (vec<PTRef>& interpolants, const ipartitions_t& A_mask);

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -315,7 +315,7 @@ void ProofGraph::buildProofGraph( int nVars )
                             { c2 = last_seen_id; c1 = id__i; }
                             // Look for pair <ant1,ant2>
                             std::pair<int, int> ant_pair (c1,c2);
-                            map< std::pair<int,int>, int >::iterator it = ants_map.find( ant_pair );
+                            auto it = ants_map.find( ant_pair );
                             bool found = ( it != ants_map.end() );
                             // If pairs not found, add id of the next node to the map
                             if( !found ) ants_map[ ant_pair ] = currId ;

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -314,8 +314,8 @@ void ProofGraph::buildProofGraph( int nVars )
                             else
                             { c2 = last_seen_id; c1 = id__i; }
                             // Look for pair <ant1,ant2>
-                            pair<int, int> ant_pair (c1,c2);
-                            map< pair<int,int>, int >::iterator it = ants_map.find( ant_pair );
+                            std::pair<int, int> ant_pair (c1,c2);
+                            map< std::pair<int,int>, int >::iterator it = ants_map.find( ant_pair );
                             bool found = ( it != ants_map.end() );
                             // If pairs not found, add id of the next node to the map
                             if( !found ) ants_map[ ant_pair ] = currId ;
@@ -363,8 +363,8 @@ void ProofGraph::buildProofGraph( int nVars )
                                 else
                                 { c2 = last_seen_id; c1 = id__i; }
                                 // Look for pair <ant1,ant2>
-                                pair<int, int> ant_pair (c1,c2);
-                                map< pair<int,int>, int >::iterator it = ants_map.find( ant_pair );
+                                std::pair<int, int> ant_pair (c1,c2);
+                                map< std::pair<int,int>, int >::iterator it = ants_map.find( ant_pair );
                                 bool found = ( it != ants_map.end() );
                                 // If pairs not found, add id of the next node to the map
                                 if( !found ) ants_map[ ant_pair ] = currId ;

--- a/src/proof/PGHelp.cc
+++ b/src/proof/PGHelp.cc
@@ -300,7 +300,7 @@ void ProofGraph::getComplexityInterpolant( PTRef int_e )
             if (logic_.isAtom(e_curr))
             {
                 // Complexity of atom is 0
-                complexity_map.insert( pair< PTRef, unsigned long >( e_curr, 0 ) );
+                complexity_map.insert( std::pair< PTRef, unsigned long >( e_curr, 0 ) );
 #ifdef PEDANTIC_DEBUG
                 cerr << "; Adding complexity of " << logic.printTerm(e_curr) << " = 0" << endl;
 #endif
@@ -358,7 +358,7 @@ void ProofGraph::getComplexityInterpolant( PTRef int_e )
                     // Formula tree representation
                     if( logic_.isAnd(e_curr) || logic_.isOr(e_curr) ) additional_compl = num_args - 1;
                     else if( logic_.isNot(e_curr) ) { assert(num_args==1); additional_compl = 1; }
-                    complexity_map.insert(pair<PTRef,unsigned long>(e_curr, comp_curr + additional_compl));
+                    complexity_map.insert(std::pair<PTRef,unsigned long>(e_curr, comp_curr + additional_compl));
 #ifdef PEDANTIC_DEBUG
                     cerr << "; Complexity of " << logic.printTerm(e_curr) << " = " << complexity_map.find(e_curr)->second << endl;
 #endif
@@ -411,7 +411,7 @@ unsigned long ProofGraph::getComplexityInterpolantIterative(PTRef int_e, bool fl
 		if( logic_.isAtom(curr_enode) )
 		{
 			// Complexity of atom is 0
-			complexity_map.insert( pair< PTRef, unsigned long >( curr_enode, 0 ) );
+			complexity_map.insert( std::pair< PTRef, unsigned long >( curr_enode, 0 ) );
 		}
 		// Case boolean connective: and, or not, iff, xor, implies
 		else if( logic_.isBooleanOperator(curr_enode) )
@@ -435,13 +435,13 @@ unsigned long ProofGraph::getComplexityInterpolantIterative(PTRef int_e, bool fl
 			if( flag )
 			{
 				// Complexity of connective is sum of complexities of arguments plus one
-				complexity_map.insert(pair<PTRef,unsigned long>(curr_enode,comp_curr + 1));
+				complexity_map.insert(std::pair<PTRef,unsigned long>(curr_enode,comp_curr + 1));
 			}
 			else
 			{
 				// Complexity of connective is sum of complexities of arguments plus number of arguments - 1
 				// E.g. ennary AND counts as eight binary AND
-				complexity_map.insert(pair<PTRef,unsigned long>(curr_enode,comp_curr + num_args -1));
+				complexity_map.insert(std::pair<PTRef,unsigned long>(curr_enode,comp_curr + num_args -1));
 			}
 		}
 	}
@@ -473,7 +473,7 @@ void ProofGraph::getPredicatesSetFromInterpolantIterative(PTRef int_e, set< PTRe
 		if( logic_.isAtom(curr_enode) )
 		{
 			pred_set_curr.insert(curr_enode);
-			predicate_map.insert(pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
+			predicate_map.insert(std::pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
 		}
 		// Case boolean connective: and, or not, iff, xor, implies
 		else if( logic_.isBooleanOperator(curr_enode) )
@@ -494,7 +494,7 @@ void ProofGraph::getPredicatesSetFromInterpolantIterative(PTRef int_e, set< PTRe
 				for(it = sub_pred_set.begin(); it!=sub_pred_set.end(); it++ )
 					pred_set_curr.insert((*it));
 			}
-			predicate_map.insert(pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
+			predicate_map.insert(std::pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
 		}
 	}
 	pred_set = predicate_map.find(int_e)->second;

--- a/src/proof/PGHelp.cc
+++ b/src/proof/PGHelp.cc
@@ -300,7 +300,7 @@ void ProofGraph::getComplexityInterpolant( PTRef int_e )
             if (logic_.isAtom(e_curr))
             {
                 // Complexity of atom is 0
-                complexity_map.insert( std::pair< PTRef, unsigned long >( e_curr, 0 ) );
+                complexity_map.insert( std::make_pair( e_curr, 0 ) );
 #ifdef PEDANTIC_DEBUG
                 cerr << "; Adding complexity of " << logic.printTerm(e_curr) << " = 0" << endl;
 #endif
@@ -358,7 +358,7 @@ void ProofGraph::getComplexityInterpolant( PTRef int_e )
                     // Formula tree representation
                     if( logic_.isAnd(e_curr) || logic_.isOr(e_curr) ) additional_compl = num_args - 1;
                     else if( logic_.isNot(e_curr) ) { assert(num_args==1); additional_compl = 1; }
-                    complexity_map.insert(std::pair<PTRef,unsigned long>(e_curr, comp_curr + additional_compl));
+                    complexity_map.insert(std::make_pair(e_curr, comp_curr + additional_compl));
 #ifdef PEDANTIC_DEBUG
                     cerr << "; Complexity of " << logic.printTerm(e_curr) << " = " << complexity_map.find(e_curr)->second << endl;
 #endif
@@ -411,7 +411,7 @@ unsigned long ProofGraph::getComplexityInterpolantIterative(PTRef int_e, bool fl
 		if( logic_.isAtom(curr_enode) )
 		{
 			// Complexity of atom is 0
-			complexity_map.insert( std::pair< PTRef, unsigned long >( curr_enode, 0 ) );
+			complexity_map.insert( std::make_pair( curr_enode, 0 ) );
 		}
 		// Case boolean connective: and, or not, iff, xor, implies
 		else if( logic_.isBooleanOperator(curr_enode) )
@@ -435,13 +435,13 @@ unsigned long ProofGraph::getComplexityInterpolantIterative(PTRef int_e, bool fl
 			if( flag )
 			{
 				// Complexity of connective is sum of complexities of arguments plus one
-				complexity_map.insert(std::pair<PTRef,unsigned long>(curr_enode,comp_curr + 1));
+				complexity_map.insert(std::make_pair(curr_enode,comp_curr + 1));
 			}
 			else
 			{
 				// Complexity of connective is sum of complexities of arguments plus number of arguments - 1
 				// E.g. ennary AND counts as eight binary AND
-				complexity_map.insert(std::pair<PTRef,unsigned long>(curr_enode,comp_curr + num_args -1));
+				complexity_map.insert(std::make_pair(curr_enode,comp_curr + num_args -1));
 			}
 		}
 	}
@@ -473,7 +473,7 @@ void ProofGraph::getPredicatesSetFromInterpolantIterative(PTRef int_e, set< PTRe
 		if( logic_.isAtom(curr_enode) )
 		{
 			pred_set_curr.insert(curr_enode);
-			predicate_map.insert(std::pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
+			predicate_map.insert(std::make_pair(curr_enode,pred_set_curr));
 		}
 		// Case boolean connective: and, or not, iff, xor, implies
 		else if( logic_.isBooleanOperator(curr_enode) )
@@ -494,7 +494,7 @@ void ProofGraph::getPredicatesSetFromInterpolantIterative(PTRef int_e, set< PTRe
 				for(it = sub_pred_set.begin(); it!=sub_pred_set.end(); it++ )
 					pred_set_curr.insert((*it));
 			}
-			predicate_map.insert(std::pair< PTRef,set<PTRef> >(curr_enode,pred_set_curr));
+			predicate_map.insert(std::make_pair(curr_enode,pred_set_curr));
 		}
 	}
 	pred_set = predicate_map.find(int_e)->second;

--- a/src/proof/PGInterAux.cc
+++ b/src/proof/PGInterAux.cc
@@ -306,12 +306,12 @@ ProofGraph::computePSFunction(vector< clauseid_t >& DFSv, const ipartitions_t& A
 			if(fa)
 			{
 				if(qtta > qttb) ++avars; else ++aevars;
-				labels->insert(pair<Var, icolor_t>(v, I_A));
+				labels->insert(std::pair<Var, icolor_t>(v, I_A));
 			}
 			else
 			{
 				if(qttb > qtta) ++bvars; else ++bevars;
-				labels->insert(pair<Var, icolor_t>(v, I_B));
+				labels->insert(std::pair<Var, icolor_t>(v, I_B));
 			}
 		}
 		//cout << avars << " A> " << aevars << " A=\n" << bvars << " B> " << bevars << " B=" << endl;

--- a/src/proof/PGInterpolator.cc
+++ b/src/proof/PGInterpolator.cc
@@ -212,7 +212,7 @@ bool ProofGraph::produceStateTransitionInterpolants ( vec< PTRef > &interpolants
     return property_holds;
 }
 
-void ProofGraph::produceConfigMatrixInterpolants (const vec< vec<int> > &configs, vec<PTRef> &interpolants)
+void ProofGraph::produceConfigMatrixInterpolants (const std::vector< vec<int> > &configs, vec<PTRef> &interpolants)
 {
     if ( verbose() ) cerr << "; General interpolation via configuration matrix " << endl;
 
@@ -320,15 +320,15 @@ bool ProofGraph::produceTreeInterpolants (opensmt::InterpolationTree *it, vec<PT
     return property_holds;
 }
 
-bool ProofGraph::producePathInterpolants ( vec<PTRef> &interpolants, const vec<ipartitions_t> &A_masks){
+bool ProofGraph::producePathInterpolants ( vec<PTRef> &interpolants, const std::vector<ipartitions_t> &A_masks){
     bool propertySatisfied = true;
     // check that masks are subset of each other
 #ifndef NDEBUG
-    for(int i = 0; i < A_masks.size()-1; ++i) {
+    for (int i = 0; i < static_cast<int>(A_masks.size()-1); ++i) {
         assert((A_masks[i] & A_masks[i+1]) == A_masks[i]);
     }
 #endif // NDEBUG
-    for(int i = 0; i < A_masks.size(); ++i) {
+    for (int i = 0; i < static_cast<int>(A_masks.size()); ++i) {
         produceSingleInterpolant(interpolants, A_masks[i]);
 //        if(verbose() > 1){
 //            std::cerr << "; Interpolant for mask: " << A_masks[i] << " is: "
@@ -648,15 +648,6 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
     {
         cout << "; Interpolant:\n" << this->logic_.printTerm(interpol) << endl;
     }
-}
-
-void ProofGraph::produceMultipleInterpolants ( const vec< ipartitions_t > &configs, vec<PTRef> &sequence_of_interpolants ) {
-    std::vector<ipartitions_t> v;
-    v.reserve(configs.size());
-    for (int i = 0; i < configs.size(); ++i) {
-        v.push_back(configs[i]);
-    }
-    produceMultipleInterpolants(v, sequence_of_interpolants);
 }
 
 void ProofGraph::produceMultipleInterpolants ( const std::vector< ipartitions_t > &configs, vec<PTRef> &sequence_of_interpolants )

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -899,8 +899,8 @@ void ProofGraph::proofPostStructuralHashing()
 	clauseid_t id;
 	ProofNode* n=NULL;
 	// Map to associate node to its antecedents
-	map< pair<clauseid_t,clauseid_t>, clauseid_t >* ants_map_ = new map< pair<clauseid_t,clauseid_t>, clauseid_t >;
-	map< pair<clauseid_t,clauseid_t>, clauseid_t >& ants_map = *ants_map_;
+	map< std::pair<clauseid_t,clauseid_t>, clauseid_t >* ants_map_ = new map< std::pair<clauseid_t,clauseid_t>, clauseid_t >;
+	map< std::pair<clauseid_t,clauseid_t>, clauseid_t >& ants_map = *ants_map_;
 
 	// NOTE Topological visit and node replacement on the fly
 	// Guarantees that both replacing and replaced node subproofs have been visited
@@ -933,8 +933,8 @@ void ProofGraph::proofPostStructuralHashing()
 					else
 					{ c2 = n->getAnt1()->getId(); c1 = n->getAnt2()->getId(); }
 					// Look for pair <ant1,ant2>
-					pair<clauseid_t, clauseid_t> ant_pair (c1,c2);
-					map< pair<clauseid_t,clauseid_t>, clauseid_t >::iterator it = ants_map.find( ant_pair );
+					std::pair<clauseid_t, clauseid_t> ant_pair (c1,c2);
+					map< std::pair<clauseid_t,clauseid_t>, clauseid_t >::iterator it = ants_map.find( ant_pair );
 					found = ( it != ants_map.end() );
 					// If pairs not found, add node to the map
 					if( !found ) ants_map[ ant_pair ] = id ;

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -137,20 +137,17 @@ void   PtStore::free(PTRef r) { pta.free(r); }  // this is guaranteed to be lazy
 Pterm& PtStore::operator[] (PTRef tr) { return pta[tr]; }
 const Pterm& PtStore::operator[] (PTRef tr) const { return pta[tr]; }
 
-bool PtStore::hasCtermKey(SymRef& k) { return cterm_map.has(k); }
-void PtStore::addToCtermMap(SymRef& k, PTRef tr) {
-    cterm_map.insert(k, tr);
-//        cterm_keys.push(k);
-}
-PTRef PtStore::getFromCtermMap(SymRef& k) { return cterm_map[k]; }
+bool  PtStore::hasCtermKey    (SymRef& k)             { return cterm_map.has(k); }
+void  PtStore::addToCtermMap  (SymRef& k, PTRef tr)   { cterm_map.insert(k, tr); }
+PTRef PtStore::getFromCtermMap(SymRef& k)             { return cterm_map[k]; }
 
-bool PtStore::hasBoolKey(const PTLKey& k) { return bool_map.find(k) != bool_map.end(); }
-void PtStore::addToBoolMap(PTLKey &&k, PTRef tr) { bool_map[std::move(k)] = tr; }
-PTRef PtStore::getFromBoolMap(const PTLKey& k) { return bool_map.at(k); }
+bool  PtStore::hasBoolKey     (const PTLKey& k)       { return bool_map.find(k) != bool_map.end(); }
+void  PtStore::addToBoolMap   (PTLKey &&k, PTRef tr)  { bool_map[std::move(k)] = tr; }
+PTRef PtStore::getFromBoolMap (const PTLKey& k)       { return bool_map.at(k); }
 
-bool PtStore::hasCplxKey(const PTLKey& k) { return cplx_map.find(k) != cplx_map.end(); }
-void PtStore::addToCplxMap(PTLKey && k, PTRef tr) { cplx_map[std::move(k)] = tr; }
-PTRef PtStore::getFromCplxMap(const PTLKey& k) { return cplx_map.at(k); }
+bool  PtStore::hasCplxKey     (const PTLKey& k)       { return cplx_map.find(k) != cplx_map.end(); }
+void  PtStore::addToCplxMap   (PTLKey && k, PTRef tr) { cplx_map[std::move(k)] = tr; }
+PTRef PtStore::getFromCplxMap (const PTLKey& k)       { return cplx_map.at(k); }
 
 PtermIter PtStore::getPtermIter() { return PtermIter(idToPTRef); }
 

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -144,19 +144,13 @@ void PtStore::addToCtermMap(SymRef& k, PTRef tr) {
 }
 PTRef PtStore::getFromCtermMap(SymRef& k) { return cterm_map[k]; }
 
-bool PtStore::hasBoolKey(PTLKey& k) { return bool_map.has(k); }
-void PtStore::addToBoolMap(PTLKey& k, PTRef tr) {
-    bool_map.insert(k, tr);
-//        bool_keys.push(k);
-}
-PTRef PtStore::getFromBoolMap(PTLKey& k) { return bool_map[k]; }
+bool PtStore::hasBoolKey(const PTLKey& k) { return bool_map.find(k) != bool_map.end(); }
+void PtStore::addToBoolMap(PTLKey &&k, PTRef tr) { bool_map[std::move(k)] = tr; }
+PTRef PtStore::getFromBoolMap(const PTLKey& k) { return bool_map.at(k); }
 
-bool PtStore::hasCplxKey(PTLKey& k) { return cplx_map.has(k); }
-void PtStore::addToCplxMap(PTLKey& k, PTRef tr) {
-    cplx_map.insert(k, tr);
-//        cplx_keys.push(k);
-}
-PTRef PtStore::getFromCplxMap(PTLKey& k) { return cplx_map[k]; }
+bool PtStore::hasCplxKey(const PTLKey& k) { return cplx_map.find(k) != cplx_map.end(); }
+void PtStore::addToCplxMap(PTLKey && k, PTRef tr) { cplx_map[std::move(k)] = tr; }
+PTRef PtStore::getFromCplxMap(const PTLKey& k) { return cplx_map.at(k); }
 
 PtermIter PtStore::getPtermIter() { return PtermIter(idToPTRef); }
 

--- a/src/pterms/PtStore.h
+++ b/src/pterms/PtStore.h
@@ -29,6 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "Pterm.h"
 #include "SymStore.h"
+#include <unordered_map>
 
 class SStore; // forward declaration
 
@@ -55,10 +56,10 @@ class PtStore {
     Map<SymRef,PTRef,SymRefHash,Equal<SymRef> > cterm_map; // Mapping constant symbols to terms
 //    vec<SymRef> cterm_keys;
 
-    Map<PTLKey,PTRef,PTLHash,Equal<PTLKey> >    cplx_map;  // Mapping complex terms to canonical terms
+    std::unordered_map<PTLKey,PTRef,PTLHash,Equal<PTLKey> >    cplx_map;  // Mapping complex terms to canonical terms
 //    vec<PTLKey> cplx_keys;
 
-    Map<PTLKey,PTRef,PTLHash,Equal<PTLKey> >    bool_map;  // Mapping boolean terms to canonical terms
+    std::unordered_map<PTLKey,PTRef,PTLHash,Equal<PTLKey> >    bool_map;  // Mapping boolean terms to canonical terms
 //    vec<PTLKey> bool_keys;
 //    friend class Logic;
     static const int ptstore_buf_idx;
@@ -86,19 +87,13 @@ class PtStore {
     }*/
     PTRef getFromCtermMap(SymRef& k);// { return cterm_map[k]; }
 
-    bool hasBoolKey(PTLKey& k);// { return bool_map.has(k); }
-    void addToBoolMap(PTLKey& k, PTRef tr);/* {
-        bool_map.insert(k, tr);
-//        bool_keys.push(k);
-    }*/
-    PTRef getFromBoolMap(PTLKey& k);// { return bool_map[k]; }
+    bool hasBoolKey(const PTLKey& k);
+    void addToBoolMap(PTLKey && k, PTRef tr);
+    PTRef getFromBoolMap(const PTLKey& k);
 
-    bool hasCplxKey(PTLKey& k);// { return cplx_map.has(k); }
-    void addToCplxMap(PTLKey& k, PTRef tr);/* {
-        cplx_map.insert(k, tr);
-//        cplx_keys.push(k);
-    }*/
-    PTRef getFromCplxMap(PTLKey& k);// { return cplx_map[k]; }
+    bool hasCplxKey(const PTLKey& k);
+    void addToCplxMap(PTLKey && k, PTRef tr);
+    PTRef getFromCplxMap(const PTLKey& k);
 
     PtermIter getPtermIter();// { return PtermIter(idToPTRef); }
 

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -47,10 +47,6 @@ struct PTLKey {
             if (k1.args[i] != k2.args[i]) break;
         return i == k1.args.size();
     }
-    void operator= (const PTLKey& k) {
-        sym = k.sym;
-        k.args.copyTo(args);
-    }
 };
 
 struct PTLHash {

--- a/src/simplifiers/LA.cc
+++ b/src/simplifiers/LA.cc
@@ -34,90 +34,88 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 void LAExpression::initialize( PTRef e, bool do_canonize )
 {
-  assert( logic.isNumEq(e) || logic.isNumLeq(e) );
-  integers = false;
+    assert( logic.isNumEq(e) || logic.isNumLeq(e) );
+    integers = false;
 
-  vector< PTRef > curr_term;
-  vector< opensmt::Real >    curr_const;
+    vector< PTRef > curr_term;
+    vector< opensmt::Real >    curr_const;
 
-  PTRef lhs = logic.getPterm(e)[0];
-  PTRef rhs = logic.getPterm(e)[1];
-  curr_term .push_back( lhs );
-  curr_const.push_back( 1 );
-  curr_term .push_back( rhs );
-  curr_const.push_back( -1 );
+    PTRef lhs = logic.getPterm(e)[0];
+    PTRef rhs = logic.getPterm(e)[1];
+    curr_term .push_back( lhs );
+    curr_const.push_back( 1 );
+    curr_term .push_back( rhs );
+    curr_const.push_back( -1 );
 
-  while ( !curr_term.empty( ) )
-  {
-    PTRef t = curr_term.back( );
-    curr_term.pop_back( );
-    opensmt::Real c = curr_const.back( );
-    curr_const.pop_back( );
-    //
-    // Only 3 cases are allowed
-    //
-    // If it is plus, enqueue the arguments with same constant
-    //
-    if ( logic.isNumPlus(t) ) {
-      const Pterm& term = logic.getPterm(t);
-      for (int i = 0; i < term.size(); i++) {
-        PTRef arg = term[i];
-        curr_term .push_back( arg );
-        curr_const.push_back( c );
-      }
-    }
-    //
-    // If it is times, then one side must be constant, other
-    // is enqueued with a new constant
-    //
-    else if ( logic.isNumTimes(t) ) {
-        const Pterm& term = logic.getPterm(t);
-        assert( term.size() == 2 );
-        PTRef x = term[0];
-        PTRef y = term[1];
-        assert(logic.isConstant(x) || logic.isConstant(y));
-        if (logic.isConstant(y)) {
-            PTRef tmp = y;
-            y = x;
-            x = tmp;
+    while ( !curr_term.empty( ) ) {
+        PTRef t = curr_term.back( );
+        curr_term.pop_back( );
+        opensmt::Real c = curr_const.back( );
+        curr_const.pop_back( );
+        //
+        // Only 3 cases are allowed
+        //
+        // If it is plus, enqueue the arguments with same constant
+        //
+        if ( logic.isNumPlus(t) ) {
+            const Pterm& term = logic.getPterm(t);
+            for (int i = 0; i < term.size(); i++) {
+                PTRef arg = term[i];
+                curr_term .push_back( arg );
+                curr_const.push_back( c );
+            }
+        } else if ( logic.isNumTimes(t) ) {
+            //
+            // If it is times, then one side must be constant, other
+            // is enqueued with a new constant
+            //
+
+            const Pterm& term = logic.getPterm(t);
+            assert( term.size() == 2 );
+            PTRef x = term[0];
+            PTRef y = term[1];
+            assert(logic.isConstant(x) || logic.isConstant(y));
+            if (logic.isConstant(y)) {
+                PTRef tmp = y;
+                y = x;
+                x = tmp;
+            }
+
+            opensmt::Real new_c = logic.getNumConst(x);
+            new_c = new_c * c;
+            curr_term .push_back( y );
+            curr_const.push_back( std::move(new_c) );
+        } else {
+            //
+            // Otherwise it is a variable, Ite, UF or constant
+            //
+
+            assert(logic.isNumVarOrIte(t) || logic.isConstant(t) || logic.isUF(t));
+            if ( logic.isConstant(t) ) {
+                const opensmt::Real tval = logic.getNumConst(t);
+                polynome[ PTRef_Undef ] += tval * c;
+            } else {
+                if (logic.hasSortNum(t))
+                    integers = true;
+
+                polynome_t::iterator it = polynome.find( t );
+                if ( it != polynome.end( ) ) {
+                    it->second += c;
+                    if ( it->first != PTRef_Undef && it->second == 0 )
+                        polynome.erase( it );
+                } else
+                    polynome[ t ] = c;
+            }
         }
-
-        opensmt::Real new_c = logic.getNumConst(x);
-        new_c = new_c * c;
-        curr_term .push_back( y );
-        curr_const.push_back( std::move(new_c) );
     }
-    //
-    // Otherwise it is a variable, Ite, UF or constant
-    //
-    else
-    {
-      assert(logic.isNumVarOrIte(t) || logic.isConstant(t) || logic.isUF(t));
-      if ( logic.isConstant(t) ) {
-        const opensmt::Real tval = logic.getNumConst(t);
-        polynome[ PTRef_Undef ] += tval * c;
-      } else {
-        if (logic.hasSortNum(t))
-          integers = true;
 
-        polynome_t::iterator it = polynome.find( t );
-        if ( it != polynome.end( ) ) {
-          it->second += c;
-          if ( it->first != PTRef_Undef && it->second == 0 )
-            polynome.erase( it );
-        } else
-          polynome[ t ] = c;
-      }
-    }
-  }
-
-  if ( polynome.find( PTRef_Undef ) == polynome.end( ) )
-    polynome[ PTRef_Undef ] = 0;
-  //
-  // Canonize
-  //
-    if(do_canonize){
-        canonize( );
+    if ( polynome.find( PTRef_Undef ) == polynome.end( ) )
+        polynome[ PTRef_Undef ] = 0;
+    //
+    // Canonize
+    //
+    if (do_canonize) {
+        canonize();
     }
 }
 
@@ -129,239 +127,179 @@ void LAExpression::initialize( PTRef e, bool do_canonize )
 opensmt::Real
 LAExpression::getRealConstant()
 {
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  assert( polynome.size( ) > 0 );
-  //
-  // There is at least one variable
-  //
-  for ( polynome_t::iterator it = polynome.begin( )
-      ; it != polynome.end( )
-      ; it ++ )
-  {
-    if ( it->first == PTRef_Undef )
-      return it->second;
-  }
-  throw std::logic_error("No constant in a polynomial");
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+    assert( polynome.size( ) > 0 );
+    //
+    // There is at least one variable
+    //
+    for ( polynome_t::iterator it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+        if ( it->first == PTRef_Undef )
+            return it->second;
+    }
+    throw std::logic_error("No constant in a polynomial");
 }
 
 PTRef LAExpression::getPTRefNonConstant()
 {
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  assert( polynome.size( ) > 0 );
-  //
-  // There is at least one variable
-  //
-  vec<PTRef> sum_list;
-  opensmt::Real constant = 0;
-  for ( polynome_t::iterator it = polynome.begin( )
-      ; it != polynome.end( )
-      ; it ++ )
-  {
-    if ( it->first == PTRef_Undef )
-      constant = it->second;
-    else
-    {
-      char* msg;
-      PTRef coeff = logic.mkConst(it->second);
-      PTRef vv = it->first;
-      vec<PTRef> term;
-      term.push(coeff);
-      term.push(vv);
-      sum_list.push( logic.mkNumTimes(term, &msg) );
-    }
-  }
-  if ( sum_list.size() == 0)
-  {
-    sum_list.push(logic.getTerm_NumZero());
-  }
-  PTRef poly = logic.mkNumPlus(sum_list);
-  return poly;
-}
-
-PTRef LAExpression::toPTRef() const
-{
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  assert( polynome.size( ) > 0 );
-  //
-  // There is at least one variable
-  //
-  vec<PTRef> sum_list;
-  opensmt::Real constant = 0;
-  for ( auto it = polynome.begin( )
-      ; it != polynome.end( )
-      ; it ++ )
-  {
-    if ( it->first == PTRef_Undef )
-      constant = it->second;
-    else
-    {
-      char* msg;
-      PTRef coeff = logic.mkConst(it->second);
-      PTRef vv = it->first;
-      vec<PTRef> term;
-      term.push(coeff);
-      term.push(vv);
-      sum_list.push( logic.mkNumTimes(term, &msg) );
-    }
-  }
-  if ( sum_list.size() == 0)
-  {
-    sum_list.push(logic.getTerm_NumZero());
-  }
-  //
-  // Return in the form ax + by + ... = -c
-  //
-  if ( r == EQ || r == LEQ )
-  {
-    PTRef poly = logic.mkNumPlus(sum_list);
-    constant = -constant;
-    PTRef c = logic.mkConst(constant);
-    if ( r == EQ ) {
-        vec<PTRef> args;
-        args.push(poly);
-        args.push(c);
-        return logic.mkEq(args);
-    }
-    else {
-       return logic.mkNumLeq(poly, c);
-    }
-  }
-  //
-  // Return in the form ax + by + ... + c
-  //
-  assert( r == UNDEF );
-  sum_list.push(logic.mkConst(constant));
-  PTRef poly = logic.mkNumPlus(sum_list);
-
-  return poly;
-}
-//
-// Print
-//
-void LAExpression::print( ostream & os ) const
-{
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  assert( polynome.size( ) > 0 );
-  if ( r == EQ )
-    os << "(=";
-  else if ( r == LEQ )
-    os << "(<=";
-  opensmt::Real constant = 0;
-  if ( polynome.size( ) == 1 )
-    os << " " << polynome.at(PTRef_Undef);
-  else
-  {
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+    assert( polynome.size( ) > 0 );
     //
     // There is at least one variable
     //
-    os << " (+";
-    for ( auto it = polynome.begin( )
-	; it != polynome.end( )
-	; it ++ )
-    {
-      if ( it->first == PTRef_Undef )
-	constant = -it->second;
-      else
-	os << " (* " << it->second << " " << logic.printTerm(it->first) << ")";
+    vec<PTRef> sum_list;
+    opensmt::Real constant = 0;
+    for ( polynome_t::iterator it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+        if ( it->first == PTRef_Undef )
+            constant = it->second;
+        else {
+            char* msg;
+            PTRef coeff = logic.mkConst(it->second);
+            PTRef vv = it->first;
+            vec<PTRef> term;
+            term.push(coeff);
+            term.push(vv);
+            sum_list.push( logic.mkNumTimes(term, &msg) );
+        }
     }
-    os << ")";
-  }
-  if ( r == EQ || r == LEQ )
-    os << " " << constant << ")";
-  os << '\n';
+    if ( sum_list.size() == 0) {
+        sum_list.push(logic.getTerm_NumZero());
+    }
+    PTRef poly = logic.mkNumPlus(sum_list);
+    return poly;
 }
+
+PTRef LAExpression::toPTRef() const {
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+    assert( polynome.size( ) > 0 );
+    //
+    // There is at least one variable
+    //
+    vec<PTRef> sum_list;
+    opensmt::Real constant = 0;
+    for ( auto it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+        if ( it->first == PTRef_Undef )
+            constant = it->second;
+        else {
+            char* msg;
+            PTRef coeff = logic.mkConst(it->second);
+            PTRef vv = it->first;
+            vec<PTRef> term;
+            term.push(coeff);
+            term.push(vv);
+            sum_list.push( logic.mkNumTimes(term, &msg) );
+        }
+    }
+    if ( sum_list.size() == 0) {
+        sum_list.push(logic.getTerm_NumZero());
+    }
+    //
+    // Return in the form ax + by + ... = -c
+    //
+    if ( r == EQ || r == LEQ ) {
+        PTRef poly = logic.mkNumPlus(sum_list);
+        constant = -constant;
+        PTRef c = logic.mkConst(constant);
+        if ( r == EQ ) {
+            vec<PTRef> args;
+            args.push(poly);
+            args.push(c);
+            return logic.mkEq(args);
+        } else {
+            return logic.mkNumLeq(poly, c);
+        }
+    }
+    //
+    // Return in the form ax + by + ... + c
+    //
+    assert( r == UNDEF );
+    sum_list.push(logic.mkConst(constant));
+    PTRef poly = logic.mkNumPlus(sum_list);
+
+    return poly;
+}
+
+//
+// Print
+//
+void LAExpression::print( ostream & os ) const {
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+    assert( polynome.size( ) > 0 );
+    if ( r == EQ )
+        os << "(=";
+    else if ( r == LEQ )
+        os << "(<=";
+    opensmt::Real constant = 0;
+    if ( polynome.size( ) == 1 )
+        os << " " << polynome.at(PTRef_Undef);
+    else {
+        //
+        // There is at least one variable
+        //
+        os << " (+";
+        for ( auto it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+            if ( it->first == PTRef_Undef )
+	            constant = -it->second;
+            else
+	            os << " (* " << it->second << " " << logic.printTerm(it->first) << ")";
+        }
+        os << ")";
+    }
+    if ( r == EQ || r == LEQ )
+        os << " " << constant << ")";
+    os << '\n';
+}
+
 //
 // Produce a substitution
 //
-//pair< Enode *, Enode * > LAExpression::getSubst( Egraph & egraph )
-pair<PTRef, PTRef> LAExpression::getSubst()
-{
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  assert( r != UNDEF );
-
-  //if ( integers )
-   // return getSubstInt();
- // else
-  return getSubstReal();
+pair<PTRef, PTRef> LAExpression::getSubst() {
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+    assert( r != UNDEF );
+    return getSubstReal();
 }
 
-/*
-//pair< Enode *, Enode * > LAExpression::getSubstInt( Egraph & egraph )
-pair<PTRef, PTRef> LAExpression::getSubstInt()
-{
-  // See if cheap substitution, not requiring our friend
-  // Euler, can be done
-  bool all_ones = true;
-  for ( polynome_t::iterator it = polynome.begin( )
-      ; it != polynome.end( ) && all_ones
-      ; it ++ )
-  {
-     all_ones = it->first  == PTRef_Undef
-             || it->second == 1
-             || it->second == -1;
-  }
 
-  if ( all_ones )
-    return getSubstReal();
-
-  opensmt_error( "IMPLEMENT EULER" );
-//  Enode * v1, * v2;
-  PTRef v1, v2;
-  return make_pair( v1, v2 );
-}*/
-
-//pair< Enode *, Enode * > LAExpression::getSubstReal( Egraph & egraph )
 pair<PTRef, PTRef> LAExpression::getSubstReal()
 {
-  if ( polynome.size( ) == 1 )
-  {
-    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-    PTRef v1 = PTRef_Undef, v2 = PTRef_Undef;
-    return make_pair( v1, v2 );
-  }
-  //
-  // There is at least one variable
-  //
-  //
-  // Solve w.r.t. first variable
-  //
-  solve( );
-//  list< Enode * > sum_list;
-  vec<PTRef> sum_list;
-  opensmt::Real constant = 0;
-  PTRef var = PTRef_Undef;
-  for ( polynome_t::iterator it = polynome.begin( )
-      ; it != polynome.end( )
-      ; it ++ )
-  {
-    if ( it->first == PTRef_Undef )
-      constant = -it->second;
-    else
-    {
-      if (var == PTRef_Undef)
-      {
-        var = it->first;
-        assert( it->second == 1 );
-      }
-      else
-      {
-          opensmt::Real coeff = -it->second;
-          PTRef c = logic.mkConst(coeff);
-//          Enode * c = egraph.mkNum( coeff );
-          PTRef vv = it->first;
-//          Enode * vv = it->first;
-          vec<PTRef> term;
-          term.push(c);
-          term.push(vv);
-          sum_list.push(logic.mkNumTimes(term));
-      }
+    if ( polynome.size( ) == 1 ) {
+        assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+        PTRef v1 = PTRef_Undef, v2 = PTRef_Undef;
+        return make_pair( v1, v2 );
     }
-  }
-  sum_list.push(logic.mkConst(constant ));
-  PTRef poly = logic.mkNumPlus(sum_list);
+    //
+    // There is at least one variable
+    //
+    //
+    // Solve w.r.t. first variable
+    //
+    solve( );
+    vec<PTRef> sum_list;
+    opensmt::Real constant = 0;
+    PTRef var = PTRef_Undef;
+    for ( polynome_t::iterator it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+        if ( it->first == PTRef_Undef )
+            constant = -it->second;
+        else {
+            if (var == PTRef_Undef) {
+                var = it->first;
+                assert( it->second == 1 );
+            } else {
+                opensmt::Real coeff = -it->second;
+                PTRef c = logic.mkConst(coeff);
+                PTRef vv = it->first;
+                vec<PTRef> term;
+                term.push(c);
+                term.push(vv);
+                sum_list.push(logic.mkNumTimes(term));
+            }
+        }
+    }
+    sum_list.push(logic.mkConst(constant ));
+    PTRef poly = logic.mkNumPlus(sum_list);
 
-  return make_pair( var, poly );
+    return make_pair( var, poly );
 }
+
 //
 // Solve w.r.t. first variable
 // ex.
@@ -372,38 +310,32 @@ pair<PTRef, PTRef> LAExpression::getSubstReal()
 //
 // it modifies the polynome internally
 //
-//Enode * LAExpression::solve( )
 PTRef LAExpression::solve()
 {
-  assert(  r == EQ );
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-  if ( polynome.size( ) == 1 )
-  {
+    assert(  r == EQ );
     assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-    return PTRef_Undef;
-  }
-  //
-  // Get first useful variable
-  //
-  polynome_t::iterator it = polynome.begin( );
-  if ( it->first == PTRef_Undef ) it ++;
-//  Enode * var = it->first;
-  PTRef var = it->first;
-  const opensmt::Real coeff = it->second;
-  //
-  // Divide polynome by coeff
-  //
-  for ( it = polynome.begin( )
-      ; it != polynome.end( )
-      ; it ++ )
-  {
-    it->second /= coeff;
-  }
-  assert( polynome[ var ] == 1 );
-  //
-  // Return substitution
-  //
-  return var;
+    if ( polynome.size( ) == 1 ) {
+        assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+        return PTRef_Undef;
+    }
+    //
+    // Get first useful variable
+    //
+    polynome_t::iterator it = polynome.begin( );
+    if ( it->first == PTRef_Undef ) it ++;
+    PTRef var = it->first;
+    const opensmt::Real coeff = it->second;
+    //
+    // Divide polynome by coeff
+    //
+    for ( it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) {
+        it->second /= coeff;
+    }
+    assert( polynome[ var ] == 1 );
+    //
+    // Return substitution
+    //
+    return var;
 }
 //
 // Canonize w.r.t. first variable
@@ -415,151 +347,45 @@ PTRef LAExpression::solve()
 //
 // it modifies the polynome internally
 //
-void
-LAExpression::canonize( )
-{
-  assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-
-//  if ( integers )
-//    canonizeInt( );
-//  else
+void LAExpression::canonize( ) {
+    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
     canonizeReal( );
 }
-
-/*
-//
-// We assume (and check) that denominators
-// of coefficients are 1
-//
-void
-LAExpression::canonizeInt( )
-{
-  assert( checkIntCoefficients( ) );
-
-  if ( polynome.size( ) == 1 )
-  {
-    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-    return;
-  }
-
-  // Iterate through the polynome and
-  // collect the GCD
-  polynome_t::iterator it = polynome.begin( );
-  opensmt::Integer igcd = 0;
-  for ( ; it != polynome.end( ) ; ++ it )
-  {
-    // Skip constant (if there)
-    if ( it->first == PTRef_Undef ) continue;
-    opensmt::Integer coeff = (it->second).get_num( );
-    if ( igcd == 0 )
-    {
-      igcd = coeff;
-      continue;
-    }
-    assert(false);
-//      Meh.. Figure this out later...
-//    mpz_t int_out;
-//    mpz_gcd( int_out, igcd, coeff );
-//    igcd = int_out;
-  }
-
-  // Nothing to do
-  if ( igcd == 1 )
-    return;
-  const opensmt::Real abs_igcd = ( igcd > 0 ? igcd : opensmt::Integer(-igcd) );
-  const opensmt::Real rgcd = opensmt::Real( abs_igcd ); 
-
-  // Divide each term by gcd
-  for ( it = polynome.begin( ) 
-      ; it != polynome.end( ) 
-      ; ++ it )
-  {
-    it->second /= rgcd;
-  }
-  // Nothing to do
-  if ( polynome.find( PTRef_Undef ) == polynome.end( ) )
-    return;
-  // Check if equality is unsat
-  if ( (polynome[ PTRef_Undef ]).get_den( ) != 1 )
-  {
-    // Write a false polynome
-    if ( r == EQ )
-    {
-      polynome.clear( );
-      polynome[ PTRef_Undef ] = 1;
-    }
-    // Tighten
-    if ( r == LEQ ) {
-        // Try to find out what's wrong...
-        assert(false);
-//      polynome[ PTRef_Undef ] = opensmt::Real( ceil(polynome[ PTRef_Undef ]) );
-//      polynome[ PTRef_Undef ] = opensmt::Real( polynome[ PTRef_Undef ].ceil( ) );
-    }
-  }
-  assert( checkIntCoefficients( ) );
-}
-*/
-
-/*
-bool
-LAExpression::checkIntCoefficients( )
-{
-  polynome_t::iterator it;
-  for ( it = polynome.begin()
-      ; it != polynome.end()
-      ; ++ it )
-  {
-    const opensmt::Real coeff = it->second;
-    if ( coeff.get_den( ) != 1 )
-      return false;
-  }
-
-  return true;
-}
-*/
 
 void
 LAExpression::canonizeReal()
 {
-  if ( polynome.size() == 1 )
-  {
-    assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
-    return;
-  }
-  //
-  // Get first useful variable
-  //
-  polynome_t::iterator it = polynome.begin( );
-  if ( it->first == PTRef_Undef ) it ++;
-  if ( r == LEQ )
-  {
-    const opensmt::Real abs_coeff = ( it->second > 0 ? it->second : opensmt::Real(-it->second));
-    for ( it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) it->second /= abs_coeff;
-  }
-  else
-  {
-    const opensmt::Real coeff = it->second;
-    for ( it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) it->second /= coeff;
-  }
+    if ( polynome.size() == 1 ) {
+        assert( polynome.find( PTRef_Undef ) != polynome.end( ) );
+        return;
+    }
+    //
+    // Get first useful variable
+    //
+    polynome_t::iterator it = polynome.begin( );
+    if ( it->first == PTRef_Undef ) it ++;
+    if ( r == LEQ ) {
+        const opensmt::Real abs_coeff = ( it->second > 0 ? it->second : opensmt::Real(-it->second));
+        for ( it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) it->second /= abs_coeff;
+    } else {
+        const opensmt::Real coeff = it->second;
+        for ( it = polynome.begin( ) ; it != polynome.end( ) ; it ++ ) it->second /= coeff;
+    }
 
-  assert( isCanonized( ) );
+    assert( isCanonized( ) );
 }
 
-void LAExpression::addExprWithCoeff( const LAExpression & a, const opensmt::Real & coeff )
-{
+void LAExpression::addExprWithCoeff( const LAExpression & a, const opensmt::Real & coeff ) {
     //
     // Iterate over expression to add
     //
-    for (polynome_t::const_iterator it = a.polynome.begin( ); it != a.polynome.end( ); it++)
-    {
+    for (polynome_t::const_iterator it = a.polynome.begin( ); it != a.polynome.end( ); it++) {
         polynome_t::iterator it2 = polynome.find( it->first );
-        if ( it2 != polynome.end( ) )
-        {
+        if ( it2 != polynome.end( ) ) {
             it2->second += coeff * it->second;
             if ( it2->first != PTRef_Undef && it2->second == 0 )
                 polynome.erase( it2 );
-        }
-        else
+        } else
             polynome[it->first] = coeff * it->second;
     }
 }

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -2146,7 +2146,8 @@ bool CoreSMTSolver::createSplit_scatter(bool last)
         // space
         constraints_negated.push(~l);
     }
-    for (const auto & split_assumption : split_assumptions) {
+    for (size_t i = 0; i < split_assumptions.size()-1; i++) {
+        const auto & split_assumption = split_assumptions[i];
         vec<Lit> tmp;
         for (auto tr : split_assumption)
             tmp.push(~tr);

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -272,14 +272,14 @@ Var CoreSMTSolver::newVar(bool sign, bool dvar)
 
 bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps)
 {
-    std::pair<CRef, CRef> fake;
+    opensmt::pair<CRef, CRef> fake;
     return addOriginalClause_(_ps, fake);
 }
 
-bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps, std::pair<CRef, CRef> & inOutCRefs)
+bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps, opensmt::pair<CRef, CRef> & inOutCRefs)
 {
     assert(decisionLevel() == 0);
-    inOutCRefs = std::make_pair(CRef_Undef, CRef_Undef);
+    inOutCRefs = {CRef_Undef, CRef_Undef};
     if (!isOK()) { return false; }
     bool logsProofForInterpolation = this->logsProofForInterpolation();
     vec<Lit> ps;
@@ -316,7 +316,7 @@ bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps, std::pair<CRef, CRe
         CRef inputClause = ca.alloc(original, false);
         CRef outputClause = resolvedUnits.empty() ? inputClause :
                 ps.size() == 0 ? CRef_Undef : ca.alloc(ps, false);
-        inOutCRefs = std::make_pair<>(inputClause, outputClause);
+        inOutCRefs = {inputClause, outputClause};
         proof->newOriginalClause(inputClause);
         if (!resolvedUnits.empty()) {
             proof->beginChain( inputClause );

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -1564,7 +1564,7 @@ lbool CoreSMTSolver::search(int nof_conflicts, int nof_learnts)
 #ifdef PEDANTIC_DEBUG
     bool thr_backtrack = false;
 #endif
-    while (split_type == spt_none || splits.size() < split_num - 1)
+    while (split_type == spt_none || static_cast<int>(splits.size()) < split_num - 1)
     {
         if (!okContinue())
             return l_Undef;
@@ -2112,8 +2112,8 @@ bool CoreSMTSolver::scatterLevel()
     for (int i = 0; ; i++)
     {
         // 2 << i == 2^(i+1)
-        if ((2 << (i-1) <= split_num - splits.size()) &&
-                (2 << i >= split_num - splits.size()))
+        if ((2 << (i-1) <= split_num - static_cast<int>(splits.size())) &&
+                (2 << i >= split_num - static_cast<int>(splits.size())))
         {
             // r-1(2^i) < 0 and we want absolute
             d = -(r-1/(float)(2<<(i-1))) > r-1/(float)(2<<i) ? i+1 : i;
@@ -2127,11 +2127,11 @@ bool CoreSMTSolver::scatterLevel()
 bool CoreSMTSolver::createSplit_scatter(bool last)
 {
     assert(splits.size() == split_assumptions.size());
-    splits.push_m(SplitData(config.smt_split_format_length() == spformat_brief));
-    split_assumptions.push();
-    SplitData& sp = splits.last();
+    splits.emplace_back(SplitData(config.smt_split_format_length() == spformat_brief));
+    split_assumptions.emplace_back();
+    SplitData& sp = splits.back();
     vec<Lit> constraints_negated;
-    vec<Lit>& split_assumption = split_assumptions.last();
+    vec<Lit>& split_assumption = split_assumptions.back();
     // Add the literals on the decision levels
     for (int i = 0; i < decisionLevel(); i++) {
         vec<Lit> tmp;
@@ -2146,12 +2146,10 @@ bool CoreSMTSolver::createSplit_scatter(bool last)
         // space
         constraints_negated.push(~l);
     }
-    for (int i = 0; i < split_assumptions.size()-1; i++)
-    {
+    for (const auto & split_assumption : split_assumptions) {
         vec<Lit> tmp;
-        vec<Lit>& split_assumption = split_assumptions[i];
-        for (int j = 0; j < split_assumption.size(); j++)
-            tmp.push(~split_assumption[j]);
+        for (auto tr : split_assumption)
+            tmp.push(~tr);
         sp.addConstraint(tmp);
     }
 

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -2127,7 +2127,7 @@ bool CoreSMTSolver::scatterLevel()
 bool CoreSMTSolver::createSplit_scatter(bool last)
 {
     assert(splits.size() == split_assumptions.size());
-    splits.push_c(SplitData(config.smt_split_format_length() == spformat_brief));
+    splits.push_m(SplitData(config.smt_split_format_length() == spformat_brief));
     split_assumptions.push();
     SplitData& sp = splits.last();
     vec<Lit> constraints_negated;

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -86,7 +86,7 @@ class SplitData
     template<class C> char* clauseToString(const C&);
     char* clauseToString(const vec<Lit>&);
     int getLitSize(const Lit l) const;
-    void toPTRefs(std::vector<vec<PtAsgn> >& out, std::vector<vec<Lit> >& in, const THandler &thandler);
+    void toPTRefs(std::vector<vec<PtAsgn> >& out, const std::vector<vec<Lit> >& in, const THandler &thandler) const;
 
 public:
     SplitData(bool no_instance = true)
@@ -109,8 +109,8 @@ public:
     }
 
     char* splitToString();
-    inline void  constraintsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, constraints, thandler); }
-    inline void  learntsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, learnts, thandler); }
+    inline void  constraintsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) const { toPTRefs(out, constraints, thandler); }
+    inline void  learntsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) const { toPTRefs(out, learnts, thandler); }
 };
 
 inline int SplitData::getLitSize(const Lit l) const
@@ -171,12 +171,8 @@ inline char* SplitData::splitToString()
     }
 */
     // The constraints
-    for (int i = 0; i < constraints.size(); i++)
-    {
-        vec<Lit>& c = constraints[i];
-        for (int j = 0; j < c.size(); j++)
-        {
-            Lit l = c[j];
+    for (vec<Lit>& c : constraints) {
+        for (Lit l : c) {
             int n = getLitSize(l);
             while (buf_cap < sz + n + 2)   // Lit, space, and NULL
             {
@@ -195,12 +191,8 @@ inline char* SplitData::splitToString()
         sz += 2;
     }
 
-    for (int i = 0; i < learnts.size(); i++)
-    {
-        vec<Lit>& c = learnts[i];
-        for (int j = 0; j < c.size(); j++)
-        {
-            Lit l = c[j];
+    for (vec<Lit> & c : learnts) {
+        for (Lit l : c) {
             int n = getLitSize(l);
             while (buf_cap < sz + n + 2)   // The size of lit, space, and NULL
             {
@@ -222,17 +214,15 @@ inline char* SplitData::splitToString()
     return buf;
 }
 
-inline void SplitData::toPTRefs(std::vector<vec<PtAsgn> >& out, std::vector<vec<Lit> >& in, const THandler& theory_handler)
+inline void SplitData::toPTRefs(std::vector<vec<PtAsgn> >& out, const std::vector<vec<Lit> >& in, const THandler& theory_handler) const
 {
-    for (int i = 0; i < in.size(); i++)
-    {
-        vec<Lit>& c = in[i];
+    for (const vec<Lit>& c : in) {
         out.emplace_back();
         vec<PtAsgn>& out_clause = out[out.size()-1];
-        for (int j = 0; j < c.size(); j++)
+        for (Lit l : c)
         {
-            PTRef tr = theory_handler.varToTerm(var(c[j]));
-            PtAsgn pta(tr, sign(c[j]) ? l_False : l_True);
+            PTRef tr = theory_handler.varToTerm(var(l));
+            PtAsgn pta(tr, sign(l) ? l_False : l_True);
             out_clause.push(pta);
         }
     }
@@ -395,8 +385,8 @@ public:
     uint64_t top_level_lits;
 
     // Splits
-    vec<SplitData> splits;
-    vec<vec<Lit> > split_assumptions;
+    std::vector<SplitData> splits;
+    std::vector<vec<Lit>> split_assumptions;
 
 protected:
     Lit forced_split; // If theory solver tells that we must split the instance, a literal with unknown value is inserted here for the splitting heuristic

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -269,7 +269,7 @@ public:
     bool    addOriginalClause(Lit p, Lit q, Lit r);                    // Add a ternary clause to the solver.
 protected:
     bool addOriginalClause_(const vec<Lit> & _ps);                                          // Add a clause to the solver
-    bool addOriginalClause_(const vec<Lit> & _ps, pair<CRef, CRef> & inOutCRefs);           // Add a clause to the solver without making superflous internal copy. Will change the passed vector 'ps'.  Write the new clause to cr
+    bool addOriginalClause_(const vec<Lit> & _ps, opensmt::pair<CRef, CRef> & inOutCRefs);  // Add a clause to the solver without making superflous internal copy. Will change the passed vector 'ps'.  Write the new clause to cr
 public:
     // Solving:
     //

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -56,6 +56,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <memory>
 #include <sstream>
 
+#include <vector>
+
 #include "Vec.h"
 #include "Heap.h"
 #include "Alg.h"
@@ -77,51 +79,38 @@ class SplitData
 {
     bool                no_instance;    // Does SplitData store the instance?
 
-    vec<vec<Lit> >      constraints;    // The split constraints
-    vec<vec<Lit> >      learnts;        // The learnt clauses
+    std::vector<vec<Lit>>      constraints;    // The split constraints
+    std::vector<vec<Lit>>      learnts;        // The learnt clauses
 
     char* litToString(const Lit);
     template<class C> char* clauseToString(const C&);
     char* clauseToString(const vec<Lit>&);
     int getLitSize(const Lit l) const;
-    void toPTRefs(vec<vec<PtAsgn> >& out, vec<vec<Lit> >& in, const THandler &thandler);
+    void toPTRefs(std::vector<vec<PtAsgn> >& out, std::vector<vec<Lit> >& in, const THandler &thandler);
 
 public:
     SplitData(bool no_instance = true)
         : no_instance(no_instance)
-
     { assert(no_instance); }
-    SplitData(SplitData&& other)
-        : no_instance(other.no_instance)
-    { other.constraints.moveTo(constraints); other.learnts.moveTo(learnts); }
-
-    SplitData(const SplitData& other)
-        : no_instance(other.no_instance)
-    { other.constraints.copyTo(constraints); other.learnts.copyTo(learnts); }
-
-    SplitData& operator= (SplitData&& o)
-    {
-        o.constraints.moveTo(constraints); o.learnts.moveTo(learnts); return *this;
-    }
 
     template<class C> void addConstraint(const C& c)
     {
-        constraints.push();
-        vec<Lit>& cstr = constraints.last();
+        constraints.emplace_back();
+        vec<Lit>& cstr = constraints.back();
         for (int i = 0; i < c.size(); i++)
             cstr.push(c[i]);
     }
     void addLearnt(Clause& c)
     {
-        learnts.push();
-        vec<Lit>& learnt = learnts.last();
+        learnts.emplace_back();
+        vec<Lit>& learnt = learnts.back();
         for (unsigned i = 0; i < c.size(); i++)
             learnt.push(c[i]);
     }
 
     char* splitToString();
-    inline void  constraintsToPTRefs(vec<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, constraints, thandler); }
-    inline void  learntsToPTRefs(vec<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, learnts, thandler); }
+    inline void  constraintsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, constraints, thandler); }
+    inline void  learntsToPTRefs(std::vector<vec<PtAsgn>>& out, const THandler& thandler) { toPTRefs(out, learnts, thandler); }
 };
 
 inline int SplitData::getLitSize(const Lit l) const
@@ -233,12 +222,12 @@ inline char* SplitData::splitToString()
     return buf;
 }
 
-inline void SplitData::toPTRefs(vec<vec<PtAsgn> >& out, vec<vec<Lit> >& in, const THandler& theory_handler)
+inline void SplitData::toPTRefs(std::vector<vec<PtAsgn> >& out, std::vector<vec<Lit> >& in, const THandler& theory_handler)
 {
     for (int i = 0; i < in.size(); i++)
     {
         vec<Lit>& c = in[i];
-        out.push();
+        out.emplace_back();
         vec<PtAsgn>& out_clause = out[out.size()-1];
         for (int j = 0; j < c.size(); j++)
         {

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -156,22 +156,8 @@ inline char* SplitData::splitToString()
     int sz = 0;
     char* buf = (char*) malloc(1024);
 
-/*
-    // Units in dl 0
-    for (int i = 0; i < (trail_idx > 0 ? trail_idx : trail.size()); i++)
-    {
-        int n = getLitSize(trail[i]);
-        while (buf_cap < sz + n + 4)   // The size of lit, trailing space, the zero, the newline, and NULL
-        {
-            buf_cap *= 2;
-            buf = (char*) realloc(buf, buf_cap);
-        }
-        sprintf(&buf[sz], "%s%d 0\n", sign(trail[i]) ? "-" : "", var(trail[i])+1);
-        sz += n+3; // points to NULL
-    }
-*/
     // The constraints
-    for (vec<Lit>& c : constraints) {
+    for (const vec<Lit>& c : constraints) {
         for (Lit l : c) {
             int n = getLitSize(l);
             while (buf_cap < sz + n + 2)   // Lit, space, and NULL
@@ -191,7 +177,7 @@ inline char* SplitData::splitToString()
         sz += 2;
     }
 
-    for (vec<Lit> & c : learnts) {
+    for (const vec<Lit> & c : learnts) {
         for (Lit l : c) {
             int n = getLitSize(l);
             while (buf_cap < sz + n + 2)   // The size of lit, space, and NULL

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -188,8 +188,8 @@ GhostSMTSolver::pickBranchLit() {
 }
 
 void GhostSMTSolver::relocAll() {
-    for (auto & appearances : thLitToClauses) {
-        for (CRef & cr : appearances) {
+    for (const auto & appearances : thLitToClauses) {
+        for (CRef cr : appearances) {
             cr = ca[cr].relocation();
         }
     }

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -54,7 +54,7 @@ GhostSMTSolver::attachClause(CRef in_clause)
         Lit l = c[i];
         if (theory_handler.isTheoryTerm(var(l))) {
             int idx = toInt(l);
-            assert(idx < thLitToClauses.size());
+            assert(idx < static_cast<int>(thLitToClauses.size()));
             thLitToClauses[idx].push(in_clause);
         }
     }
@@ -76,8 +76,8 @@ GhostSMTSolver::newVar(bool polarity, bool dvar)
 {
     Var v = SimpSMTSolver::newVar(polarity, dvar);
     int idx = toInt(mkLit(v, true)); // true polarity has higher index
-    while (thLitToClauses.size() <= idx)
-        thLitToClauses.push();
+    while (static_cast<int>(thLitToClauses.size()) <= idx)
+        thLitToClauses.emplace_back();
     return v;
 }
 
@@ -188,11 +188,9 @@ GhostSMTSolver::pickBranchLit() {
 }
 
 void GhostSMTSolver::relocAll() {
-    for (int i = 0; i < thLitToClauses.size(); i++) {
-        vec<CRef> &appearances = thLitToClauses[i];
-        for (int j = 0; j < appearances.size(); j++) {
-            CRef cr = appearances[j];
-            appearances[j] = ca[cr].relocation();
+    for (auto & appearances : thLitToClauses) {
+        for (CRef & cr : appearances) {
+            cr = ca[cr].relocation();
         }
     }
 }

--- a/src/smtsolvers/GhostSMTSolver.h
+++ b/src/smtsolvers/GhostSMTSolver.h
@@ -9,7 +9,7 @@
 class GhostSMTSolver : public SimpSMTSolver
 {
 private:
-    vec<vec<CRef>> thLitToClauses;
+    std::vector<vec<CRef>> thLitToClauses;
     vec<Var> ghostTrail;
     vec<int> ghostTrailLim;
     Var pickBranchVar();

--- a/src/smtsolvers/LAScore.h
+++ b/src/smtsolvers/LAScore.h
@@ -16,7 +16,7 @@ template<class EV>
 class LABestLitBuf {
 private:
     int size;
-    struct EVLitPair { EV first; Lit second; };
+    using EVLitPair = opensmt::pair<EV, Lit>;
     vec<EVLitPair> buf;
     const vec<lbool> &assigns;
     EV  heur_worst;     // the lowest heuristic value currently in buf

--- a/src/smtsolvers/LAScore.h
+++ b/src/smtsolvers/LAScore.h
@@ -16,7 +16,8 @@ template<class EV>
 class LABestLitBuf {
 private:
     int size;
-    vec<std::pair < EV, Lit> > buf;
+    struct EVLitPair { EV first; Lit second; };
+    vec<EVLitPair> buf;
     const vec<lbool> &assigns;
     EV  heur_worst;     // the lowest heuristic value currently in buf
     int heur_worst_loc; // The location of heur_worst in buf
@@ -44,7 +45,7 @@ public:
             : size(sz), assigns(assigns), randomize(randomize), rnd_seed(rnd_seed)
     {
         for (int i = 0; i < size; i++)
-            buf.push(std::pair < EV, Lit > {EV(), lit_Undef});
+            buf.push(EVLitPair{EV(), lit_Undef});
         heur_worst_loc = 0;
         heur_worst = buf[heur_worst_loc].first;
     }
@@ -52,7 +53,7 @@ public:
     void insert(Lit l, EV &val) {
         int i;
         if (val < heur_worst) { return; }
-        buf[heur_worst_loc] = std::pair<EV,Lit>(val, l);
+        buf[heur_worst_loc] = EVLitPair{val, l};
         EV current_worst = EV::max_val;
         for (i = 0; i < size; i++) {
             int loc = (heur_worst_loc+i) % size;
@@ -140,8 +141,6 @@ public:
     public:
         DoubleVal() : round(-1), val(std::numeric_limits<double>::lowest()) {}
         DoubleVal(int round, double val) : round(round), val(val) {}
-        DoubleVal(const DoubleVal& o) { round = o.round; val = o.val; }
-        DoubleVal& operator=(const DoubleVal& o) { round = o.round; val = o.val; return *this; }
         static const DoubleVal max_val;
 
         bool operator<  (const DoubleVal& o) const {

--- a/src/smtsolvers/LookaheadSplitter.cc
+++ b/src/smtsolvers/LookaheadSplitter.cc
@@ -88,7 +88,7 @@ LookaheadSMTSolver::LALoopRes LookaheadSplitter::solveLookahead()
     root->print();
 #endif
     copySplits(root);
-    assert(splits.size() == config.sat_split_num());
+    assert(static_cast<int>(splits.size()) == config.sat_split_num());
     return LALoopRes::unknown_final;
 }
 
@@ -144,7 +144,7 @@ void LookaheadSplitter::copySplits(LASplitNode *root)
         }
         queue.pop();
         if (n->sd != nullptr) {
-            splits.push_m(std::move(*n->sd));
+            splits.emplace_back(std::move(*n->sd));
             n->sd = nullptr;
         }
     }

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -184,7 +184,7 @@ skip_theory_preproc:
 //=================================================================================================
 // Added code
 
-bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause, std::pair<CRef, CRef> & inOutCRefs)
+bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause, opensmt::pair<CRef, CRef> & inOutCRefs)
 {
     inOutCRefs = {CRef_Undef, CRef_Undef};
     assert( config.sat_preprocess_theory == 0 );
@@ -622,7 +622,7 @@ bool SimpSMTSolver::eliminateVar(Var v)
     vec<Lit>& resolvent = add_tmp;
     for (int i = 0; i < pos.size(); i++) {
         for (int j = 0; j < neg.size(); j++) {
-            std::pair<CRef,CRef> dummy {CRef_Undef, CRef_Undef};
+            opensmt::pair<CRef,CRef> dummy {CRef_Undef, CRef_Undef};
             if (merge(ca[pos[i]], ca[neg[j]], v, resolvent) && !addOriginalSMTClause(resolvent, dummy))
                 return false;
         }
@@ -665,7 +665,7 @@ bool SimpSMTSolver::substitute(Var v, Lit x)
 
         removeClause(cls[i]);
 
-        std::pair<CRef,CRef> dummy {CRef_Undef, CRef_Undef};
+        opensmt::pair<CRef,CRef> dummy {CRef_Undef, CRef_Undef};
         if (!addOriginalSMTClause(subst_clause, dummy))
             return ok = false;
     }

--- a/src/smtsolvers/SimpSMTSolver.h
+++ b/src/smtsolvers/SimpSMTSolver.h
@@ -63,7 +63,7 @@ class SimpSMTSolver : public CoreSMTSolver
     //
     Var     newVar    (bool polarity = true, bool dvar = true) override;
 
-    bool addOriginalSMTClause(const vec<Lit> & smt_clause, pair<CRef, CRef> & inOutCRefs);
+    bool addOriginalSMTClause(const vec<Lit> & smt_clause, opensmt::pair<CRef, CRef> & inOutCRefs);
 public:
 
     bool    substitute(Var v, Lit x);  // Replace all occurences of v with x (may cause a contradiction).

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -423,17 +423,17 @@ THandler::dumpHeaderToFile(ostream& dump_out)
     logic.dumpHeaderToFile(dump_out);
 }
 
-const char* THandler::printAsrtClause(vec<Lit>& r) {
+char* THandler::printAsrtClause(vec<Lit>& r) {
     stringstream os;
     for (int i = 0; i < r.size(); i++) {
         Var v = var(r[i]);
         bool sgn = sign(r[i]);
         os << (sgn ? "not " : "") << getLogic().printTerm(tmap.varToPTRef(v)) << " ";
     }
-    return os.str().c_str();
+    return strdup(os.str().c_str());
 }
 
-const char* THandler::printAsrtClause(Clause* c) {
+char* THandler::printAsrtClause(Clause* c) {
     vec<Lit> v;
     for (unsigned i = 0; i < c->size(); i++)
         v.push((*c)[i]);

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -126,8 +126,8 @@ protected:
 
 // Debug
 public:
-    const char* printAsrtClause(vec<Lit>& r);
-    const char* printAsrtClause(Clause *c);
+    char* printAsrtClause(vec<Lit>& r);
+    char* printAsrtClause(Clause *c);
     bool checkTrailConsistency(vec<Lit>& trail);
 protected:
 #ifdef PEDANTIC_DEBUG

--- a/src/tsolvers/bvsolver/BitBlaster.cc
+++ b/src/tsolvers/bvsolver/BitBlaster.cc
@@ -1128,13 +1128,13 @@ BitBlaster::bbBvurem(PTRef tr)
 }
 
 void
-BitBlaster::ls_write(int s, int i, PTRef tr, vec<vec<PTRef> >& table)
+BitBlaster::ls_write(int s, int i, PTRef tr, std::vector<vec<PTRef> >& table)
 {
     table[s+1][i] = tr;
 }
 
 PTRef
-BitBlaster::ls_read(int s, int i, vec<vec<PTRef> >& table)
+BitBlaster::ls_read(int s, int i, std::vector<vec<PTRef> >& table)
 {
     return table[s+1][i];
 }
@@ -1166,11 +1166,11 @@ BitBlaster::bbBvlshift(PTRef tr)
     int l = bs[a].size();
     int n = opensmt::getLogFromPowOfTwo(bs[a].size());
 
-    vec<vec<PTRef> > ls;
+    std::vector<vec<PTRef> > ls;
     for (int s = -1; s <= n-1; s++) {
-        ls.push();
+        ls.emplace_back();
         for (int i = 0; i < l; i++)
-            ls.last().push(PTRef_Undef);
+            ls.back().push(PTRef_Undef);
     }
 
     for (int i = 0; i < l; i++)
@@ -1184,7 +1184,7 @@ BitBlaster::bbBvlshift(PTRef tr)
                 ls_write(s, i, logic.mkIte(bs[b][s], logic.getTerm_false(), ls_read(s-1, i, ls)), ls);
         }
     }
-    return bs.newBvector(names, ls.last(), mkActVar(s_bbBvlsh), tr);
+    return bs.newBvector(names, ls.back(), mkActVar(s_bbBvlsh), tr);
 }
 
 BVRef
@@ -1227,11 +1227,11 @@ BitBlaster::bbBvrshift(PTRef tr, bool arith)
     int l = bs[a].size();
     int n = opensmt::getLogFromPowOfTwo(bs[a].size());
 
-    vec<vec<PTRef> > ls;
+    std::vector<vec<PTRef>> ls;
     for (int s = -1; s <= n-1; s++) {
-        ls.push();
+        ls.emplace_back();
         for (int i = 0; i < l; i++)
-            ls.last().push(PTRef_Undef);
+            ls.back().push(PTRef_Undef);
     }
 
     for (int i = 0; i < l; i++)
@@ -1247,7 +1247,7 @@ BitBlaster::bbBvrshift(PTRef tr, bool arith)
         }
     }
     PTRef actVar = arith ? mkActVar(s_bbBvarsh) : mkActVar(s_bbBvlrsh);
-    return bs.newBvector(names, ls.last(), actVar, tr);
+    return bs.newBvector(names, ls.back(), actVar, tr);
 }
 
 
@@ -2138,7 +2138,7 @@ void BitBlaster::computeModel( )
         }
         ValPair v(e, value.get_str().c_str());
 
-        model.insert(e, v);
+        model[e] = v;
     }
     has_model = true;
 }

--- a/src/tsolvers/bvsolver/BitBlaster.h
+++ b/src/tsolvers/bvsolver/BitBlaster.h
@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "SimpSMTSolver.h"
 #include "BVStore.h"
+#include <unordered_map>
 
 // forward declarations
 class BVLogic;
@@ -138,8 +139,8 @@ private:
     BVRef bbDistinct   (PTRef);
 
     PTRef bbBvadd_carryonly(PTRef sum, PTRef cin); // for signed comparison
-    void ls_write(int s, int i, PTRef tr, vec<vec<PTRef> >& table); // Helper function for shifts
-    PTRef ls_read(int s, int i, vec<vec<PTRef> >& table); // Helper function for shifts
+    void ls_write(int s, int i, PTRef tr, std::vector<vec<PTRef> >& table); // Helper function for shifts
+    PTRef ls_read(int s, int i, std::vector<vec<PTRef> >& table); // Helper function for shifts
 
   // Not yet considered
   // vector< Enode * > & bbUf         ( Enode * );
@@ -171,7 +172,7 @@ private:
     vec<PTRef>                      variables;                     // Variables
     map< int, Var >                 cnf_var;                       // BB variable to cnf var
     bool                            has_model;                     // Is the model computed
-    Map<PTRef,ValPair,PTRefHash>    model;                         // Model is stored here
+    std::unordered_map<PTRef,ValPair,PTRefHash>    model;          // Model is stored here
 
     int                             bitwidth;
 };

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -281,16 +281,16 @@ void Egraph::declareTerm(PTRef tr) {
     }
 
     for (auto PTRefERefPair : PTRefERefPairVec) {
-        updateParentsVector(PTRefERefPair.first);
+        updateParentsVector(PTRefERefPair.tr);
     }
 
     if (logic.hasSortBool(tr) and not logic.isDisequality(tr)) {
         assert(PTRefERefPairVec.size() == 2);
         for (auto PTRefERefPair : PTRefERefPairVec) {
-            boolTermToERef.insert(PTRefERefPair.first, PTRefERefPair.second);
+            boolTermToERef.insert(PTRefERefPair.tr, PTRefERefPair.er);
         }
-        assert(PTRefERefPairVec[0].first == logic.mkNot(PTRefERefPairVec[1].first));
-        assertNEq(PTRefERefPairVec[0].second, PTRefERefPairVec[1].second, Expl(Expl::Type::pol, PtAsgn_Undef, PTRefERefPairVec[0].first));
+        assert(PTRefERefPairVec[0].tr == logic.mkNot(PTRefERefPairVec[1].tr));
+        assertNEq(PTRefERefPairVec[0].er, PTRefERefPairVec[1].er, Expl(Expl::Type::pol, PtAsgn_Undef, PTRefERefPairVec[0].tr));
     }
 
     if (logic.hasSortBool(tr)) {

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -174,14 +174,14 @@ bool EnodeStore::needsEnode(PTRef tr) const {
  * the positive form and and the second the negated form of the PTRef tr; or is empty
  * if the PTRef has already been inserted.
  */
-vec<std::pair<PTRef,ERef>> EnodeStore::constructTerm(PTRef tr) {
+vec<PTRefERefPair> EnodeStore::constructTerm(PTRef tr) {
 
     assert(needsEnode(tr));
 
     if (termToERef.has(tr))
         return {};
 
-    vec<std::pair<PTRef,ERef>> new_enodes;
+    vec<PTRefERefPair> new_enodes;
 
     if (logic.isDisequality(tr)) {
         addDistClass(tr);

--- a/src/tsolvers/egraph/EnodeStore.h
+++ b/src/tsolvers/egraph/EnodeStore.h
@@ -32,6 +32,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 class Logic;
 
+struct PTRefERefPair { PTRef tr; ERef er; };
+
 class EnodeStore {
     Logic&         logic;
     Map<SigPair,ERef,SigHash,Equal<const SigPair&> > sig_tab;
@@ -78,7 +80,7 @@ public:
     ERef         getERef(PTRef tr)     const { return termToERef[tr]; }
     PTRef        getPTRef(ERef er)     const { return ERefToTerm[er]; }
 
-    vec<std::pair<PTRef,ERef>> constructTerm(PTRef tr);
+    vec<PTRefERefPair> constructTerm(PTRef tr);
 
     Enode&       operator[] (ERef e)         { return ea[e]; }
     const Enode& operator[] (ERef e)   const { return ea[e]; }

--- a/src/tsolvers/egraph/Explainer.cc
+++ b/src/tsolvers/egraph/Explainer.cc
@@ -104,7 +104,7 @@ void Explainer::reRootOn(ERef x) {
     }
 }
 
-vec<PtAsgn> Explainer::explain(::pair<ERef,ERef> nodePair) {
+vec<PtAsgn> Explainer::explain(opensmt::pair<ERef,ERef> nodePair) {
 
 #ifdef EXPLICIT_CONGRUENCE_EXPLANATIONS
     congruences.clear();

--- a/src/tsolvers/egraph/Explainer.cc
+++ b/src/tsolvers/egraph/Explainer.cc
@@ -104,7 +104,7 @@ void Explainer::reRootOn(ERef x) {
     }
 }
 
-vec<PtAsgn> Explainer::explain(std::pair<ERef,ERef> nodePair) {
+vec<PtAsgn> Explainer::explain(::pair<ERef,ERef> nodePair) {
 
 #ifdef EXPLICIT_CONGRUENCE_EXPLANATIONS
     congruences.clear();

--- a/src/tsolvers/egraph/Explainer.h
+++ b/src/tsolvers/egraph/Explainer.h
@@ -53,8 +53,8 @@ protected:
     //
     // Explanation routines and data
     //
-    using PendingQueue = vec<::pair<ERef,ERef>>;
-    virtual vec<PtAsgn> explain      (::pair<ERef,ERef>);        // Main routine for explanation
+    using PendingQueue = vec<opensmt::pair<ERef,ERef>>;
+    virtual vec<PtAsgn> explain      (opensmt::pair<ERef,ERef>);        // Main routine for explanation
     virtual PtAsgn  explainEdge      (ERef v, ERef p, PendingQueue &exp_pending, DupChecker& dc);
     virtual void    explainAlongPath (ERef, ERef, vec<PtAsgn> &outExplanation, PendingQueue &exp_pending, DupChecker& dc); // Store explanation in explanation
     virtual void    enqueueArguments (ERef, ERef, PendingQueue &exp_pending); // Enqueue arguments to be explained
@@ -74,7 +74,7 @@ protected:
     vec<ERef>       exp_cleanup;                      // List of nodes to be restored
     int             time_stamp = 0;                   // Need for finding NCA
 
-    vec<::pair<PTRef,PTRef>> congruences;
+    vec<opensmt::pair<PTRef,PTRef>> congruences;
 public:
     Explainer(EnodeStore & store) : store(store) {}
     virtual ~Explainer() = default;
@@ -82,7 +82,7 @@ public:
     void                storeExplanation    (ERef, ERef, PtAsgn);        // Store the explanation for the merge
     void                removeExplanation   ();                          // Undoes the effect of storeExplanation
     virtual vec<PtAsgn> explain             (ERef, ERef);                // Return explanation of why the given two terms are equal
-    const vec<::pair<PTRef,PTRef>> &getCongruences() const { return congruences; }
+    const vec<opensmt::pair<PTRef,PTRef>> &getCongruences() const { return congruences; }
 };
 
 class InterpolatingExplainer : public Explainer {

--- a/src/tsolvers/egraph/Explainer.h
+++ b/src/tsolvers/egraph/Explainer.h
@@ -53,8 +53,8 @@ protected:
     //
     // Explanation routines and data
     //
-    using PendingQueue = vec<std::pair<ERef,ERef>>;
-    virtual vec<PtAsgn> explain      (std::pair<ERef,ERef>);     // Main routine for explanation
+    using PendingQueue = vec<::pair<ERef,ERef>>;
+    virtual vec<PtAsgn> explain      (::pair<ERef,ERef>);        // Main routine for explanation
     virtual PtAsgn  explainEdge      (ERef v, ERef p, PendingQueue &exp_pending, DupChecker& dc);
     virtual void    explainAlongPath (ERef, ERef, vec<PtAsgn> &outExplanation, PendingQueue &exp_pending, DupChecker& dc); // Store explanation in explanation
     virtual void    enqueueArguments (ERef, ERef, PendingQueue &exp_pending); // Enqueue arguments to be explained
@@ -74,7 +74,7 @@ protected:
     vec<ERef>       exp_cleanup;                      // List of nodes to be restored
     int             time_stamp = 0;                   // Need for finding NCA
 
-    vec<std::pair<PTRef,PTRef>> congruences;
+    vec<::pair<PTRef,PTRef>> congruences;
 public:
     Explainer(EnodeStore & store) : store(store) {}
     virtual ~Explainer() = default;
@@ -82,7 +82,7 @@ public:
     void                storeExplanation    (ERef, ERef, PtAsgn);        // Store the explanation for the merge
     void                removeExplanation   ();                          // Undoes the effect of storeExplanation
     virtual vec<PtAsgn> explain             (ERef, ERef);                // Return explanation of why the given two terms are equal
-    const vec<std::pair<PTRef,PTRef>> &getCongruences() const { return congruences; }
+    const vec<::pair<PTRef,PTRef>> &getCongruences() const { return congruences; }
 };
 
 class InterpolatingExplainer : public Explainer {

--- a/src/tsolvers/liasolver/LIASolver.cc
+++ b/src/tsolvers/liasolver/LIASolver.cc
@@ -67,10 +67,10 @@ TRes LIASolver::checkIntegersAndSplit() {
             }
 
             // We might have this blocked already, and then the solver should essentially return "I don't know, please go ahead".
-            if (cuts[getVarId(x)].has(c)) {
+            if (cuts[getVarId(x)].find(c) != cuts[getVarId(x)].end()) {
                 continue;
             }
-            cuts[getVarId(x)].insert(c, true);
+            cuts[getVarId(x)][c] = true;
 
             // Check if integer splitting is possible for the current variable
             if (simplex.hasLBound(x) && simplex.hasUBound(x) && c < simplex.Lb(x) && c + 1 > simplex.Ub(x)) { //then splitting not possible, and we create explanation
@@ -126,9 +126,9 @@ void LIASolver::markVarAsInt(LVRef v) {
         int_vars_map.insert(v, true);
         int_vars.push(v);
     }
-
-    while(static_cast<unsigned>(cuts.size()) <= getVarId(v))
-        cuts.push();
+    while (static_cast<unsigned>(cuts.size()) <= getVarId(v)) {
+        cuts.emplace_back(0);
+    }
 }
 
 PTRef LIASolver::getInterpolant(std::map<PTRef, icolor_t> const& labels) {

--- a/src/tsolvers/liasolver/LIASolver.h
+++ b/src/tsolvers/liasolver/LIASolver.h
@@ -4,6 +4,8 @@
 #include "LIALogic.h"
 #include "LASolver.h"
 #include "lasolver/LARefs.h"
+#include <unordered_map>
+#include <vector>
 
 #include <map>
 
@@ -76,7 +78,7 @@ protected:
 
     Map<LVRef, bool, LVRefHash> int_vars_map; // stores problem variables for duplicate check
     vec<LVRef> int_vars;                      // stores the list of problem variables without duplicates
-    vec<Map<opensmt::Real, bool, FastRationalHash> > cuts;
+    std::vector<std::unordered_map<opensmt::Real, bool, FastRationalHash> > cuts;
 
 };
 

--- a/src/tsolvers/liasolver/Matrix.cc
+++ b/src/tsolvers/liasolver/Matrix.cc
@@ -5,9 +5,9 @@
 #include <liasolver/Matrix.h>
 
 LAVecRef
-LAVecStore::getNewVec(const vec<opensmt::Real>& ps, const opensmt::Real& den)
+LAVecStore::getNewVec(std::vector<opensmt::Real>&& ps, const opensmt::Real& den)
 {
-    LAVecRef vr = lva.alloc(ps, den);
+    LAVecRef vr = lva.alloc(std::move(ps), den);
     return vr;
 }
 

--- a/src/tsolvers/liasolver/Matrix.h
+++ b/src/tsolvers/liasolver/Matrix.h
@@ -26,10 +26,10 @@ private:
     opensmt::Real args[0]; // Either the elements or the relocation reference
 
 public:
-    LAVec(const vec<opensmt::Real>& ps, const opensmt::Real& den) : den(den) {
+    LAVec(std::vector<opensmt::Real>&& ps, const opensmt::Real& den) : den(den) {
         header.size = ps.size();
         header.reloced = 0;
-        for (int i = 0; i < ps.size(); i++) {
+        for (int i = 0; i < static_cast<int>(ps.size()); i++) {
             new (&args[i]) opensmt::Real(ps[i]);
         }
     }
@@ -65,10 +65,10 @@ public:
     LAVecAllocator()                   : n_vecs(0) {}
     unsigned getNumVecs() const { return n_vecs; };
 
-    LAVecRef alloc(const vec<opensmt::Real>& ps, const opensmt::Real& den) {
+    LAVecRef alloc(std::vector<opensmt::Real>&& ps, const opensmt::Real& den) {
         uint32_t v = RegionAllocator<uint32_t>::alloc(lavecWord32Size(ps.size()));
         LAVecRef vid = {v};
-        new (lea(vid)) LAVec(ps, den);
+        new (lea(vid)) LAVec(std::move(ps), den);
         n_vecs++;
         return vid;
     }
@@ -93,9 +93,9 @@ private:
 public:
     LAVecStore(LAVecAllocator& lva, LALogic& logic) : lva(lva), logic(logic) {}
     inline void   clear() { lavecs.clear(); };
-    LAVecRef getNewVec(const vec<opensmt::Real>& ps, const opensmt::Real& den);
-    LAVecRef getNewVec(const vec<opensmt::Real>& ps) { return getNewVec(ps, 1); }
-    LAVecRef getNewVec(int size) { vec<opensmt::Real> tmp; for (int i = 0; i < size; i++) tmp.push_c(0); return getNewVec(tmp); }
+    LAVecRef getNewVec(std::vector<opensmt::Real>&& ps, const opensmt::Real& den);
+    LAVecRef getNewVec(std::vector<opensmt::Real>&& ps) { return getNewVec(std::move(ps), 1); }
+    LAVecRef getNewVec(int size) { std::vector<opensmt::Real> tmp; tmp.resize(size); return getNewVec(std::move(tmp)); }
     int    numVecs() const ;
     void   remove(const LAVecRef r);
     LAVec& operator [] (LAVecRef vr) { return lva[vr]; }

--- a/src/tsolvers/liasolver/Matrix.h
+++ b/src/tsolvers/liasolver/Matrix.h
@@ -29,7 +29,7 @@ public:
     LAVec(std::vector<opensmt::Real>&& ps, const opensmt::Real& den) : den(den) {
         header.size = ps.size();
         header.reloced = 0;
-        for (int i = 0; i < static_cast<int>(ps.size()); i++) {
+        for (size_t i = 0; i < ps.size(); i++) {
             new (&args[i]) opensmt::Real(ps[i]);
         }
     }

--- a/src/tsolvers/lrasolver/LRAModel.cc
+++ b/src/tsolvers/lrasolver/LRAModel.cc
@@ -20,11 +20,11 @@ LRAModel::addVar(LVRef v)
         return n_vars_with_model;
 
     while (static_cast<unsigned>(current_assignment.size()) <= getVarId(v)) {
-        current_assignment.push();
-        last_consistent_assignment.push();
+        current_assignment.emplace_back();
+        last_consistent_assignment.emplace_back();
         changed_vars_set.assure_domain(getVarId(v));
-        int_lbounds.push();
-        int_ubounds.push();
+        int_lbounds.emplace_back();
+        int_ubounds.emplace_back();
     }
 
     has_model.insert(v, true);

--- a/src/tsolvers/lrasolver/LRAModel.h
+++ b/src/tsolvers/lrasolver/LRAModel.h
@@ -19,14 +19,14 @@
 class LRAModel
 {
 protected:
-    vec<vec<LABoundRef> > int_lbounds;
-    vec<vec<LABoundRef> > int_ubounds;
+    std::vector<vec<LABoundRef> > int_lbounds;
+    std::vector<vec<LABoundRef> > int_ubounds;
 
     vec<int> bound_limits;
     vec<LABoundRef> bound_trace;
 
-    vec<Delta>  current_assignment;
-    vec<Delta>  last_consistent_assignment;
+    std::vector<Delta>  current_assignment;
+    std::vector<Delta>  last_consistent_assignment;
     nat_set     changed_vars_set;
     vec<LVRef>  changed_vars_vec;
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -171,3 +171,11 @@ target_sources(EnodeStoreTest
 
 target_link_libraries(EnodeStoreTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET EnodeStoreTest)
+
+add_executable(VecMoveableTest)
+target_sources(VecMoveableTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_VecMoveable.cc"
+        )
+
+target_link_libraries(VecMoveableTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET VecMoveableTest)

--- a/test/unit/test_Explain.cc
+++ b/test/unit/test_Explain.cc
@@ -9,7 +9,7 @@
 #include <utility>
 
 class UFExplainTest : public ::testing::Test {
-    using PTERef = std::pair<PTRef,ERef>;
+    using PTERef = PTRefERefPair;
     SRef ufsort;
     PTERef makeAndStorePTRef(PTRef tr) { vec<PTERef> v = store.constructTerm(tr); assert(v.size() == 1); return v[0]; }
 
@@ -32,10 +32,10 @@ protected:
 
         SymRef f = logic.declareFun("f", ufsort, {ufsort, ufsort}, nullptr, false);
 
-        f_c1_c0 = makeAndStorePTRef(logic.insertTerm(f, {c1.first, c0.first}));
+        f_c1_c0 = makeAndStorePTRef(logic.insertTerm(f, {c1.tr, c0.tr}));
 
-        f_c2_c0 = makeAndStorePTRef(logic.insertTerm(f, {c2.first, c0.first}));
-        f_f_c2_c0_c0 = makeAndStorePTRef(logic.insertTerm(f, {f_c2_c0.first, c0.first}));
+        f_c2_c0 = makeAndStorePTRef(logic.insertTerm(f, {c2.tr, c0.tr}));
+        f_f_c2_c0_c0 = makeAndStorePTRef(logic.insertTerm(f, {f_c2_c0.tr, c0.tr}));
 
     }
     EnodeStore& getStore() { return store; }
@@ -43,21 +43,21 @@ protected:
 
 TEST_F(UFExplainTest, test_UFExplain) {
 
-    PTRef eq1 = logic.mkEq(c2.first, c1.first);
-    PTRef eq3 = logic.mkEq(f_f_c2_c0_c0.first, c0.first);
-    PTRef eq7 = logic.mkEq(f_c1_c0.first, c1.first);
+    PTRef eq1 = logic.mkEq(c2.tr, c1.tr);
+    PTRef eq3 = logic.mkEq(f_f_c2_c0_c0.tr, c0.tr);
+    PTRef eq7 = logic.mkEq(f_c1_c0.tr, c1.tr);
 
     Explainer explainer(store);
-    explainer.storeExplanation(c2.second, c1.second, {eq1, l_True});
-    explainer.storeExplanation(f_f_c2_c0_c0.second, c0.second, {eq3, l_True});
-    explainer.storeExplanation(c1.second, f_c1_c0.second, {eq7, l_True});
-    explainer.storeExplanation(f_c1_c0.second, f_f_c2_c0_c0.second, PtAsgn_Undef);
-    ASSERT_THROW(explainer.explain(c1.second, f_c2_c0.second), OsmtInternalException);
-    explainer.storeExplanation(f_c2_c0.second, f_c1_c0.second, PtAsgn_Undef);
-    ASSERT_NO_THROW(explainer.explain(c1.second, f_c2_c0.second));
-    ASSERT_NO_THROW(explainer.explain(c2.second, c0.second));
-    std::cout << logic.pp(c2.first) << " = " << logic.pp(c0.first) << ": " << std::endl;
-    for (PtAsgn pta : explainer.explain(c2.second, c0.second)) {
+    explainer.storeExplanation(c2.er, c1.er, {eq1, l_True});
+    explainer.storeExplanation(f_f_c2_c0_c0.er, c0.er, {eq3, l_True});
+    explainer.storeExplanation(c1.er, f_c1_c0.er, {eq7, l_True});
+    explainer.storeExplanation(f_c1_c0.er, f_f_c2_c0_c0.er, PtAsgn_Undef);
+    ASSERT_THROW(explainer.explain(c1.er, f_c2_c0.er), OsmtInternalException);
+    explainer.storeExplanation(f_c2_c0.er, f_c1_c0.er, PtAsgn_Undef);
+    ASSERT_NO_THROW(explainer.explain(c1.er, f_c2_c0.er));
+    ASSERT_NO_THROW(explainer.explain(c2.er, c0.er));
+    std::cout << logic.pp(c2.tr) << " = " << logic.pp(c0.tr) << ": " << std::endl;
+    for (PtAsgn pta : explainer.explain(c2.er, c0.er)) {
         std::cout << "  " << logic.pp(pta.tr) << std::endl;
     }
 

--- a/test/unit/test_Matrix.cpp
+++ b/test/unit/test_Matrix.cpp
@@ -96,11 +96,12 @@ TEST(Matrix_test, vec_creation)
     LAVecStore vecStore(va, logic);
     // INT32_MIN
     Real r {"-2147483648"};
-    vec<Real> reals;
+    std::vector<Real> reals;
+    reals.resize(10);
     for (int i = 0; i < 10; i++) {
-        reals.push_c(Real(i));
+        reals[i] = Real(i);
     }
-    LAVecRef vr = vecStore.getNewVec(reals);
+    LAVecRef vr = vecStore.getNewVec(std::move(reals));
     for (int i = 1; i <= va[vr].size(); i++) {
         ASSERT_EQ(va[vr][i], i-1);
     }

--- a/test/unit/test_Matrix.cpp
+++ b/test/unit/test_Matrix.cpp
@@ -538,7 +538,7 @@ TEST(lcm_test, lcm_list)
     FastRational p2(3, 7);
     FastRational p3(5, 11);
 
-    vec<FastRational> l = {p1, p2, p3};
+    vector<FastRational> l = {p1, p2, p3};
     FastRational r = get_multiplicand(l);
     ASSERT_EQ(r, 385);
 }

--- a/test/unit/test_Matrix.cpp
+++ b/test/unit/test_Matrix.cpp
@@ -539,7 +539,7 @@ TEST(lcm_test, lcm_list)
     FastRational p2(3, 7);
     FastRational p3(5, 11);
 
-    vector<FastRational> l = {p1, p2, p3};
+    std::vector<FastRational> l = {p1, p2, p3};
     FastRational r = get_multiplicand(l);
     ASSERT_EQ(r, 385);
 }

--- a/test/unit/test_Rationals.cpp
+++ b/test/unit/test_Rationals.cpp
@@ -132,16 +132,6 @@ TEST(Rationals_test, test_overwrite)
     r = q;
 }
 
-TEST(Rationals_test, test_unique)
-{
-    vec<Real> v = {1, 1, 2, 3, 3, 4};
-    vec<Real> w = {1, 2, 3, 4};
-    uniq(v);
-    ASSERT_EQ(v.size(), w.size());
-    for (int i = 0; i < v.size(); i++)
-        ASSERT_EQ(v[i], w[i]);
-}
-
 TEST(Rationals_test, test_uword)
 {
     uint32_t x = 2589903246;

--- a/test/unit/test_Rationals.cpp
+++ b/test/unit/test_Rationals.cpp
@@ -229,6 +229,20 @@ TEST(Rationals_test, test_addition)
     }
 }
 
+TEST(Rationals_test, test_multiplicand)
+{
+    {
+        std::vector<FastRational> rs{FastRational(1, 3), FastRational(1, 5), FastRational(1, 6)};
+        FastRational mul = get_multiplicand(rs);
+        ASSERT_EQ(mul, 30);
+    }
+    {
+        std::vector<FastRational> rs{FastRational(1, 3), FastRational(1, 5), FastRational(2, 5)};
+        FastRational mul = get_multiplicand(rs);
+        ASSERT_EQ(mul, 15);
+    }
+}
+
 TEST(Rationals_test, test_subtraction)
 {
     {

--- a/test/unit/test_SubstitutionBreaker.cpp
+++ b/test/unit/test_SubstitutionBreaker.cpp
@@ -69,7 +69,7 @@ TEST(SubstitutionBreaker, test_getLoops) {
     vec<SNRef> startNodes = slb.constructSubstitutionGraph(std::move(substs));
     std::cerr << slb.printGraphAndLoops(startNodes, {}) << std::endl;
     ASSERT_GT(startNodes.size(), 0);
-    vec<vec<SNRef>> loops = slb.findLoops(startNodes);
+    auto loops = slb.findLoops(startNodes);
     ASSERT_EQ(loops.size(), 0); // The system does not remove self-loops
     std::cerr << slb.printGraphAndLoops(startNodes, loops) << std::endl;
 }
@@ -113,7 +113,7 @@ TEST(SubstitutionBreaker, test_getLoops2) {
     SubstLoopBreaker slb(logic);
     vec<SNRef> startNodes = slb.constructSubstitutionGraph(std::move(substs));
     ASSERT_GT(startNodes.size(), 0);
-    vec<vec<SNRef>> loops = slb.findLoops(startNodes);
+    auto loops = slb.findLoops(startNodes);
     ASSERT_EQ(loops.size(), 1);
 }
 
@@ -148,6 +148,6 @@ TEST(SubstitutionBreaker, test_getLoops3) {
     vec<SNRef> startNodes = slb2.constructSubstitutionGraph(std::move(new_substs));
 
     std::cerr << slb2.printGraphAndLoops(startNodes, {}) << std::endl;
-    vec<vec<SNRef>> loops = slb2.findLoops(startNodes);
+    auto loops = slb2.findLoops(startNodes);
     ASSERT_EQ(loops.size(), 0);
 }

--- a/test/unit/test_VecMoveable.cc
+++ b/test/unit/test_VecMoveable.cc
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include <Pterm.h>
+#include <type_traits>
+
+class VecTest: public ::testing::Test {
+public:
+    class Foo {
+        vec<PTLKey> v;
+    };
+    VecTest() {}
+};
+
+TEST_F(VecTest, test_VecMoveable) {
+    ASSERT_FALSE(std::is_trivially_copyable<Foo>());
+}
+


### PR DESCRIPTION
This PR removes undefined behaviour related to our use of `mtl::vec`.  It also fixes problems with indices in for-loops, indentations, and some soundness bugs in code that is currently not used.  The performance is not negatively affected, as can be seen from the scatter plots below (the y-axis commit hashes do not refer to hashes in the current PR because of rebasing, but they should be valid).

### Motivation
The goal of the PR is to allow portability for the new generation of language and compilers.

### Some observations
 - The main difference is the switch from the use of `mtl::vec<T>` to `std::vector<T>` in cases where the stored item is not trivially copyable.  `mtl::vec` uses `realloc` in case it runs out of space, and this is undefined behaviour for objects that are not trivially copyable (see the Notes section in the [c++ reference on realloc](https://en.cppreference.com/w/cpp/memory/c/realloc)).
- While going through the code I noticed some unnecessary copying in the storage implementation.  These are now fixed and might explain some speed-ups in easy instances.
- While I believe that some of the uses of `mtl::vec` are in fact safe because the code logic guarantees that realloc is never called, these cases are nevertheless reported as errors (or warnings) by some compilers (notably g++-9) so I decided to change the code.
- There are some uses of `std::pair` in the code.  `std::pair` is not trivially copyable, so I introduced `opensmt::pair` that is (given that the underlying template classes are), and is now used where necessary.
- In the process I changed MiniSat's `OccList`s to contain `std::vector<Vec>` instead of `mtl::vec<Vec>`.  This must have been anticipated by original developers because of the use of the template `Vec`.  I fixed the issue this way, and the plots below suggest that there is no performance overhead.
 
### plots

- QF_LIA
![non-incremental-QF_LIA-b0153674-2021-01-11_vs_6ee66e86-2021-01-12](https://user-images.githubusercontent.com/8374962/104565149-226cf000-564c-11eb-9242-c9979791a8d8.png)
- QF_LRA
![non-incremental-QF_LRA-b0153674-2021-01-11_vs_a134aa1a-2021-01-11](https://user-images.githubusercontent.com/8374962/104565171-2bf65800-564c-11eb-9238-aa38451fdc8d.png)
- QF_UF
![non-incremental-QF_UF-b0153674-2021-01-11_vs_a134aa1a-2021-01-11](https://user-images.githubusercontent.com/8374962/104565222-416b8200-564c-11eb-9505-12b3fc39e7e4.png)
