### PR TITLE
Refactoring of retrieving top-level formulae

### DIFF
--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -26,6 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "Cnfizer.h"
 #include "SimpSMTSolver.h"
+#include "TreeOps.h"
 #include "OsmtInternalException.h"
 
 #include <queue>
@@ -137,9 +138,8 @@ lbool Cnfizer::cnfizeAndGiveToSolver(PTRef formula, FrameId frame_id)
         assert(pmanager.getPartitionIndex(formula) != -1);
         currentPartition = pmanager.getPartitionIndex(formula);
     }
-    vec<PTRef> top_level_formulae;
     // Retrieve top-level formulae - this is a list constructed from a conjunction
-    retrieveTopLevelFormulae (formula, top_level_formulae);
+    vec<PTRef> top_level_formulae = topLevelConjuncts(logic, formula);
     assert (top_level_formulae.size() != 0);
     TRACE("Top level formulae:")
     TRACE_FLA_VEC(top_level_formulae)
@@ -425,33 +425,6 @@ bool Cnfizer::assertClause (PTRef f)
         return addClause(clause);
     }
     throw OsmtInternalException("UNREACHABLE: Unexpected situation in Cnfizer");
-}
-
-//
-// Retrieve the formulae at the top-level.  Ignore duplicates
-//
-void Cnfizer::retrieveTopLevelFormulae (PTRef root, vec<PTRef> &top_level_formulae)
-{
-    vec<PTRef> to_process;
-
-    Map<PTRef, bool, PTRefHash> seen;
-
-    to_process.push (root);
-
-    while (to_process.size() != 0) {
-        PTRef f = to_process.last();
-        to_process.pop();
-        Pterm &cand_t = logic.getPterm (f);
-
-        if (logic.isAnd (f)) {
-            for (int i = cand_t.size() - 1; i >= 0; i--) {
-                to_process.push(cand_t[i]);
-            }
-        } else if (!seen.has (f)) {
-            top_level_formulae.push (f);
-            seen.insert (f, true);
-        }
-    }
 }
 
 //

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -97,7 +97,6 @@ public:
     bool     isClause                   (PTRef);
     bool     isCnf                      (PTRef);
     bool     checkDeMorgan              ( PTRef );                      // Check if formula can be deMorganized
-    void     retrieveTopLevelFormulae   ( PTRef, vec<PTRef> & );        // Retrieves the list of top-level formulae
 protected:
 
     bool     assertClause               (PTRef f);                              // Gives formula to the SAT solver

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -57,6 +57,7 @@ public:
             PTRef currentRef = currentEntry.term;
             if (not cfg.previsit(currentRef)) {
                 toProcess.pop_back();
+                done[Idx(logic.getPterm(currentRef).getId())] = 1;
                 continue;
             }
             assert(not done[Idx(logic.getPterm(currentRef).getId())]);
@@ -106,6 +107,32 @@ class AppearsInUfVisitor : public TermVisitor<AppearsInUFVisitorConfig> {
 public:
     AppearsInUfVisitor(Logic & logic): TermVisitor<AppearsInUFVisitorConfig>(logic, cfg), cfg(logic) {}
 };
+
+class TopLevelConjunctsConfig : public DefaultVisitorConfig {
+    Logic & logic;
+    vec<PTRef> & conjuncts;
+public:
+    TopLevelConjunctsConfig(Logic & logic, vec<PTRef> & res) : logic(logic), conjuncts(res) {}
+
+    bool previsit(PTRef term) override {
+        if (not logic.isAnd(term)) {
+            conjuncts.push(term);
+            return false;
+        }
+        return true;
+    }
+};
+
+inline void topLevelConjuncts(Logic & logic, PTRef fla, vec<PTRef> & res) {
+    TopLevelConjunctsConfig config(logic, res);
+    TermVisitor<TopLevelConjunctsConfig>(logic, config).visit(fla);
+}
+
+inline vec<PTRef> topLevelConjuncts(Logic & logic, PTRef fla) {
+    vec<PTRef> res;
+    topLevelConjuncts(logic, fla, res);
+    return res;
+}
 
 template<class T>
 class Qel {


### PR DESCRIPTION
As a preparation for dealing with distinct in the pre-processing phase, this PR pulls the method to retrieve top-level formulae out of Cnfizer. This is needed to distinguish top-level distincts from other distincts in the formula.

This PR also fixes TermVisitor to prevent duplicate calls to `previsit` for the same term if it returned `false` the first time.