### PR TITLE
Enabling the option to simplify interpolants also in SMT-LIB scripts

### DIFF
--- a/src/options/SMTConfig.cc
+++ b/src/options/SMTConfig.cc
@@ -487,6 +487,7 @@ const char* SMTConfig::o_restart_inc   = ":restart-inc";
 const char* SMTConfig::o_produce_proofs = ":produce-proofs";
 const char* SMTConfig::o_produce_inter = ":produce-interpolants";
 const char* SMTConfig::o_certify_inter = ":certify-interpolants";
+const char* SMTConfig::o_simplify_inter = ":simplify-interpolants";
 const char* SMTConfig::o_interpolant_cnf = ":cnf-interpolants";
 const char* SMTConfig::o_proof_struct_hash       = ":proof-struct-hash";
 const char* SMTConfig::o_proof_struct_hash_build = ":proof-struct-hash-build";
@@ -606,7 +607,6 @@ SMTConfig::initializeConfig( )
   proof_remove_mixed            = 0;
 //  proof_certify_inter           = 0;
   proof_random_seed	        = 0;
-  simplify_interpolant           = 0;
   sat_theory_polarity_suggestion = 1;
   cuf_bitwidth                   = 32;
 }

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -251,6 +251,7 @@ public:
   static const char* o_produce_proofs;
   static const char* o_produce_inter;
   static const char* o_certify_inter;
+  static const char* o_simplify_inter;
   static const char* o_interpolant_cnf;
   static const char* o_proof_struct_hash;
   static const char* o_proof_num_graph_traversals;
@@ -568,6 +569,9 @@ public:
   bool produce_inter() const
     { return optionTable.has(o_produce_inter) ?
         optionTable[o_produce_inter]->getValue().numval > 0 : false; }
+  int simplify_inter() const
+    { return optionTable.has(o_simplify_inter) ?
+             optionTable[o_simplify_inter]->getValue().numval : 0; }
   int proof_struct_hash() const
     { return optionTable.has(o_proof_struct_hash) ?
         optionTable[o_proof_struct_hash]->getValue().numval : 1; }
@@ -891,14 +895,19 @@ public:
   int          lra_integer_solver;           // Flag to require integer solution for LA problem
   int          lra_check_on_assert;          // Probability (0 to 100) to run check when assert is called
 
-  // interpolant parameters
-  int           simplify_interpolant;
-
     static char* server_host;
     static uint16_t server_port;
     static char* database_host;
     static uint16_t database_port;
 
+    void setSimplifyInterpolant(int val) {
+        const char* msg;
+        setOption(o_simplify_inter, SMTOption(val), msg);
+    }
+
+    int getSimplifyInterpolant() const {
+        return simplify_inter();
+    }
 
 private:
 

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -348,7 +348,7 @@ public:
     // Inverts the normal order Hashing + RecyclePivots
     bool			switchToRPHashing()			{ return (config.proof_switch_to_rp_hash >= 1);}
     inline bool    additionalRandomization       ( ) { return ( config.proof_random_context_analysis == 1 ); }
-    int             simplifyInterpolant                     ( ) const { return config.simplify_interpolant; }
+    int             simplifyInterpolant () const { return config.getSimplifyInterpolant(); }
     //
     // Build et al.
     //


### PR DESCRIPTION
When OpenSMT is used as a library, the project has access to enable simplification of the interpolants immediately after they are computed through the field `SMTConfig::simplify_interpolant`.
However, this option cannot be set from SMT-LIB script using the standard `(set-option)` command.

This PR removes the field and instead uses the standard way to set and retrieve the value of this option.