### PR TITLE
Small refactoring of Logic::isLit

### DIFF
--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -297,7 +297,7 @@ bool Cnfizer::checkCnf (PTRef formula)
 
 bool Cnfizer::checkConj (PTRef e)
 {
-    if (logic.isLit (e)) // A Boolean constant
+    if (isLiteral(e)) // A Boolean constant
         return true;
 
     Pterm &and_t = logic.getPterm (e);
@@ -409,7 +409,7 @@ bool Cnfizer::checkPureConj (PTRef e, Map<PTRef, bool, PTRefHash, Equal<PTRef> >
         if (logic.isAnd (e))
             for (int i = 0; i < and_t.size(); i++)
                 to_process.push (and_t[i]);
-        else if (!logic.isLit (e))
+        else if (!isLiteral(e))
             return false;
 
         check_cache.insert (e, true);
@@ -464,7 +464,7 @@ bool Cnfizer::giveToSolver ( PTRef f )
     //
     // A unit clause
     //
-    if (logic.isLit (f))
+    if (isLiteral(f))
     {
         clause.push (this->getOrCreateLiteralFor (f));
         return addClause(clause);
@@ -532,9 +532,9 @@ void Cnfizer::retrieveTopLevelFormulae (PTRef root, vec<PTRef> &top_level_formul
 //
 void Cnfizer::retrieveClause ( PTRef f, vec<PTRef> &clause )
 {
-    assert (logic.isLit (f) || logic.isOr (f));
+    assert (isLiteral(f) || logic.isOr (f));
 
-    if ( logic.isLit (f) )
+    if (isLiteral(f))
         clause.push (f);
     else if ( logic.isOr (f) )
     {
@@ -550,9 +550,9 @@ void Cnfizer::retrieveClause ( PTRef f, vec<PTRef> &clause )
 //
 void Cnfizer::retrieveConjuncts ( PTRef f, vec<PTRef> &conjuncts )
 {
-    assert (logic.isLit (f) || logic.isAnd (f));
+    assert (isLiteral(f) || logic.isAnd (f));
 
-    if (logic.isLit (f))
+    if (isLiteral(f))
         conjuncts.push (f);
     else
     {
@@ -585,4 +585,8 @@ bool Cnfizer::Cache::contains(PTRef term, PTRef frame_term) {
 void Cnfizer::Cache::insert(PTRef term, PTRef frame_term) {
     assert(!contains(term, frame_term));
     cache.insert(std::make_pair<>(term, frame_term));
+}
+
+bool Cnfizer::isLiteral(PTRef ptr) const {
+    return (logic.isNot(ptr) and logic.isAtom(logic.getPterm(ptr)[0])) or logic.isAtom(ptr);
 }

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -116,6 +116,7 @@ private:
     bool    checkPureConj        (PTRef, Map<PTRef,bool,PTRefHash>& check_cache); // Check if a formula is purely a conjuntion
 
 protected:
+    bool isLiteral(PTRef ptr) const;
     inline Lit getOrCreateLiteralFor(PTRef ptr) {return this->tmap.getOrCreateLit(ptr);}
     inline vec<PTRef> getNestedBoolRoots(PTRef ptr) { return logic.getNestedBoolRoots(ptr); }
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -943,12 +943,6 @@ PTRef Logic::mkBoolVar(const char* name)
     return tr;
 }
 
-// A term is literal if it is an atom or a negation of an atom
-bool Logic::isLit(PTRef tr) const
-{
-    return (isNot(tr) and isAtom(getPterm(tr)[0])) or isAtom(tr);
-}
-
 SRef Logic::declareSort(const char* id, char** msg)
 {
     if (containsSort(id)) {

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -379,8 +379,6 @@ class Logic {
     bool        isIff(SymRef sr) const;// { return sr == getSym_eq(); }
     bool        isIff(PTRef tr) const;// { return isIff(getPterm(tr).symb()); }
 
-    bool        isLit(PTRef tr) const;
-
 
     bool        hasSortBool(PTRef tr) const;// { return sym_store[getPterm(tr).symb()].rsort() == sort_BOOL; }
     bool        hasSortBool(SymRef sr) const;// { return sym_store[sr].rsort() == sort_BOOL; }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -90,7 +90,7 @@ add_executable(LogicMkTermsTest)
 target_sources(LogicMkTermsTest
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LogicMkTerms.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LIALogicMkTerms.cc"
-    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LRALogicMkTerms.cpp"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LRALogicMkTerms.cc"
     )
 
 target_link_libraries(LogicMkTermsTest OpenSMT gtest gtest_main)

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -225,22 +225,3 @@ TEST_F(LRALogicMkTermsTest, testAtom_LRA) {
     EXPECT_FALSE(logic.isAtom(product));
 }
 
-TEST_F(LRALogicMkTermsTest, testLiteral_LRA) {
-    PTRef ineq = logic.mkNumLeq(x, logic.getTerm_NumZero());
-    EXPECT_TRUE(logic.isLit(ineq));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(ineq)));
-
-    PTRef strict = logic.mkNumLt(x, logic.getTerm_NumZero());
-    EXPECT_TRUE(logic.isLit(strict));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(strict)));
-
-    PTRef eq = logic.mkEq(x, logic.getTerm_NumZero());
-    EXPECT_TRUE(logic.isLit(eq));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(eq)));
-
-    PTRef sum = logic.mkNumPlus(x,y);
-    EXPECT_FALSE(logic.isLit(sum));
-    PTRef product = logic.mkNumTimes(x, logic.mkConst(2));
-    EXPECT_FALSE(logic.isLit(product));
-}
-

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -206,3 +206,41 @@ TEST_F(LRALogicMkTermsTest, test_Inequality_Simplification)
     );
 }
 
+TEST_F(LRALogicMkTermsTest, testAtom_LRA) {
+    PTRef ineq = logic.mkNumLeq(x, logic.getTerm_NumZero());
+    EXPECT_TRUE(logic.isAtom(ineq));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(ineq)));
+
+    PTRef strict = logic.mkNumLt(x, logic.getTerm_NumZero());
+    EXPECT_FALSE(logic.isAtom(strict));
+    EXPECT_TRUE(logic.isAtom(logic.mkNot(strict)));
+
+    PTRef eq = logic.mkEq(x, logic.getTerm_NumZero());
+    EXPECT_TRUE(logic.isAtom(eq));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(eq)));
+
+    PTRef sum = logic.mkNumPlus(x,y);
+    EXPECT_FALSE(logic.isAtom(sum));
+    PTRef product = logic.mkNumTimes(x, logic.mkConst(2));
+    EXPECT_FALSE(logic.isAtom(product));
+}
+
+TEST_F(LRALogicMkTermsTest, testLiteral_LRA) {
+    PTRef ineq = logic.mkNumLeq(x, logic.getTerm_NumZero());
+    EXPECT_TRUE(logic.isLit(ineq));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(ineq)));
+
+    PTRef strict = logic.mkNumLt(x, logic.getTerm_NumZero());
+    EXPECT_TRUE(logic.isLit(strict));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(strict)));
+
+    PTRef eq = logic.mkEq(x, logic.getTerm_NumZero());
+    EXPECT_TRUE(logic.isLit(eq));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(eq)));
+
+    PTRef sum = logic.mkNumPlus(x,y);
+    EXPECT_FALSE(logic.isLit(sum));
+    PTRef product = logic.mkNumTimes(x, logic.mkConst(2));
+    EXPECT_FALSE(logic.isLit(product));
+}
+

