### PR TITLE
Fixed edge case in FastRationals

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -480,6 +480,7 @@ inline FastRational FastRational::operator-() const {
         mpq_init(x.mpq);
         mpq_neg(x.mpq, mpq);
         x.state = State::MPQ_ALLOCATED_AND_VALID;
+        x.try_fit_word(); // MB: If current value is 2^31, it does not fit word representation, but it's negation -2^31 does.
         return x;
     }
 }

--- a/test/unit/test_Rationals.cpp
+++ b/test/unit/test_Rationals.cpp
@@ -114,6 +114,16 @@ TEST(Rationals_test, test_negate_int32min) {
     EXPECT_TRUE(r > 0);
 }
 
+TEST(Rationals_test, test_negate_minus_int32min) {
+    // - INT32_MIN = 2^31
+    Real r {"2147483648"};
+    Real neg = -r;
+    EXPECT_TRUE(neg.isWellFormed());
+    EXPECT_TRUE(neg < 0);
+    r.negate();
+    EXPECT_TRUE(r.isWellFormed());
+}
+
 TEST(Rationals_test, test_additionAssign) {
     Real a {"2147483640"};
     Real b {"10"};


### PR DESCRIPTION
I found one more case where a FastRational with `mpq` representation has been created even though it could fit the word representation.
This happened in unary minus operator where if the input is `2^31`, it does not fit word representation, but its negation `-2^31` fits.