### PR TITLE
Make the partition information of clauses more explicit.

### DIFF
--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -133,8 +133,8 @@ class MainSolver
     sstat simplifyFormulas(char** msg);
     sstat solve           ();
 
-    sstat giveToSolver(PTRef root, FrameId push_id) {
-        if (ts.cnfizeAndGiveToSolver(root, push_id) == l_False) return s_False;
+    sstat giveToSolver(PTRef root, FrameId push_id, PartIdx partitionIndex) {
+        if (ts.cnfizeAndGiveToSolver(root, push_id, partitionIndex) == l_False) return s_False;
         return s_Undef; }
 
     PTRef rewriteMaxArity(PTRef);

--- a/src/api/PartitionManager.h
+++ b/src/api/PartitionManager.h
@@ -58,7 +58,7 @@ public:
         partitionInfo.transferPartitionMembership(old, new_ptref);
     }
 
-    int getPartitionIndex(PTRef ref) const {
+    PartIdx getPartitionIndex(PTRef ref) const {
         return partitionInfo.getPartitionIndex(ref);
     }
 };

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -74,7 +74,7 @@ public:
 
     virtual ~Cnfizer( ) { }
 
-    lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id); // Main routine
+    lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id, PartIdx partitionIndex); // Main routine
 
     lbool  getTermValue(PTRef) const;
 
@@ -86,9 +86,9 @@ public:
 
 protected:
 
-    virtual bool cnfizeAndAssert        ( PTRef );       // Cnfize and assert the top-level.
-    virtual bool cnfize                 ( PTRef ) = 0;   // Actual cnfization. To be implemented in derived classes
-    bool     deMorganize                ( PTRef );       // Apply deMorgan rules whenever feasible
+    virtual bool cnfizeAndAssert        ( PTRef, PartIdx partitionIndex );       // Cnfize and assert the top-level.
+    virtual bool cnfize                 ( PTRef, PartIdx partitionIndex ) = 0;   // Actual cnfization. To be implemented in derived classes
+    bool     deMorganize                ( PTRef, PartIdx partitionIndex );       // Apply deMorgan rules whenever feasible
     void     declareVars                (vec<PTRef>&);   // Declare a set of Boolean atoms to the solver (without asserting them)
 
 public:
@@ -98,10 +98,10 @@ public:
     void     retrieveTopLevelFormulae   ( PTRef, vec<PTRef> & );         // Retrieves the list of top-level formulae
 protected:
 
-    bool     giveToSolver               ( PTRef );                              // Gives formula to the SAT solver
+    bool     giveToSolver               ( PTRef, PartIdx partitionIndex );        // Gives formula to the SAT solver
 
 
-    bool addClause(const vec<Lit> &);
+    bool addClause(const vec<Lit> &, PartIdx partitionIndex);
 
     void  retrieveClause             ( PTRef, vec<PTRef> & );         // Retrieve a clause from a formula
     void  retrieveConjuncts          ( PTRef, vec<PTRef> & );         // Retrieve the list of conjuncts

--- a/src/cnfizers/Tseitin.h
+++ b/src/cnfizers/Tseitin.h
@@ -55,13 +55,13 @@ private:
     // Cache of already cnfized terms. Note that this is different from Cnfizer cache of already processed top-level flas
     Cache alreadyCnfized;
 
-    bool cnfize             (PTRef);                          // Cnfize the given term
-    bool cnfizeAnd          (PTRef);                          // Cnfize conjunctions
-    bool cnfizeOr           (PTRef);                          // Cnfize disjunctions
-    bool cnfizeIff          (PTRef);                          // Cnfize iffs
-    bool cnfizeXor          (PTRef);                          // Cnfize xors
-    bool cnfizeIfthenelse   (PTRef);                          // Cnfize if then elses
-    bool cnfizeImplies      (PTRef);                          // Cnfize if then elses
+    bool cnfize             (PTRef, PartIdx);                          // Cnfize the given term
+    bool cnfizeAnd          (PTRef, PartIdx);                          // Cnfize conjunctions
+    bool cnfizeOr           (PTRef, PartIdx);                          // Cnfize disjunctions
+    bool cnfizeIff          (PTRef, PartIdx);                          // Cnfize iffs
+    bool cnfizeXor          (PTRef, PartIdx);                          // Cnfize xors
+    bool cnfizeIfthenelse   (PTRef, PartIdx);                          // Cnfize if then elses
+    bool cnfizeImplies      (PTRef, PartIdx);                          // Cnfize if then elses
 //    void copyArgsWithCache(PTRef, vec<PTRef>&, Map<PTRef, PTRef, PTRefHash>&);
 };
 

