### PR TITLE
Unifying style, small refactorings

### DIFF
--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -55,10 +55,9 @@ Cnfizer::Cnfizer ( SMTConfig       &config_
     , tmap     (tmap)
     , s_empty  (true)
     , alreadyAsserted(logic.getTerm_true())
-{
-    frame_terms.push(logic.getTerm_true()); // frame 0 does not have a var
-    frame_term = frame_terms[0];
-}
+    , frame_terms({logic.getTerm_true()})
+    , current_frame_term(frame_terms[0])
+{ }
 
 void Cnfizer::initialize()
 {
@@ -80,17 +79,18 @@ Cnfizer::solve(vec<FrameId>& en_frames)
 {
     vec<Lit> assumps;
     // Initialize so that by default frames are disabled
-    for (int i = 0; i < frame_terms.size(); i++)
-        assumps.push(this->getOrCreateLiteralFor(frame_terms[i]));
+    for (PTRef tr : frame_terms) {
+        assumps.push(this->getOrCreateLiteralFor(tr));
+    }
 
     // Enable the terms which are listed in en_frames
     // At this point assumps has the same size as frame_terms and the
     // elements are in the same order.  We simply invert the
     // corresponding literals
-    for (int i = 0; i < en_frames.size(); i++) {
-        int asmp_idx = en_frames[i].id;
-        assumps[asmp_idx] = ~assumps[asmp_idx];
+    for (const FrameId & fid : en_frames) {
+        assumps[fid.id] = ~assumps[fid.id];
     }
+
     // Filter out the lit_Trues and lit_Falses used as empty values
     Lit lit_true = this->getOrCreateLiteralFor(logic.getTerm_true());
     int i, j;
@@ -117,7 +117,7 @@ void Cnfizer::setFrameTerm(FrameId frame_id)
         frame_terms[frame_id.id] = frame_term;
     }
 
-    frame_term = frame_terms[frame_id.id];
+    current_frame_term = frame_terms[frame_id.id];
 }
 
 //
@@ -150,36 +150,29 @@ lbool Cnfizer::cnfizeAndGiveToSolver(PTRef formula, FrameId frame_id)
     {
         PTRef f = top_level_formulae[i];
         assert(not logic.isAnd(f)); // Conjunction should have been split when retrieving top-level formulae
-        if (alreadyAsserted.contains(f, frame_term)) {
+        if (alreadyAsserted.contains(f, current_frame_term)) {
             continue;
         }
         TRACE("Adding clause " << logic.printTerm (f))
         // Give it to the solver if already in CNF
-        if (isClause(f))
-        {
+        if (isClause(f)) {
             TRACE(" => Already a clause")
             res = assertClause(f);
-        }
-
-        // Check whether it can be rewritten using deMorgan laws
-
-        else if (checkDeMorgan (f) == true)
-        {
+        } else if (checkDeMorgan(f)) {
+            // Check whether it can be rewritten using deMorgan laws
             TRACE(" => Will be de Morganized")
             res = deMorganize (f);
-        }
-        else
-        {
+        } else {
             TRACE(" => proper cnfization")
             res = cnfizeAndAssert (f); // Perform actual cnfization (implemented in subclasses)
         }
-        alreadyAsserted.insert(f, frame_term);
+        alreadyAsserted.insert(f, current_frame_term);
     }
     s_empty = false; // solver no longer empty
     if (res) {
         vec<PTRef> nestedBoolRoots = getNestedBoolRoots(formula);
-        for (int i = 0; i < nestedBoolRoots.size(); ++i) {
-            res &= cnfize(nestedBoolRoots[i]); // cnfize the formula without asserting the top level
+        for (PTRef tr : nestedBoolRoots) {
+            res &= cnfize(tr); // cnfize the formula without asserting the top level
         }
         assert(res);
         declareVars(logic.propFormulasAppearingInUF);
@@ -205,8 +198,8 @@ bool Cnfizer::cnfizeAndAssert(PTRef formula) {
 
 void Cnfizer::declareVars(vec<PTRef>& vars)
 {
-    for (int i = 0; i < vars.size(); i++) {
-        Lit l = tmap.getOrCreateLit(vars[i]);
+    for (PTRef tr : vars) {
+        Lit l = tmap.getOrCreateLit(tr);
         solver.addVar(var(l));
     }
 }
@@ -232,10 +225,9 @@ bool Cnfizer::deMorganize ( PTRef formula )
 
         retrieveConjuncts (pt[0], conjuncts);
 
-        for (int i = 0; i < conjuncts.size(); i++)
-        {
-            clause.push (~this->getOrCreateLiteralFor (conjuncts[i]));
-            TRACE("(not " << logic.printTerm (conjuncts[i]) << ")")
+        for (PTRef tr : conjuncts) {
+            clause.push (~this->getOrCreateLiteralFor(tr));
+            TRACE("(not " << logic.printTerm (tr) << ")")
         }
 
         rval = addClause(clause);
@@ -272,17 +264,14 @@ bool Cnfizer::isConjunctionOfClauses(PTRef e) {
 
         Pterm const & and_t = logic.getPterm(e);
 
-        for (int i = 0; i < and_t.size(); i++) {
-            if (logic.isAnd(and_t[i])) {
-                to_process.push(and_t[i]);
-            }
-            else if (not isClause(and_t[i])) {
+        for (PTRef tr : and_t) {
+            if (logic.isAnd(tr)) {
+                to_process.push(tr);
+            } else if (not isClause(tr)) {
                 return false;
             }
         }
-
     }
-
     return true;
 }
 
@@ -311,12 +300,11 @@ bool Cnfizer::isClause(PTRef e) {
 
         Pterm const & or_t = logic.getPterm (e);
 
-        for (int i = 0; i < or_t.size(); i++) {
-            if (logic.isOr(or_t[i])) {
-                to_process.push(or_t[i]);
-            }
-            else {
-                if (not isLiteral(or_t[i])) {
+        for (PTRef tr : or_t) {
+            if (logic.isOr(tr)) {
+                to_process.push(tr);
+            } else {
+                if (not isLiteral(tr)) {
                     return false;
                 }
             }
@@ -333,7 +321,7 @@ bool Cnfizer::isClause(PTRef e) {
 bool Cnfizer::checkDeMorgan (PTRef e)
 {
     Map<PTRef, bool, PTRefHash, Equal<PTRef> > check_cache;
-    Pterm &not_t = logic.getPterm (e);
+    const Pterm &not_t = logic.getPterm (e);
 
     if (logic.isNot (e) && checkPureConj (not_t[0], check_cache) ) return true;
     else return false;
@@ -359,12 +347,13 @@ bool Cnfizer::checkPureConj (PTRef e, Map<PTRef, bool, PTRefHash, Equal<PTRef> >
         to_process.pop();
         Pterm &and_t = logic.getPterm (e);
 
-        if (logic.isAnd (e))
-            for (int i = 0; i < and_t.size(); i++)
-                to_process.push (and_t[i]);
-        else if (!isLiteral(e))
+        if (logic.isAnd(e)) {
+            for (PTRef tr : and_t) {
+                to_process.push(tr);
+            }
+        } else if (not isLiteral(e)) {
             return false;
-
+        }
         check_cache.insert (e, true);
     }
 
@@ -375,8 +364,8 @@ bool Cnfizer::addClause(const vec<Lit> & c_in)
 {
     vec<Lit> c;
     c_in.copyTo(c);
-    if (frame_term != logic.getTerm_true()) {
-        Lit l = this->getOrCreateLiteralFor(frame_term);
+    if (current_frame_term != logic.getTerm_true()) {
+        Lit l = this->getOrCreateLiteralFor(current_frame_term);
         tmap.setFrozen(var(l));
         c.push(l);
     }
@@ -417,9 +406,8 @@ bool Cnfizer::assertClause (PTRef f)
     //
     // A unit clause
     //
-    if (isLiteral(f))
-    {
-        clause.push (this->getOrCreateLiteralFor (f));
+    if (isLiteral(f)) {
+        clause.push(this->getOrCreateLiteralFor(f));
         return addClause(clause);
     }
 
@@ -427,13 +415,12 @@ bool Cnfizer::assertClause (PTRef f)
     // A clause
     //
 
-    if (logic.isOr (f))
-    {
+    if (logic.isOr(f)) {
         vec<PTRef> lits;
         retrieveClause (f, lits);
 
-        for (int i = 0; i < lits.size(); i++)
-            clause.push (this->getOrCreateLiteralFor (lits[i]));
+        for (PTRef tr : lits)
+            clause.push(this->getOrCreateLiteralFor(tr));
 
         return addClause(clause);
     }
@@ -451,18 +438,16 @@ void Cnfizer::retrieveTopLevelFormulae (PTRef root, vec<PTRef> &top_level_formul
 
     to_process.push (root);
 
-    while (to_process.size() != 0)
-    {
+    while (to_process.size() != 0) {
         PTRef f = to_process.last();
         to_process.pop();
         Pterm &cand_t = logic.getPterm (f);
 
-        if (logic.isAnd (f))
+        if (logic.isAnd (f)) {
             for (int i = cand_t.size() - 1; i >= 0; i--) {
-                to_process.push (cand_t[i]);
+                to_process.push(cand_t[i]);
             }
-        else if (!seen.has (f))
-        {
+        } else if (!seen.has (f)) {
             top_level_formulae.push (f);
             seen.insert (f, true);
         }
@@ -476,14 +461,13 @@ void Cnfizer::retrieveClause ( PTRef f, vec<PTRef> &clause )
 {
     assert (isLiteral(f) || logic.isOr (f));
 
-    if (isLiteral(f))
-        clause.push (f);
-    else if ( logic.isOr (f) )
-    {
+    if (isLiteral(f)) {
+        clause.push(f);
+    } else if ( logic.isOr (f) ) {
         Pterm const &t = logic.getPterm (f);
-
-        for ( int i = 0; i < t.size(); i++)
-            retrieveClause ( t[i], clause );
+        for (PTRef tr : t) {
+            retrieveClause(tr, clause);
+        }
     }
 }
 
@@ -494,14 +478,14 @@ void Cnfizer::retrieveConjuncts ( PTRef f, vec<PTRef> &conjuncts )
 {
     assert (isLiteral(f) || logic.isAnd (f));
 
-    if (isLiteral(f))
-        conjuncts.push (f);
-    else
-    {
+    if (isLiteral(f)) {
+        conjuncts.push(f);
+    } else {
         Pterm &t = logic.getPterm (f);
 
-        for (int i = 0; i < t.size(); i++)
-            retrieveConjuncts (t[i], conjuncts);
+        for (PTRef tr : t) {
+            retrieveConjuncts(tr, conjuncts);
+        }
     }
 }
 
@@ -509,8 +493,7 @@ void Cnfizer::retrieveConjuncts ( PTRef f, vec<PTRef> &conjuncts )
 lbool Cnfizer::getTermValue (PTRef tr) const
 {
     assert (solver.isOK());
-    if (tmap.hasLit(tr))
-    {
+    if (tmap.hasLit(tr)) {
         Lit l = tmap.getLit(tr);
         lbool val = solver.modelValue(l);
         assert (val != l_Undef);

--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -55,7 +55,7 @@ Cnfizer::Cnfizer ( SMTConfig       &config_
     , tmap     (tmap)
     , s_empty  (true)
     , alreadyAsserted(logic.getTerm_true())
-    , frame_terms({logic.getTerm_true()})
+    , frame_terms({logic.getTerm_true()}) // Frame 0 does not have an enabling var
     , current_frame_term(frame_terms[0])
 { }
 

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -75,7 +75,7 @@ public:
            );
 
 
-    virtual ~Cnfizer( ) { }
+    virtual ~Cnfizer() = default;
 
     lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id); // Main routine
 

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -36,7 +36,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <unordered_set>
 
 class SimpSMTSolver;
-class CnfState;
 class THandler;
 struct SMTConfig;
 
@@ -123,8 +122,8 @@ protected:
 
     int currentPartition = -1;
 
-    PTRef frame_term;
     vec<PTRef> frame_terms;
+    PTRef current_frame_term;
     void setFrameTerm(FrameId frame_id);
 };
 

--- a/src/cnfizers/Tseitin.cc
+++ b/src/cnfizers/Tseitin.cc
@@ -47,7 +47,7 @@ bool Tseitin::cnfize(PTRef term) {
         //
         // Skip if the node has already been processed before
         //
-        if (alreadyCnfized.contains(ptr, frame_term)){
+        if (alreadyCnfized.contains(ptr, current_frame_term)){
             continue;
         }
 
@@ -77,7 +77,7 @@ bool Tseitin::cnfize(PTRef term) {
             }
         }
 tseitin_end:
-        alreadyCnfized.insert(ptr, frame_term);
+        alreadyCnfized.insert(ptr, current_frame_term);
     }
 
     return res;


### PR DESCRIPTION
Now that we're cleaning `Cnfizer` I also added some small things that maybe could be in line with the spirit of the original PR.
- use list comprehension for loops when possible
- make a pass on uniforming the indentation style in if - else -constructs and white spaces in function calls
- rename the current frame variable more appropriately
- Clean the constructor (and destructor) a little