### PR TITLE
Fix manipulation with Pterms in Model

### DIFF
--- a/src/models/Model.cc
+++ b/src/models/Model.cc
@@ -23,11 +23,11 @@ PTRef Model::evaluate(PTRef term) {
     }
     else {
         // complex term not seen before, compute and store the value
-        const Pterm & t = logic.getPterm(term);
-        SymRef symbol = t.symb();
+        SymRef symbol = logic.getPterm(term).symb();
+        int size = logic.getPterm(term).size();
         vec<PTRef> nargs;
-        for (int i = 0; i < t.size(); ++i) {
-            PTRef narg = evaluate(t[i]);
+        for (int i = 0; i < size; ++i) {
+            PTRef narg = evaluate(logic.getPterm(term)[i]);
             nargs.push(narg);
         }
         PTRef val = logic.insertTerm(symbol, nargs);


### PR DESCRIPTION
This PR fixes the problem in Modell where a C++ reference to `Pterm` is kept and used in a loop where new terms can be created. This can potentially cause a segmentation fault if reallocation of the term table happens inside the loop.