### PR TITLE
Seed global random generator with seed from SMTConfig to ensure reproducible runs.

### DIFF
--- a/src/proof/PGMain.cc
+++ b/src/proof/PGMain.cc
@@ -35,6 +35,8 @@ void ProofGraph::printProofGraph( )
 
 void ProofGraph::transfProofForReduction( )
 {
+	// Initialize C-random number generator with fixed seed to ensure reproducibility
+	srand(config.getRandomSeed());
 	// Fill proof
 	fillProofGraph();
 


### PR DESCRIPTION
A number of methods in proof reduction uses  C's rand() method to randomly decide a choice when all heuristics fail.
This PR seeds the random number generator at the beginning of the reduction algorithm.
It's a workaround that could be improved later (for example by fixing the default choice and removing all the calls to rand()).