### PR TITLE
Fix crash in UF interpolator

### DIFF
--- a/regression_itp/uf_local_colors_insufficient.smt2
+++ b/regression_itp/uf_local_colors_insufficient.smt2
@@ -1,0 +1,26 @@
+(set-option :produce-interpolants 1)
+(set-logic QF_UF)
+(declare-sort U 0)
+(declare-fun f (U U) U)
+(declare-fun P (U) Bool)
+(declare-fun x () U)
+(declare-fun y () U)
+
+(declare-fun r1 () U)
+(declare-fun r2 () U)
+(declare-fun a1 () U)
+(declare-fun a2 () U)
+(declare-fun b1 () U)
+(declare-fun b2 () U)
+
+(assert (! (and (= r1 (f a1 b1)) (= r2 (f a2 b2)))
+:named B))
+
+(assert (! (and (P (f x y)) (= a1 x) (= b1 y) (= a2 x) (= b2 y) (not (= r1 r2)))
+:named A))
+
+
+(check-sat)
+(get-interpolants A B)
+
+

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -1227,7 +1227,7 @@ void UFInterpolator::splitEdge(CEdge * edge, PTRef intermediateTerm) {
     PTRef intermediate_next_reason = PTRef_Undef;
     if (cgraph.hasNode(intermediateTerm)) {
         intermediate = cgraph.getNode(intermediateTerm);
-        if (intermediate->next != nullptr) {
+        if (intermediate->next) {
             intermediate_next = intermediate->next->target;
             intermediate_next_reason = intermediate->next->reason;
             cgraph.removeCEdge(intermediate->next);

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -521,7 +521,7 @@ UFInterpolator::J(const path_t & p, vector<path_t> & b_paths) {
 
     vec<PTRef> conj;
 
-    for (auto path : b_paths) {
+    for (const auto & path : b_paths) {
         conj.push(logic.mkEq(path.first->e, path.second->e));
     }
 
@@ -555,13 +555,13 @@ UFInterpolator::Iprime(const path_t & pi) {
         conj.push(I(theta));
     }
 
-    for (auto path : b_paths)
+    for (const auto & path : b_paths)
         conj.push(I(path));
 
     // Finally compute implication
     vec<PTRef> conj_impl;
 
-    for (auto path : b_paths)
+    for (const auto & path : b_paths)
         conj_impl.push(logic.mkEq(path.first->e, path.second->e));
 
     PTRef implicant = logic.mkAnd(conj_impl);
@@ -592,13 +592,13 @@ UFInterpolator::IprimeSwap(const path_t & pi) {
         conj.push(ISwap(theta));
     }
 
-    for (auto path : b_paths)
+    for (const auto & path : b_paths)
         conj.push(ISwap(path));
 
     // Finally compute implication
     vec<PTRef> conj_impl;
 
-    for (auto path : b_paths) {
+    for (const auto & path : b_paths) {
         conj_impl.push(logic.mkEq(path.first->e, path.second->e));
     }
 

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -1251,7 +1251,7 @@ void UFInterpolator::splitEdge(CEdge * edge, PTRef intermediateTerm) {
 
     cgraph.addCEdge(intermediate, to, PTRef_Undef);
 //    intermediate->next->color = to->color;
-    if (intermediate_next != nullptr) {
+    if (intermediate_next) {
         // MB: It looks like it is possible that there has already been an edge n -> cnn
         // In that case a self-loop edge would be added here and that causes trouble later
         // We need to prevent that

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -94,6 +94,7 @@ public:
 
     void  addCNode (PTRef e);
     void  addCEdge (PTRef, PTRef, PTRef);
+    void  addCEdge (CNode *, CNode *, PTRef);
 
     void removeCEdge(CEdge *);
 
@@ -141,6 +142,9 @@ private:
     icolor_t colorNode(CNode * c);
     bool colorEdges(CNode * c1, CNode * c2);
     bool colorEdgesFrom(CNode * x);
+    void colorCongruenceEdge(CEdge * edge);
+
+    void splitEdge(CEdge * edge, PTRef intermediateTerm);
 
     size_t getSortedEdges(CNode *, CNode *, vector<CEdge *> &);
 


### PR DESCRIPTION
Because we re-use one theory solver for all theory conflicts, it may happen that the explanation of a conflict depends on a term not present in that particular conflict (but is present in the input formula).
This breaks the invariant assumed before, i.e., that local coloring information is enough to color the `CGraph` (congruence graph representing the explanation).
But even in global coloring information, a term (like `f(x)`) can originally be assigned only color `A` (when present only in partition `A`) while in the `CGraph` we need to color it as `AB` because both `f` and `x` have color `AB`.
This required a small change in the code which was not prepared for such situation.

Added are a regression and a unit test that show this problem, although they are sensitive to the order in which the terms are introduced.

Fixes #231.