--- a/src/common/FlaPartitionMap.cc
+++ b/src/common/FlaPartitionMap.cc
@@ -25,14 +25,14 @@ void FlaPartitionMap::transferPartitionMembership(PTRef old, PTRef new_ptref) {
     }
 }
 
-int FlaPartitionMap::getPartitionIndex(PTRef ref) const {
+PartIdx FlaPartitionMap::getPartitionIndex(PTRef ref) const {
     auto it = top_level_flas.find(ref);
     if (it != top_level_flas.end()) {
-        return static_cast<int>(it->second);
+        return PartIdx{static_cast<int>(it->second)};
     }
     auto other_it = other_flas.find(ref);
     if (other_it != other_flas.end()) {
-        return static_cast<int>(other_it->second);
+        return PartIdx{static_cast<int>(other_it->second)};
     }
-    return -1;
+    return PartIdx_Undef;
 }

--- a/src/common/FlaPartitionMap.h
+++ b/src/common/FlaPartitionMap.h
@@ -10,6 +10,14 @@
 #include <map>
 #include <vector>
 
+struct PartIdx {
+    int id;
+    bool operator== (const PartIdx o) const { return o.id == id; }
+    bool operator!= (const PartIdx o) const { return o.id != id; }
+};
+const struct PartIdx PartIdx_Default = {0};
+const struct PartIdx PartIdx_Undef   = {INT32_MAX};
+
 class FlaPartitionMap {
     std::map<PTRef, unsigned int> top_level_flas;
     std::map<PTRef, unsigned int> other_flas;
@@ -20,7 +28,7 @@ public:
     std::vector<PTRef> get_top_level_flas () const;
     unsigned getNoOfPartitions() const {return get_top_level_flas().size();}
     void transferPartitionMembership(PTRef old, PTRef new_ptref);
-    int getPartitionIndex(PTRef ref) const;
+    PartIdx getPartitionIndex(PTRef ref) const;
 };
 
 

--- a/src/common/PartitionInfo.h
+++ b/src/common/PartitionInfo.h
@@ -29,7 +29,7 @@ public:
     inline std::vector<PTRef> getTopLevelFormulas() const { return flaPartitionMap.get_top_level_flas(); }
     inline unsigned int getNoOfPartitions() const {return flaPartitionMap.getNoOfPartitions(); }
     inline void transferPartitionMembership(PTRef o, PTRef n) { return flaPartitionMap.transferPartitionMembership(o, n); }
-    inline int getPartitionIndex(PTRef p) const { return flaPartitionMap.getPartitionIndex(p); }
+    inline PartIdx getPartitionIndex(PTRef p) const { return flaPartitionMap.getPartitionIndex(p); }
 
     void invalidatePartitions(ipartitions_t const & p);
 };

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -269,7 +269,7 @@ Var CoreSMTSolver::newVar(bool sign, bool dvar)
     return v;
 }
 
-bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps)
+bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps, PartIdx partitionIndex)
 {
     assert(decisionLevel() == 0);
     if (!isOK()) { return false; }
@@ -309,7 +309,7 @@ bool CoreSMTSolver::addOriginalClause_(const vec<Lit> & _ps)
         CRef inputClause = ca.alloc(original, false);
         clauseToInsert = resolvedUnits.empty() ? inputClause :
                 ps.size() == 0 ? CRef_Undef : ca.alloc(ps, false);
-        proof->newOriginalClause(inputClause);
+        proof->newOriginalClause(inputClause, partitionIndex);
         if (!resolvedUnits.empty()) {
             proof->beginChain( inputClause );
             for(Lit l : resolvedUnits) {
@@ -1033,12 +1033,6 @@ void CoreSMTSolver::finalizeProof(CRef finalConflict) {
         proof->addResolutionStep(unitReason, varToResolve);
     }
     proof->endChain(CRef_Undef);
-}
-
-void CoreSMTSolver::setPartition(std::size_t partitionIndex) {
-    if (proof) {
-        proof->setPartition(partitionIndex);
-    }
 }
 
 /*_________________________________________________________________________________________________
@@ -2165,7 +2159,7 @@ bool CoreSMTSolver::createSplit_scatter(bool last)
 
 bool CoreSMTSolver::excludeAssumptions(vec<Lit>& neg_constrs)
 {
-    addOriginalClause(neg_constrs);
+    addOriginalClause(neg_constrs, PartIdx_Undef);
     simplify();
     return ok;
 }

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -248,13 +248,13 @@ protected:
     virtual Var newVar(bool polarity, bool dvar);//    (bool polarity = true, bool dvar = true); // Add a new variable with parameters specifying variable mode.
 public:
     void    addVar(Var v); // Anounce the existence of a variable to the solver
-    bool    addOriginalClause(const vec<Lit> & ps);
+    bool    addOriginalClause(const vec<Lit> & ps, PartIdx partitionIndex);
     bool    addEmptyClause();                                   // Add the empty clause, making the solver contradictory.
-    bool    addOriginalClause(Lit p);                                  // Add a unit clause to the solver.
-    bool    addOriginalClause(Lit p, Lit q);                           // Add a binary clause to the solver.
-    bool    addOriginalClause(Lit p, Lit q, Lit r);                    // Add a ternary clause to the solver.
+    bool    addOriginalClause(Lit p, PartIdx partitionIndex);       // Add a unit clause to the solver.
+    bool    addOriginalClause(Lit p, Lit q, PartIdx partitionIndex);// Add a binary clause to the solver.
+    bool    addOriginalClause(Lit p, Lit q, Lit r, PartIdx partitionIndex);// Add a ternary clause to the solver.
 protected:
-    bool addOriginalClause_(const vec<Lit> & _ps);                                          // Add a clause to the solver
+    bool addOriginalClause_(const vec<Lit> & _ps, PartIdx partitionIndex); // Add a clause to the solver
 public:
     // Solving:
     //
@@ -754,7 +754,6 @@ protected:
 public:
 
     void    printTrace() const;
-    void    setPartition(std::size_t partitionIndex);
 
 protected:
     virtual inline void clausesPublish() {};
@@ -844,35 +843,35 @@ inline bool     CoreSMTSolver::enqueue         (Lit p, CRef from)
     return value(p) != l_Undef ? value(p) != l_False : (uncheckedEnqueue(p, from), true);
 }
 
-inline bool     CoreSMTSolver::addOriginalClause(const vec<Lit> & ps)
+inline bool     CoreSMTSolver::addOriginalClause(const vec<Lit> & ps, PartIdx partitionIndex)
 {
-    return addOriginalClause_(ps);
+    return addOriginalClause_(ps, partitionIndex);
 }
 inline bool     CoreSMTSolver::addEmptyClause  ()
 {
     add_tmp.clear();
-    return addOriginalClause_(add_tmp);
+    return addOriginalClause_(add_tmp, PartIdx_Default);
 }
-inline bool     CoreSMTSolver::addOriginalClause(Lit p)
+inline bool     CoreSMTSolver::addOriginalClause(Lit p, PartIdx partitionIndex)
 {
     add_tmp.clear();
     add_tmp.push(p);
-    return addOriginalClause_(add_tmp);
+    return addOriginalClause_(add_tmp, partitionIndex);
 }
-inline bool     CoreSMTSolver::addOriginalClause(Lit p, Lit q)
+inline bool     CoreSMTSolver::addOriginalClause(Lit p, Lit q, PartIdx partitionIndex)
 {
     add_tmp.clear();
     add_tmp.push(p);
     add_tmp.push(q);
-    return addOriginalClause_(add_tmp);
+    return addOriginalClause_(add_tmp, partitionIndex);
 }
-inline bool     CoreSMTSolver::addOriginalClause(Lit p, Lit q, Lit r)
+inline bool     CoreSMTSolver::addOriginalClause(Lit p, Lit q, Lit r, PartIdx partitionIndex)
 {
     add_tmp.clear();
     add_tmp.push(p);
     add_tmp.push(q);
     add_tmp.push(r);
-    return addOriginalClause_(add_tmp);
+    return addOriginalClause_(add_tmp, partitionIndex);
 }
 
 

--- a/src/smtsolvers/Proof.cc
+++ b/src/smtsolvers/Proof.cc
@@ -35,11 +35,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   , cl_al		( cl )
 { }
 
-void Proof::newOriginalClause(CRef c) {
-    assert(currentPartition != static_cast<std::size_t>(-1));
+void Proof::newOriginalClause(CRef c, PartIdx partitionIndex) {
+    assert(partitionIndex != PartIdx_Undef);
     newLeafClause(c, clause_type::CLA_ORIG);
     ipartitions_t partition = 0;
-    setbit(partition, currentPartition);
+    setbit(partition, partitionIndex.id);
     clause_class[c] |= partition;
 }
 

--- a/src/smtsolvers/Proof.h
+++ b/src/smtsolvers/Proof.h
@@ -31,6 +31,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <unordered_map>
 #include <iosfwd>
 #include <functional>
+#include "FlaPartitionMap.h"
 
 //=================================================================================================
 
@@ -90,19 +91,16 @@ class Proof
     ClauseAllocator&            cl_al;
     std::unordered_map<Lit, CRef, LitHash> assumed_literals;
     std::unordered_map<CRef, ipartitions_t> clause_class;
-    std::size_t currentPartition = 0;
 
 public:
 
     Proof ( ClauseAllocator& cl );
     ~Proof( ) = default;
 
-    void setPartition(std::size_t partition) { currentPartition = partition; }
-
     ipartitions_t getClauseClassMask(CRef c) const { assert(clause_class.count(c) != 0); return clause_class.at(c); }
 
     // Notifies the proof about a new original clause.
-    void newOriginalClause(CRef c);
+    void newOriginalClause(CRef c, PartIdx partitionIndex);
 
     // Notifies the proof about a new T-clause.
     void newTheoryClause(CRef c) { newLeafClause(c, clause_type::CLA_THEORY); }

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -184,7 +184,7 @@ skip_theory_preproc:
 //=================================================================================================
 // Added code
 
-bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause)
+bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause, PartIdx partitionIndex)
 {
     assert( config.sat_preprocess_theory == 0 );
 
@@ -212,7 +212,7 @@ bool SimpSMTSolver::addOriginalSMTClause(const vec<Lit> & smt_clause)
         cerr << "XXX skipped handling of unary theory literal?" << endl;
     }
     int nclauses = clauses.size();
-    if (!CoreSMTSolver::addOriginalClause_(smt_clause))
+    if (!CoreSMTSolver::addOriginalClause_(smt_clause, partitionIndex))
         return false;
 
     if (use_simplification && clauses.size() == nclauses + 1)
@@ -621,7 +621,7 @@ bool SimpSMTSolver::eliminateVar(Var v)
     vec<Lit>& resolvent = add_tmp;
     for (int i = 0; i < pos.size(); i++) {
         for (int j = 0; j < neg.size(); j++) {
-            if (merge(ca[pos[i]], ca[neg[j]], v, resolvent) && !addOriginalSMTClause(resolvent))
+            if (merge(ca[pos[i]], ca[neg[j]], v, resolvent) && !addOriginalSMTClause(resolvent, PartIdx_Undef))
                 return false;
         }
     }
@@ -663,7 +663,7 @@ bool SimpSMTSolver::substitute(Var v, Lit x)
 
         removeClause(cls[i]);
 
-        if (!addOriginalSMTClause(subst_clause))
+        if (!addOriginalSMTClause(subst_clause, PartIdx_Undef))
             return ok = false;
     }
 

--- a/src/smtsolvers/SimpSMTSolver.h
+++ b/src/smtsolvers/SimpSMTSolver.h
@@ -63,7 +63,7 @@ class SimpSMTSolver : public CoreSMTSolver
     //
     Var     newVar    (bool polarity = true, bool dvar = true) override;
 
-    bool addOriginalSMTClause(const vec<Lit> & smt_clause);
+    bool addOriginalSMTClause(const vec<Lit> & smt_clause, PartIdx partitionIndex);
 public:
 
     bool    substitute(Var v, Lit x);  // Replace all occurences of v with x (may cause a contradiction).

--- a/src/tsolvers/bvsolver/BitBlaster.cc
+++ b/src/tsolvers/bvsolver/BitBlaster.cc
@@ -1466,7 +1466,7 @@ BitBlaster::bbDistinct(PTRef tr)
 bool
 BitBlaster::addClause(vec<Lit> & c)
 {
-    return solverP.addOriginalClause(c);
+    return solverP.addOriginalClause(c, PartIdx_Undef);
 }
 
 //=============================================================================


### PR DESCRIPTION
A suggestion on how to avoid coupling the partition to the solver when clauses are inserted.