### PR TITLE
Reduction of memory allocations - part2

### DIFF
--- a/src/tsolvers/lasolver/Polynomial.h
+++ b/src/tsolvers/lasolver/Polynomial.h
@@ -133,7 +133,17 @@ void Polynomial::merge(const Polynomial &other, const opensmt::Real &coeff, ADD 
             ++otherIt;
         }
     }
-    std::vector<Term>(std::make_move_iterator(storage.begin()), std::make_move_iterator(storage.begin() + storageIndex)).swap(poly);
+    auto polySize = poly.size();
+    if (storageIndex > polySize) {
+        std::move(storage.begin(), storage.begin() + polySize, poly.begin());
+        poly.insert(poly.end(), std::make_move_iterator(storage.begin() + polySize), std::make_move_iterator(storage.begin() + storageIndex));
+    }
+    else if (/*storageIndex <= poly.size() and */ polySize <= 2 * storageIndex) {
+        std::move(storage.begin(), storage.begin() + storageIndex, poly.begin());
+        poly.erase(poly.begin() + storageIndex, poly.end());
+    } else {
+        std::vector<Term>(std::make_move_iterator(storage.begin()), std::make_move_iterator(storage.begin() + storageIndex)).swap(poly);
+    }
 }
 
 #endif //OPENSMT_POLYNOMIAL_H

--- a/src/tsolvers/lasolver/Simplex.cc
+++ b/src/tsolvers/lasolver/Simplex.cc
@@ -211,7 +211,7 @@ LVRef Simplex::findNonBasicForPivotByBland(LVRef basicVar) {
             assert(basicVar != y);
             assert(tableau.isNonBasic(y));
             auto const &coeff = term.coeff;
-            const bool &coeff_is_pos = isPositive(coeff);
+            const bool coeff_is_pos = isPositive(coeff);
             if ((!coeff_is_pos && isModelStrictlyUnderUpperBound(y))
                 || (coeff_is_pos && isModelStrictlyOverLowerBound(y))) {
                 // Choose the leftmost nonbasic variable with a negative (reduced) cost

--- a/src/tsolvers/lasolver/Simplex.cc
+++ b/src/tsolvers/lasolver/Simplex.cc
@@ -189,7 +189,7 @@ LVRef Simplex::findNonBasicForPivotByBland(LVRef basicVar) {
         // For the Bland rule
         auto curr_var_id_y = max_var_id;
         // look for nonbasic terms to fix the breaking of the bound
-        for (auto term : tableau.getRowPoly(basicVar)) {
+        for (auto const & term : tableau.getRowPoly(basicVar)) {
             auto y = term.var;
             assert(basicVar != y);
             assert(tableau.isNonBasic(y));
@@ -206,7 +206,7 @@ LVRef Simplex::findNonBasicForPivotByBland(LVRef basicVar) {
     else if (isModelOutOfUpperBound(basicVar)) {
         auto curr_var_id_y = max_var_id;
         // look for nonbasic terms to fix the unbounding
-        for (auto term : tableau.getRowPoly(basicVar)) {
+        for (auto const & term : tableau.getRowPoly(basicVar)) {
             auto y = term.var;
             assert(basicVar != y);
             assert(tableau.isNonBasic(y));
@@ -302,7 +302,7 @@ void Simplex::changeValueBy(LVRef var, const Delta & diff) {
 
 void Simplex::updateValues(const LVRef bv, const LVRef nv){
     assert(isModelOutOfBounds(bv));
-    auto bvNewVal = (isModelOutOfLowerBound(bv)) ? model->Lb(bv) : model->Ub(bv);
+    auto const & bvNewVal = (isModelOutOfLowerBound(bv)) ? model->Lb(bv) : model->Ub(bv);
     const auto & coeff = tableau.getCoeff(bv, nv);
     // nvDiff represents how much we need to change nv, so that bv gets to the right value
     auto nvDiff = (bvNewVal - model->read(bv)) / coeff;


### PR DESCRIPTION
This PR represents part 2 in reducing memory allocations, it builds on top of #255.
It itself has two parts.
One is just avoiding unnecessary copies by using `const &` in a few places where this was missing.
The other one is more important and it tries to avoid allocating a temporary vector of `Term`s in `Polynomial::merge`.
An important note here is that we need to be careful not to end up with lots of polynomials in the `Tableau` with small size but huge capacity. This would blow up in terms of memory usage.
So sometimes we need to shrink them to release unused capacity. The goal of this change is to do that only when necessary.
The experiments show the current version seems to be working well.

[comparison_lra_mem1_mem2.pdf](https://github.com/usi-verification-and-security/opensmt/files/6614559/comparison_lra_mem1_mem2.pdf)
