### PR TITLE
Avoid unnecessary allocations and deallocation of GNU MPs

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -184,16 +184,21 @@ private:
             setMpqMemoryAllocated();
         }
     }
+
+    bool fitsWord() const
+    {
+        assert(not wordPartValid() and mpqPartValid()); // Do not call this method if word part is already valid
+        return mpz_fits_sint_p(mpq_numref(mpq)) and mpz_fits_uint_p(mpq_denref(mpq));
+    }
+
     //
     // Tries to convert the current rational
     // stored in mpq into word/uword
     //
     void try_fit_word()
     {
-        assert( mpqPartValid() );
-        assert(!wordPartValid()); // MB: It does not make sense to call this method if word is valid
-        if ( mpz_fits_sint_p(mpq_numref(mpq))
-             && mpz_fits_uint_p(mpq_denref(mpq))) {
+        assert(not wordPartValid() and mpqPartValid()); // Do not call this method if word part is already valid
+        if (fitsWord()) {
             num = mpz_get_si(mpq_numref(mpq));
             den = mpz_get_ui(mpq_denref(mpq));
             setWordPartValid();
@@ -379,16 +384,15 @@ public:
         return *this;
     }
     inline FastRational inverse() const;
+
     bool isZero() const {
-        if (wordPartValid()) {
-            return num==0;
-        } else {
-            return mpq_sgn(mpq)==0;
-        }
+        assert(wordPartValid() or not fitsWord());
+        return wordPartValid() and num == 0;
     }
 
-    bool isOneHeuristic() const {
-         return wordPartValid() && num == 1 && den == 1;
+    bool isOne() const {
+        assert(wordPartValid() or not fitsWord());
+        return wordPartValid() && num == 1 && den == 1;
     }
 
 

--- a/src/tsolvers/lasolver/Delta.h
+++ b/src/tsolvers/lasolver/Delta.h
@@ -51,6 +51,7 @@ public:
     inline Delta();                               // Same as Delta(UPPER)
     inline Delta(const Real & v);                // Constructor for Real delta
     inline Delta(const Real & v, const Real & d); // Constructor for Real delta with strict part
+    inline Delta(Real && v, Real && d);          // Constructor for Real delta with strict part
     inline Delta(const Delta & a);               // Copy constructor
     inline ~Delta();                             // Destructor
 
@@ -256,6 +257,8 @@ Delta::Delta(const Real & v) : r{v}, d{0} {}
 // Constructor for Real delta with strict bit
 //
 Delta::Delta(const Real & v_r, const Real & v_d) : r{v_r}, d{v_d} {}
+
+Delta::Delta(Real && v_r, Real && v_d) : r{std::move(v_r)}, d{std::move(v_d)} { }
 
 
 //

--- a/src/tsolvers/lasolver/Delta.h
+++ b/src/tsolvers/lasolver/Delta.h
@@ -100,7 +100,8 @@ public:
     inline friend bool operator>=(const Real & c, const Delta & a);
 
     // Arithmetic overloadings
-    inline friend Delta operator+=(Delta & a, const Delta & b);
+    Delta& operator+=(const Delta & b);
+    Delta& operator+=(Delta && b);
 
     inline friend Delta operator-=(Delta & a, const Delta & b);
 
@@ -140,10 +141,16 @@ bool Delta::hasDelta() const {
 }
 
 // Arithmetic operators definitions.
-Delta operator+=(Delta & a, const Delta & b) {
-    a.r += b.R();
-    a.d += b.D();
-    return a;
+inline Delta& Delta::operator+=(const Delta & b) {
+    this->r += b.R();
+    this->d += b.D();
+    return *this;
+}
+
+inline Delta& Delta::operator+=(Delta && b) {
+    this->r += std::move(b.r);
+    this->d += std::move(b.d);
+    return *this;
 }
 
 Delta operator-=(Delta & a, const Delta & b) {

--- a/src/tsolvers/lasolver/Delta.h
+++ b/src/tsolvers/lasolver/Delta.h
@@ -100,10 +100,11 @@ public:
     inline friend bool operator>=(const Real & c, const Delta & a);
 
     // Arithmetic overloadings
-    Delta& operator+=(const Delta & b);
+    Delta& operator+=(Delta const & b);
     Delta& operator+=(Delta && b);
 
-    inline friend Delta operator-=(Delta & a, const Delta & b);
+    Delta& operator-=(Delta const & b);
+    Delta& operator-=(Delta && b);
 
     inline friend Delta operator-(const Delta & a, const Delta & b);
 
@@ -153,10 +154,16 @@ inline Delta& Delta::operator+=(Delta && b) {
     return *this;
 }
 
-Delta operator-=(Delta & a, const Delta & b) {
-    a.r -= b.R();
-    a.d -= b.D();
-    return a;
+inline Delta& Delta::operator-=(Delta const & b) {
+    this->r -= b.R();
+    this->d -= b.D();
+    return *this;
+}
+
+inline Delta& Delta::operator-=(Delta && b) {
+    this->r -= std::move(b.R());
+    this->d -= std::move(b.D());
+    return *this;
 }
 
 Delta operator-(const Delta & a, const Delta & b) {

--- a/src/tsolvers/lasolver/Polynomial.h
+++ b/src/tsolvers/lasolver/Polynomial.h
@@ -87,6 +87,7 @@ void Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, ADD 
     auto myEnd = std::make_move_iterator(poly.end());
     auto otherEnd = other.poly.cend();
     TermCmp cmp;
+    FastRational tmp;
     while(true) {
         if (myIt == myEnd) {
             for (auto it = otherIt; it != otherEnd; ++it) {
@@ -110,13 +111,13 @@ void Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, ADD 
         }
         else {
             assert(myIt->var == otherIt->var);
-            auto mergedCoeff = otherIt->coeff * coeff;
-            mergedCoeff += myIt->coeff;
-            if (mergedCoeff.isZero()) {
+            multiplication(tmp, otherIt->coeff, coeff);
+            myIt->coeff += tmp;
+            if (myIt->coeff.isZero()) {
                 informRemoved(myIt->var);
             }
             else {
-                storage.emplace_back(myIt->var, std::move(mergedCoeff));
+                storage.emplace_back(*myIt);
             }
             ++myIt;
             ++otherIt;

--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -17,10 +17,6 @@ namespace {
     inline bool contains(const C & container, const E & elem){
         return container.find(elem) != container.end();
     }
-
-    inline bool isOne(const opensmt::Real & r){
-        return r == 1;
-    }
 }
 
 void Tableau::nonbasicVar(LVRef v) {
@@ -131,13 +127,11 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
     {
         Polynomial & nvPoly = getRowPoly(bv);
         const auto coeff = nvPoly.removeVar(nv);
-        Real bvCoeff{1};
-        if (!isOne(coeff)) {
+        if (not coeff.isOneHeuristic()) {
             nvPoly.divideBy(coeff);
-            bvCoeff /= coeff;
         }
         nvPoly.negate();
-        nvPoly.addTerm(bv, bvCoeff);
+        nvPoly.addTerm(bv, coeff.inverse());
     }
 
     // remove row for bv, add row for nv

--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -127,7 +127,7 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
     {
         Polynomial & nvPoly = getRowPoly(bv);
         const auto coeff = nvPoly.removeVar(nv);
-        if (not coeff.isOneHeuristic()) {
+        if (not coeff.isOne()) {
             nvPoly.divideBy(coeff);
         }
         nvPoly.negate();

--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -255,21 +255,21 @@ bool Tableau::checkConsistency() const {
 void Tableau::normalizeRow(LVRef v) {
     assert(isQuasiBasic(v)); // Do not call this for non quasi rows
     Polynomial & row = getRowPoly(v);
-    std::vector<Polynomial::Term> toEliminate;
+    std::vector<Polynomial::Term const*> toEliminate;
     for (auto const & term : row) {
         if (isQuasiBasic(term.var)) {
             normalizeRow(term.var);
-            toEliminate.push_back(term);
+            toEliminate.push_back(&term);
         }
         if (isBasic(term.var)) {
-            toEliminate.push_back(term);
+            toEliminate.push_back(&term);
         }
     }
     if (!toEliminate.empty()) {
         Polynomial p;
-        for (auto & term : toEliminate) {
-            p.merge(getRowPoly(term.var), term.coeff, [](LVRef) {}, [](LVRef) {});
-            p.addTerm(term.var, -term.coeff);
+        for (auto const* term : toEliminate) {
+            p.merge(getRowPoly(term->var), term->coeff, [](LVRef) {}, [](LVRef) {});
+            p.addTerm(term->var, -term->coeff);
         }
         row.merge(p, 1, [](LVRef) {}, [](LVRef) {});
     }


### PR DESCRIPTION
Playing with [heaptrack](https://github.com/KDE/heaptrack) I noticed that when we need to fall back to `mpq` representation of rationals, OpenSMT makes a huge amount of small allocations and deallocations related to handling this representation.

While trying to investigate that, I found a couple of places in the code where we make unnecessary copies of `FastRationals` or create unnecessary temporaries. This PR proposes some changes to avoid that.