--- a/test/unit/test_LogicMkTerms.cc
+++ b/test/unit/test_LogicMkTerms.cc
@@ -152,3 +152,84 @@ TEST_F(LogicMkTermsTest, testUniqueAbstractValue) {
     PTRef uniq2 = logic.mkUniqueAbstractValue(logic.getSort_bool());
     ASSERT_NE(uniq1, uniq2);
 }
+
+TEST_F(LogicMkTermsTest, testAtom_Bool) {
+    PTRef a = logic.mkBoolVar("a");
+    PTRef b = logic.mkBoolVar("b");
+    PTRef c = logic.mkBoolVar("c");
+    EXPECT_TRUE(logic.isAtom(a));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(a)));
+
+    EXPECT_FALSE(logic.isAtom(logic.mkAnd(a,b)));
+    EXPECT_FALSE(logic.isAtom(logic.mkOr(a,b)));
+    EXPECT_FALSE(logic.isAtom(logic.mkXor(a,b)));
+    EXPECT_FALSE(logic.isAtom(logic.mkImpl(a,b)));
+    // Boolean equivalence is not considered an atom!
+    EXPECT_FALSE(logic.isAtom(logic.mkEq(a,b)));
+    // Boolean ITE is not considered an atom!
+    EXPECT_FALSE(logic.isAtom(logic.mkIte(c,a,b)));
+
+    EXPECT_TRUE(logic.isAtom(logic.getTerm_true()));
+    EXPECT_TRUE(logic.isAtom(logic.getTerm_false()));
+}
+
+TEST_F(LogicMkTermsTest, testLiteral_Bool) {
+    PTRef a = logic.mkBoolVar("a");
+    PTRef b = logic.mkBoolVar("b");
+    PTRef c = logic.mkBoolVar("c");
+    EXPECT_TRUE(logic.isLit(a));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(a)));
+
+    EXPECT_FALSE(logic.isLit(logic.mkAnd(a,b)));
+    EXPECT_FALSE(logic.isLit(logic.mkOr(a,b)));
+    EXPECT_FALSE(logic.isLit(logic.mkImpl(a,b)));
+    EXPECT_FALSE(logic.isLit(logic.mkEq(a,b)));
+    EXPECT_FALSE(logic.isLit(logic.mkIte(c,a,b)));
+
+    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkAnd(a,b))));
+    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkOr(a,b))));
+    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkImpl(a,b))));
+    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkEq(a,b))));
+    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkIte(c,a,b))));
+
+    EXPECT_TRUE(logic.isLit(logic.getTerm_true()));
+    EXPECT_TRUE(logic.isLit(logic.getTerm_false()));
+}
+
+TEST_F(LogicMkTermsTest, testAtom_UF) {
+    SRef sref = logic.declareSort("U", nullptr);
+    PTRef a = logic.mkVar(sref, "a");
+    PTRef b = logic.mkVar(sref, "b");
+    PTRef c = logic.mkVar(sref, "c");
+    PTRef eq = logic.mkEq(a,b);
+    PTRef dist = logic.mkDistinct({a,b,c});
+    EXPECT_TRUE(logic.isAtom(eq));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(eq)));
+
+    EXPECT_TRUE(logic.isAtom(dist));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(dist)));
+
+    SymRef predicate = logic.declareFun("p", logic.getSort_bool(), {sref}, nullptr);
+    PTRef pa = logic.mkUninterpFun(predicate, {a});
+    EXPECT_TRUE(logic.isAtom(pa));
+    EXPECT_FALSE(logic.isAtom(logic.mkNot(pa)));
+}
+
+TEST_F(LogicMkTermsTest, testLiteral_UF) {
+    SRef sref = logic.declareSort("U", nullptr);
+    PTRef a = logic.mkVar(sref, "a");
+    PTRef b = logic.mkVar(sref, "b");
+    PTRef c = logic.mkVar(sref, "c");
+    PTRef eq = logic.mkEq(a,b);
+    PTRef dist = logic.mkDistinct({a,b,c});
+    EXPECT_TRUE(logic.isLit(eq));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(eq)));
+
+    EXPECT_TRUE(logic.isLit(dist));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(dist)));
+
+    SymRef predicate = logic.declareFun("p", logic.getSort_bool(), {sref}, nullptr);
+    PTRef pa = logic.mkUninterpFun(predicate, {a});
+    EXPECT_TRUE(logic.isLit(pa));
+    EXPECT_TRUE(logic.isLit(logic.mkNot(pa)));
+}

