### PR TITLE
Do not copy termColors in iteration

### DIFF
--- a/src/smtsolvers/TheoryInterpolator.h
+++ b/src/smtsolvers/TheoryInterpolator.h
@@ -111,7 +111,7 @@ private:
         }
         // Make sure complex terms have correct color assigned
         vec<PTRef> terms;
-        for (auto const entry : termColors) {
+        for (auto const & entry : termColors) {
             PTRef term = entry.first;
             if (entry.second != I_AB and (logic.isUF(term) or logic.isUP(term)) and
                 symbolColors.at(logic.getSymRef(term)) == I_AB) {


### PR DESCRIPTION
Apple clang version 12.0.0 complains that currently the iterator in question needs to copy a value.  I believe that's correct.  This PR fixes the iteration to use const & instead of copying.