### PR TITLE
Reducing memory allocations - part 1

### DIFF
--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -147,7 +147,7 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
         removeRowFromColumn(bv, var);
         addRowToColumn(nv, var);
     }
-    std::vector<Polynomial::Term> storage;
+
     // for all (active) rows containing nv, substitute
     for (auto rowVar : getColumn(bv)) {
         if(rowVar == nv || isQuasiBasic(rowVar)) {
@@ -170,7 +170,7 @@ void Tableau::pivot(LVRef bv, LVRef nv) {
                        assert(contains(getColumn(removedVar), rowVar));
                        removeRowFromColumn(rowVar, removedVar);
                    }
-                   , storage
+                   , tmp_storage
         );
     }
     assert(!cols[nv.x]);
@@ -268,10 +268,10 @@ void Tableau::normalizeRow(LVRef v) {
     if (!toEliminate.empty()) {
         Polynomial p;
         for (auto const* term : toEliminate) {
-            p.merge(getRowPoly(term->var), term->coeff, [](LVRef) {}, [](LVRef) {});
+            p.merge(getRowPoly(term->var), term->coeff, [](LVRef) {}, [](LVRef) {}, tmp_storage);
             p.addTerm(term->var, -term->coeff);
         }
-        row.merge(p, 1, [](LVRef) {}, [](LVRef) {});
+        row.merge(p, 1, [](LVRef) {}, [](LVRef) {}, tmp_storage);
     }
 }
 

--- a/src/tsolvers/lasolver/Tableau.h
+++ b/src/tsolvers/lasolver/Tableau.h
@@ -101,6 +101,9 @@ private:
         NONE, BASIC, NONBASIC, QUASIBASIC
     };
     std::vector<VarType> varTypes;
+
+    std::vector<Polynomial::Term> tmp_storage;
+
     void ensureTableauReadyFor(LVRef v);
 
     void addRow(LVRef v, std::unique_ptr<Polynomial> p);


### PR DESCRIPTION
[Heaptrack](https://github.com/KDE/heaptrack) identified some parts of OpenSMT making a lot of memory allocations. This PR is the first one in a series attempting to reduce the number of memory allocations.
`Polynomial::merge` is the key method that keeps the Tableau of LASolver in a consistent state and is called quite a number of times.
It uses additional space (storage) to properly merge two polynomials into a new one. However, this additional storage was not re-used as much as it could.
This PR proposes to save this temporary storage in the Tableau, so it can be does not have to be allocated and destroyed repeatedly.
Moreover, the method `Tableau::normalizeRow` was not re-using this storage previously at all, even though  it could.
Both `normalizeRow` and `pivot` now reuse the storage associated with the `Tableau`.

In addition to re-using the vector itself, we also try to re-use the `FastRationals` stored in the vector, so we don't clear and re-fill the storage every time.
