### PR TITLE
Proof transformations cleanup - part 3 of N: ProofGraph::recyclePivotsIter

### DIFF
--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -531,6 +531,8 @@ private:
     void liftVarsToLeaves(std::vector<Var> const & vars);
     void replaceSubproofsWithNoPartitionTheoryVars(std::vector<Var> const & vars);
 
+    void recyclePivotsIter_RecyclePhase();
+
     //NOTE added for experimentation
     Var 				  pred_to_push;
 

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -218,7 +218,6 @@ struct ProofNode
     // Test methods
     //
     inline bool                  isLeaf(){ assert((ant1==NULL && ant2==NULL) || (ant1!=NULL && ant2!=NULL)); return (ant1==NULL);}
-    inline bool                  hasBeenReplaced(){ return(ant1!=NULL && ant2==NULL); }
     // 0 if positive, 1 if negative, -1 if not found
     short                         hasOccurrenceBin( Var );
     // true if positive occurrence pivot is in first antecedent
@@ -380,6 +379,8 @@ public:
     void              setVisited2               ( clauseid_t id ) { mpz_setbit(visited_2, id); }
     void              resetVisited1             ( )               { mpz_set_ui(visited_1,0); }
     void              resetVisited2             ( )               { mpz_set_ui(visited_2,0); }
+    bool              isResetVisited1           ( )               { return mpz_cmp_ui(visited_1, 0) == 0; }
+    bool              isResetVisited2           ( )               { return mpz_cmp_ui(visited_2, 0) == 0; }
 
     unsigned          getMaxIdVar           ( ) { return max_id_variable; }
     void              getGraphInfo          ( );

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -160,7 +160,7 @@ double ProofGraph::recyclePivotsIter() {
             mem_used == 0 ? 0 : mem_used / 1048576.0);
     }
 
-    auto hasBeenReplaced = [](ProofNode * node) { return node->getAnt1() != nullptr and node->getAnt2() == nullptr; };
+    auto hasBeenReplaced = [](ProofNode * node) { return node->getAnt1() and not node->getAnt2(); };
     // Restructuring, from leaves to root
     assert(isResetVisited2());
     std::deque<clauseid_t> q;
