### PR TITLE
Small optimizations

### DIFF
--- a/src/itehandler/IteToSwitch.h
+++ b/src/itehandler/IteToSwitch.h
@@ -83,7 +83,7 @@ namespace ite {
     };
 
 
-    enum class type {
+    enum class type : char {
         white, gray, black
     };
 

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -44,8 +44,9 @@ void ProofGraph::initTSolver() {
         const auto & clause = this->getNode(id)->getClause();
         for (auto const & lit : clause) {
             Var v = var(lit);
-            assert(thandler->isTheoryTerm(v));
-            thandler->declareAtom(this->varToPTRef(v));
+            PTRef atom = this->varToPTRef(v);
+            assert(logic_.isTheoryTerm(atom));
+            thandler->declareAtom(atom);
         }
     }
 }

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -7,7 +7,7 @@
 
 bool GhostSMTSolver::isGhost(Lit l)
 {
-    if (!theory_handler.isTheoryTerm(var(l))) return false;
+    if (!theory_handler.isDeclared(var(l))) return false;
     vec<CRef> &appearances = thLitToClauses[toInt(l)];
     int i;
     for (i = 0; i < appearances.size(); i++) {
@@ -52,7 +52,7 @@ GhostSMTSolver::attachClause(CRef in_clause)
 
     for (unsigned i = 0; i < c.size(); i++) {
         Lit l = c[i];
-        if (theory_handler.isTheoryTerm(var(l))) {
+        if (theory_handler.isDeclared(var(l))) {
             int idx = toInt(l);
             assert(idx < static_cast<int>(thLitToClauses.size()));
             thLitToClauses[idx].push(in_clause);
@@ -117,7 +117,7 @@ GhostSMTSolver::pickBranchPolarity(Var next) {
     bool sign = false;
     bool use_theory_suggested_polarity = config.use_theory_polarity_suggestion();
 
-    if (use_theory_suggested_polarity && theory_handler.isTheoryTerm(next)) {
+    if (use_theory_suggested_polarity && theory_handler.isDeclared(next)) {
         lbool suggestion = this->theory_handler.getSolverHandler().getPolaritySuggestion(this->theory_handler.varToTerm(next));
         if (suggestion != l_Undef) {
             sign = (suggestion != l_True);

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -38,6 +38,8 @@ class THandler
 private:
     Theory &          theory;
     TermMapper &      tmap;                     // Mappings between TRefs and Lits
+    vec<bool>         declared;                 // Cache for quick check if given SAT variable has been declared to theory solvers
+
 public:
 
     THandler(Theory & tsh, TermMapper & termMapper)
@@ -48,7 +50,9 @@ public:
 
     ~THandler() = default;
 
-    void clear();// { getSolverHandler().clearSolver(); }  // Clear the solvers from their states
+    void clear();  // Clear the solvers from their states
+
+    bool isDeclared (Var v) { return v < declared.size() and declared[v]; } // Has v been declared to the theory solvers?
 
     Theory& getTheory();// { return theory; }
     Logic&  getLogic() ;// { return theory.getLogic(); }
@@ -72,7 +76,6 @@ public:
     void fillTheoryVars       (ModelBuilder & modelBuilder) const;
     void addSubstitutions     (ModelBuilder & modelBuilder) const;
 
-    bool    isTheoryTerm       ( Var v ) ;//{ return getLogic().isTheoryTerm(varToTerm(v)); }
     PTRef   varToTerm          ( Var v ) const;//{ return tmap.varToPTRef(v); }  // Return the term ref corresponding to a variable
     Pterm&  varToPterm         ( Var v) ;// { return getLogic().getPterm(tmap.varToPTRef(v)); } // Return the term corresponding to a variable
     Lit     PTRefToLit         ( PTRef tr);// { return tmap.getLit(tr); }
@@ -86,8 +89,7 @@ public:
     void    clearModel        ();// { /*getSolverHandler().clearModel();*/ }   // Clear the model if necessary
     bool    assertLits        (const vec<Lit> &);             // Give to the TSolvers the newly added literals on the trail
     bool    assertLit         (PtAsgn pta);// { return getSolverHandler().assertLit(pta); } // Push the assignment to all theory solvers
-    void    declareAtoms      (PTRef tr) { getSolverHandler().declareAtoms(tr); }
-    void    declareAtom       (PTRef tr) { getSolverHandler().declareAtom(tr); }
+    void    declareAtom       (PTRef tr);
     void    informNewSplit    (PTRef tr); // Splitting variable data structure updates (e.g., recompute bounds list)
     TRes    check             (bool);       // Check trail in the theories
     void    backtrack         (int);        // Remove literals that are not anymore on the trail

--- a/src/tsolvers/TSolverHandler.cc
+++ b/src/tsolvers/TSolverHandler.cc
@@ -42,13 +42,6 @@ bool TSolverHandler::assertLit(PtAsgn asgn)
     return res;
 }
 
-void TSolverHandler::declareAtoms(PTRef tr) {
-    auto atoms = getAtoms(tr, getLogic());
-    for (const PTRef atom : atoms) {
-        declareAtom(atom);
-    }
-}
-
 
 // Clear the vars of the solvers
 void TSolverHandler::clearSolver()

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -79,7 +79,6 @@ public:
     void    fillTheoryVars    (ModelBuilder& modelBuilder) const;
     void    computeModel      ();                      // Computes a model in the solver if necessary
     bool    assertLit         (PtAsgn);                // Push the assignment to all theory solvers
-    void    declareAtoms      (PTRef);                 // Declare atoms to theory solvers
     void    informNewSplit(PTRef);                     // Recompute split datastructures
     void    declareAtom(PTRef tr);                     // Declare atom to the appropriate solver
 //    virtual SolverId getId() const { return my_id; }


### PR DESCRIPTION
This PR suggests two small optimizations for improving performance.

The first one is just using smaller underlying type for `class enum ite::type` so it requires less memory.

The second one is caching the information in `THandler` which SAT variables are interesting for theory solvers.
The original check was using `Logic::isTheoryTerm` which is non-trivial. Moreover, this check has been reported for every literal added or removed from SAT trace every time.

The experiments show this amounts to ~3% speed up both in UF and LRA.

[comparison_uf.pdf](https://github.com/usi-verification-and-security/opensmt/files/6566544/comparison_uf.pdf)
[comparison_lra.pdf](https://github.com/usi-verification-and-security/opensmt/files/6566545/comparison_lra.pdf)
