### PR TITLE
Proof transformations cleanup - part 2 of N: Refactor ProofGraph::mergeClauses

### DIFF
--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -390,7 +390,7 @@ public:
     void              printClause           ( ProofNode * );
     void              printClause           ( ProofNode *, ostream & );
     inline ProofNode* getNode               ( clauseid_t id ) { assert( id<graph.size() ); return graph[ id ]; }
-    bool              mergeClauses          (std::vector<Lit> const &, std::vector<Lit> const &, std::vector<Lit>&, Var);
+    static bool       mergeClauses          (std::vector<Lit> const &, std::vector<Lit> const &, std::vector<Lit>&, Var);
     inline bool       isRoot                ( ProofNode* n ) { assert(n); return( n->getId() == root ); }
     inline ProofNode* getRoot               ( ) { assert( root<graph.size() );assert(graph[ root ]); return graph[ root ]; }
     inline void       setRoot               ( clauseid_t id ) { assert( id<graph.size() ); root=id; }

--- a/src/proof/PGHelp.cc
+++ b/src/proof/PGHelp.cc
@@ -220,37 +220,35 @@ bool ProofGraph::mergeClauses(std::vector<Lit> const & A, std::vector<Lit> const
     std::size_t j = 0;
     std::size_t res = 0;
 
+    auto addIfNotPivot = [&resolv, &res, pivot](Lit l) {
+        if (var(l) != pivot) {
+            assert(res == 0 or resolv[res - 1] != l);
+            resolv[res++] = l;
+        }
+    };
+
     while (i < Asize and j < Bsize) {
-        if (A[i] <= B[j]) {
-            if (A[i] == B[j]) { ++j; }
-            if (var(A[i]) != pivot) {
-                assert(res == 0 or resolv[res - 1] != A[i]); // no duplicates
-                resolv[res++] = A[i];
-            }
+        if (A[i] == B[j]) {
+            addIfNotPivot(A[i]);
+            ++i;
+            ++j;
+        } else if (A[i] < B[j]) {
+            addIfNotPivot(A[i]);
             ++i;
         } else {
             assert(B[j] < A[i]);
-            if (var(B[j]) != pivot) {
-                assert(res == 0 or resolv[res - 1] != B[j]); // no duplicates
-                resolv[res++] = B[j];
-            }
+            addIfNotPivot(B[j]);
             ++j;
         }
     }
 
     while (i < Asize) {
-        if (var(A[i]) != pivot) {
-            assert(res == 0 or resolv[res - 1] != A[i]); // no duplicates
-            resolv[res++] = A[i];
-        }
+        addIfNotPivot(A[i]);
         ++i;
     }
 
     while (j < Bsize) {
-        if (var(B[j]) != pivot) {
-            assert(res == 0 or resolv[res - 1] != B[j]); // no duplicates
-            resolv[res++] = B[j];
-        }
+        addIfNotPivot(B[j]);
         ++j;
     }
     assert(resolv.size() >= res);

--- a/src/proof/PGHelp.cc
+++ b/src/proof/PGHelp.cc
@@ -228,11 +228,8 @@ bool ProofGraph::mergeClauses(std::vector<Lit> const & A, std::vector<Lit> const
     };
 
     while (i < Asize and j < Bsize) {
-        if (A[i] == B[j]) {
-            addIfNotPivot(A[i]);
-            ++i;
-            ++j;
-        } else if (A[i] < B[j]) {
+        if (A[i] <= B[j]) {
+            if (A[i] == B[j]) { ++j; }
             addIfNotPivot(A[i]);
             ++i;
         } else {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -164,3 +164,11 @@ target_sources(FunctionTemplateTest
 target_link_libraries(FunctionTemplateTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET FunctionTemplateTest)
 
+add_executable(ProofTest)
+target_sources(ProofTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Proof.cc"
+        )
+
+target_link_libraries(ProofTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET ProofTest)
+

--- a/test/unit/test_Proof.cc
+++ b/test/unit/test_Proof.cc
@@ -1,0 +1,90 @@
+//
+// Created by Martin Blicha on 07.07.21.
+//
+
+#include <gtest/gtest.h>
+#include <PG.h>
+
+TEST(ProofTest, test_mergeClauses_PivotPresent_NoDuplicates) {
+    std::vector<Lit> left { mkLit(0, true), mkLit(1,false) };
+    std::vector<Lit> right { mkLit(1, true), mkLit(2,false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], mkLit(0,true));
+    EXPECT_EQ(res[1], mkLit(2,false));
+}
+
+TEST(ProofTest, test_mergeClauses_PivotPresent_Duplicates) {
+    std::vector<Lit> left { mkLit(0, true), mkLit(1,false), mkLit(2,false) };
+    std::vector<Lit> right { mkLit(1, true), mkLit(2,false), mkLit(3,false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 3);
+    EXPECT_EQ(res[0], mkLit(0,true));
+    EXPECT_EQ(res[1], mkLit(2,false));
+    EXPECT_EQ(res[2], mkLit(3,false));
+}
+
+TEST(ProofTest, test_mergeClauses_GarbageInResult) {
+    std::vector<Lit> left { mkLit(0, true), mkLit(1,false) };
+    std::vector<Lit> right { mkLit(1, true), mkLit(2,false) };
+    std::vector<Lit> res { mkLit(100, true), mkLit(42, false), mkLit(0, true), mkLit(0, true) };
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], mkLit(0,true));
+    EXPECT_EQ(res[1], mkLit(2,false));
+}
+
+TEST(ProofTest, test_mergeClauses_DuplicateAfterFirstEnd) {
+    std::vector<Lit> left { mkLit(0, true), mkLit(1,false), mkLit(4,false) };
+    std::vector<Lit> right { mkLit(1, true), mkLit(2,false), mkLit(3,false), mkLit(4,false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 4);
+    EXPECT_EQ(res[0], mkLit(0,true));
+    EXPECT_EQ(res[1], mkLit(2,false));
+    EXPECT_EQ(res[2], mkLit(3,false));
+    EXPECT_EQ(res[3], mkLit(4,false));
+}
+
+TEST(ProofTest, test_mergeClauses_DuplicateAfterSecondEnd) {
+    std::vector<Lit> left { mkLit(1, true), mkLit(2,false), mkLit(3,false), mkLit(4,false) };
+    std::vector<Lit> right { mkLit(0, true), mkLit(1,false), mkLit(4,false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 4);
+    EXPECT_EQ(res[0], mkLit(0,true));
+    EXPECT_EQ(res[1], mkLit(2,false));
+    EXPECT_EQ(res[2], mkLit(3,false));
+    EXPECT_EQ(res[3], mkLit(4,false));
+}
+
+TEST(ProofTest, test_mergeClauses_PivotAfterSecondEnd) {
+    std::vector<Lit> left { mkLit(1, true), mkLit(2,false), mkLit(3,false), mkLit(4,false) };
+    std::vector<Lit> right { mkLit(1, false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 3);
+    EXPECT_EQ(res[0], mkLit(2,false));
+    EXPECT_EQ(res[1], mkLit(3,false));
+    EXPECT_EQ(res[2], mkLit(4,false));
+}
+
+TEST(ProofTest, test_mergeClauses_PivotAfterFirstEnd) {
+    std::vector<Lit> left { mkLit(1, false) };
+    std::vector<Lit> right { mkLit(1, true), mkLit(2,false), mkLit(3,false), mkLit(4,false) };
+    std::vector<Lit> res;
+    Var pivot = 1;
+    ProofGraph::mergeClauses(left, right, res, pivot);
+    ASSERT_EQ(res.size(), 3);
+    EXPECT_EQ(res[0], mkLit(2,false));
+    EXPECT_EQ(res[1], mkLit(3,false));
+    EXPECT_EQ(res[2], mkLit(4,false));
+}


### PR DESCRIPTION
The implementation of the method has been simplified and assertions for preconditions and postconditions have been added.
Several unit tests have been added to check correctness of the implementation.