@@ -170,14 +170,14 @@ double ProofGraph::recyclePivotsIter() {
         assert(id < getGraphSize());
         ProofNode * n = getNode(id);
         q.pop_front();
-        if (n == nullptr or isSetVisited2(id)) { continue; }
+        if (not n or isSetVisited2(id)) { continue; }
         if (n->getAnt1() and not isSetVisited2(n->getAnt1()->getId())) { continue; }
         if (n->getAnt2() and not isSetVisited2(n->getAnt2()->getId())) { continue; }
         // Mark node as visited if both antecedents visited
         setVisited2(id);
         //Non leaf node
         if (n->getAnt1() or n->getAnt2()) {
-            assert(not(n->getAnt1() == nullptr and n->getAnt2() != nullptr));
+            assert(n->getAnt1() or not n->getAnt2());
             // If replaced assign children to replacing node and remove
             if (hasBeenReplaced(n)) {
                 ProofNode * replacing = n->getAnt1();
@@ -192,7 +192,7 @@ double ProofGraph::recyclePivotsIter() {
                     else opensmt_error_();
                     assert(res->getAnt1() != res->getAnt2());
                     replacing->addRes(resId);
-                    assert(!isSetVisited2(resId));
+                    assert(not isSetVisited2(resId));
                     q.push_back(resId);
                 }
                 replacing->remRes(id);
@@ -204,9 +204,9 @@ double ProofGraph::recyclePivotsIter() {
             } else { // node stays
                 assert(n->getAnt1() and n->getAnt2());
                 assert((n->getAnt1()->getAnt1() and n->getAnt1()->getAnt2())
-                       or (n->getAnt1()->getAnt1() == nullptr and n->getAnt1()->getAnt2() == nullptr));
+                       or (not n->getAnt1()->getAnt1() and not n->getAnt1()->getAnt2()));
                 assert((n->getAnt2()->getAnt1() and n->getAnt2()->getAnt2())
-                       or (n->getAnt2()->getAnt1() == nullptr and n->getAnt2()->getAnt2() == nullptr));
+                       or (not n->getAnt2()->getAnt1() and not n->getAnt2()->getAnt2()));
 
                 // NOTE not clear how this might happen
                 if (n->getAnt1() == n->getAnt2()) {
@@ -279,7 +279,7 @@ double ProofGraph::recyclePivotsIter() {
                             else if (res->getAnt2() == n) { res->setAnt2(replacing); }
                             else opensmt_error_();
                             replacing->addRes(clauseid);
-                            assert(!isSetVisited2(clauseid));
+                            assert(not isSetVisited2(clauseid));
                             // Enqueue resolvent
                             q.push_back(clauseid);
                         }

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -40,7 +40,7 @@ void ProofGraph::recyclePivotsIter_RecyclePhase() {
     mpz_init(incr_safe_lit_set_2);
 
     const size_t size = getGraphSize();
-    mpz_t * safe_lit_set = new mpz_t[size];
+    auto * safe_lit_set = new mpz_t[size];
 
     // Allocate root bitset
     mpz_init(safe_lit_set[getRoot()->getId()]);
@@ -51,8 +51,7 @@ void ProofGraph::recyclePivotsIter_RecyclePhase() {
 
     assert(isResetVisited1());
     // To initialize pivots set to the set of the first resolvent
-    for (std::size_t i = 0; i < DFSvec.size(); ++i) {
-        clauseid_t id = DFSvec[i];
+    for (clauseid_t id : DFSvec) {
         ProofNode * n = getNode(id);
         assert(n);
 

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -75,20 +75,20 @@ void ProofGraph::recyclePivotsIter_RecyclePhase() {
 
             assert(n->getAnt1());
             assert(n->getAnt2());
-            // 0 if no replacement, 1 if replacement by ant1, 2 if by ant2
-            short replace = 0;
+            enum class Replace : char {NO, ANT1, ANT2};
+            Replace replace = Replace::NO;
             // Check whether pivot present in all subgraph paths
             if (mpz_tstbit(safe_lit_set[id], pos_piv)) {
-                replace = ant1_has_pos_occ_piv ? 1 : 2;
+                replace = ant1_has_pos_occ_piv ? Replace::ANT1 : Replace::ANT2;
             } else if (mpz_tstbit(safe_lit_set[id], neg_piv)) {
-                replace = ant1_has_pos_occ_piv ? 2 : 1;
+                replace = ant1_has_pos_occ_piv ? Replace::ANT2 : Replace::ANT1;
             }
             // A node marked to be replaced is left with the replacing
             // antecedent at ant1 and with ant2 set to NULL
-            if (replace == 1) {
+            if (replace == Replace::ANT1) {
                 n->getAnt2()->remRes(id);
                 n->setAnt2(nullptr);
-            } else if (replace == 2) {
+            } else if (replace == Replace::ANT2) {
                 n->getAnt1()->remRes(id);
                 n->setAnt1(n->getAnt2());
                 n->setAnt2(nullptr);
@@ -106,7 +106,8 @@ void ProofGraph::recyclePivotsIter_RecyclePhase() {
                     mpz_and(safe_lit_set[id], safe_lit_set[id], other);
             };
             switch (replace) {
-                case 0: {
+                case Replace::NO:
+                {
                     // Set pivot bit for propagation
                     mpz_set(incr_safe_lit_set_1, safe_lit_set[id]);
                     mpz_set(incr_safe_lit_set_2, safe_lit_set[id]);
@@ -118,10 +119,10 @@ void ProofGraph::recyclePivotsIter_RecyclePhase() {
                     updateSet(id2, incr_safe_lit_set_2);
                     break;
                 }
-                case 1:
+                case Replace::ANT1:
                     updateSet(id1, safe_lit_set[id]);
                     break;
-                case 2:
+                case Replace::ANT2:
                     updateSet(id2, safe_lit_set[id]);
                     break;
                 default:


### PR DESCRIPTION
This PR contains style fixes for method `ProofGraph::recyclePivotsIter`.
In addition, two separate phases of this method has been identified:
In the first phase, the proof is traversed from bottom to top and redundant nodes are identified. The redundant edge is removed.
In the second phase, the proof is traversed from top to bottom and redundant nodes identified in the previous phase are replaced with their (now single) parent. This can expose more redundant nodes as now some resolutions might not be necessary anymore.

The first phase has been extracted to standalone method `ProofGraph::recyclePivotsIter_RecyclePhase`. The second phase is still kept in the original method unchanged (except the style fixes).

Depends on #262.