--- a/test/unit/test_LogicMkTerms.cc
+++ b/test/unit/test_LogicMkTerms.cc
@@ -173,28 +173,6 @@ TEST_F(LogicMkTermsTest, testAtom_Bool) {
     EXPECT_TRUE(logic.isAtom(logic.getTerm_false()));
 }
 
-TEST_F(LogicMkTermsTest, testLiteral_Bool) {
-    PTRef a = logic.mkBoolVar("a");
-    PTRef b = logic.mkBoolVar("b");
-    PTRef c = logic.mkBoolVar("c");
-    EXPECT_TRUE(logic.isLit(a));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(a)));
-
-    EXPECT_FALSE(logic.isLit(logic.mkAnd(a,b)));
-    EXPECT_FALSE(logic.isLit(logic.mkOr(a,b)));
-    EXPECT_FALSE(logic.isLit(logic.mkImpl(a,b)));
-    EXPECT_FALSE(logic.isLit(logic.mkEq(a,b)));
-    EXPECT_FALSE(logic.isLit(logic.mkIte(c,a,b)));
-
-    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkAnd(a,b))));
-    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkOr(a,b))));
-    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkImpl(a,b))));
-    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkEq(a,b))));
-    EXPECT_FALSE(logic.isLit(logic.mkNot(logic.mkIte(c,a,b))));
-
-    EXPECT_TRUE(logic.isLit(logic.getTerm_true()));
-    EXPECT_TRUE(logic.isLit(logic.getTerm_false()));
-}
 
 TEST_F(LogicMkTermsTest, testAtom_UF) {
     SRef sref = logic.declareSort("U", nullptr);
@@ -213,23 +191,4 @@ TEST_F(LogicMkTermsTest, testAtom_UF) {
     PTRef pa = logic.mkUninterpFun(predicate, {a});
     EXPECT_TRUE(logic.isAtom(pa));
     EXPECT_FALSE(logic.isAtom(logic.mkNot(pa)));
-}
-
-TEST_F(LogicMkTermsTest, testLiteral_UF) {
-    SRef sref = logic.declareSort("U", nullptr);
-    PTRef a = logic.mkVar(sref, "a");
-    PTRef b = logic.mkVar(sref, "b");
-    PTRef c = logic.mkVar(sref, "c");
-    PTRef eq = logic.mkEq(a,b);
-    PTRef dist = logic.mkDistinct({a,b,c});
-    EXPECT_TRUE(logic.isLit(eq));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(eq)));
-
-    EXPECT_TRUE(logic.isLit(dist));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(dist)));
-
-    SymRef predicate = logic.declareFun("p", logic.getSort_bool(), {sref}, nullptr);
-    PTRef pa = logic.mkUninterpFun(predicate, {a});
-    EXPECT_TRUE(logic.isLit(pa));
-    EXPECT_TRUE(logic.isLit(logic.mkNot(pa)));
 }


### PR DESCRIPTION
In `Logic` we have methods `isLit` and `isAtom` with custom implementation.
I believe `isLit` should just rely on `isAtom`.