### PR TITLE
Enforce representation invariant of FastRational

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -494,6 +494,7 @@ inline void FastRational::negate() {
         // MB: for the special case num == WORD_MIN && wordPartValid
         setWordPartInvalid();
     }
+    assert(isWellFormed());
 }
 
 inline int FastRational::compare(const FastRational& b) const {
@@ -606,6 +607,7 @@ template<uword> uword gcd(uword a, uword b);
 
 inline bool FastRational::isWellFormed() const
 {
+    assert(wordPartValid() or not fitsWord());
     return (  wordPartValid() || mpqPartValid() )
            && ( !wordPartValid() || (den != 0 && gcd(absVal(num), den)==1) )
            && ( !mpqPartValid()  || mpz_sgn(mpq_denref(mpq))!=0 )
@@ -1039,6 +1041,7 @@ inline FastRational FastRational::inverse() const {
     dest.ensure_mpq_memory_allocated();
     mpq_inv(dest.mpq, mpq);
     dest.state = State::MPQ_ALLOCATED_AND_VALID;
+    assert(dest.isWellFormed());
     return dest;
 }
 

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -493,6 +493,7 @@ inline void FastRational::negate() {
         mpq_neg(mpq, mpq);
         // MB: for the special case num == WORD_MIN && wordPartValid
         setWordPartInvalid();
+        try_fit_word();
     }
     assert(isWellFormed());
 }
@@ -1041,6 +1042,7 @@ inline FastRational FastRational::inverse() const {
     dest.ensure_mpq_memory_allocated();
     mpq_inv(dest.mpq, mpq);
     dest.state = State::MPQ_ALLOCATED_AND_VALID;
+    dest.try_fit_word();
     assert(dest.isWellFormed());
     return dest;
 }

--- a/test/unit/test_Rationals.cpp
+++ b/test/unit/test_Rationals.cpp
@@ -462,3 +462,23 @@ TEST(Rationals_test, test_addNegated)
     }
 }
 
+TEST(Rationals_test, testWordRepresentation_Negate) {
+    FastRational a(INT_MIN); // a fits into word representation
+    ASSERT_TRUE(a.wordPartValid());
+    a.negate(); // a now does not fit into word representation
+    ASSERT_FALSE(a.wordPartValid());
+    a.negate(); // a now again fits into word representation
+    ASSERT_TRUE(a.wordPartValid());
+}
+
+TEST(Rationals_test, testWordRepresentation_Inverse) {
+    uword val = INT_MAX;
+    ++val;
+    FastRational a(1, val); // a fits into word representation
+    ASSERT_TRUE(a.wordPartValid());
+    a = a.inverse(); // a now does not fit into word representation
+    ASSERT_FALSE(a.wordPartValid());
+    a = a.inverse(); // a now again fits into word representation
+    ASSERT_TRUE(a.wordPartValid());
+}
+


### PR DESCRIPTION
Thanks to an example from @MasoudAsadzade, we discovered that the representation invariant for `FastRational` could have been violated within operations `negate` and `inverse`.
That is, we could have end up with a FastRational that fits into word representation, but actually had only the mpq representation.

This PR fixes this problem and adds the corresponding checks.