### PR TITLE
Proof transformations cleanup - part 5 of N: ProofGraph::proofTransformAndRestructure

### DIFF
--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -473,7 +473,7 @@ public:
     double          recyclePivotsIter();
     void            recycleUnits();
 
-    bool            getRuleContext				 (clauseid_t, clauseid_t, RuleContext&);
+    RuleContext     getRuleContext				 (clauseid_t, clauseid_t);
     // In case of A1 rule, return id of node added
     clauseid_t      ruleApply               (RuleContext&);
     clauseid_t      applyRuleA1             (RuleContext&);

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -566,7 +566,7 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
         // Enqueue leaves first
         q.assign(leaves_ids.begin(), leaves_ids.end());
         some_transf_done = false;
-        do {
+        while (not q.empty()) {
             clauseid_t id = q.front();
             assert(id < getGraphSize());
             q.pop_front();
@@ -587,9 +587,9 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
                     assert(n->getAnt1());
                     assert(n->getAnt2());
                     assert((n->getAnt1()->getAnt1() and n->getAnt1()->getAnt2())
-                           or (n->getAnt1()->getAnt1() == nullptr and n->getAnt1()->getAnt2() == nullptr));
+                           or (not n->getAnt1()->getAnt1() and not n->getAnt1()->getAnt2()));
                     assert((n->getAnt2()->getAnt1() and n->getAnt2()->getAnt2())
-                           or (n->getAnt2()->getAnt1() == nullptr && n->getAnt2()->getAnt2() == nullptr));
+                           or (not n->getAnt2()->getAnt1() and not n->getAnt2()->getAnt2()));
 
                     //Look for pivot in antecedents
                     short f1 = n->getAnt1()->hasOccurrenceBin(n->getPivot());
@@ -684,7 +684,7 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
                             assert(res->getAnt1() == n or res->getAnt2() == n);
                             if (res->getAnt1() == n) { res->setAnt1(replacing); }
                             else if (res->getAnt2() == n) { res->setAnt2(replacing); }
-                            else {opensmt_error("Error in the structure of the proof"); }
+                            else { throw OsmtInternalException("Invalid proof structure " + std::string(__FILE__) + ", " + std::to_string(__LINE__)); }
                             replacing->addRes(resolvent);
                             q.push_back(resolvent);
                         }
@@ -709,7 +709,7 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
                         if (getNode(resolvent) != nullptr) { q.push_back(resolvent); }
                 }
             }
-        } while (not q.empty());
+        }
         // Visit vector
         resetVisited1();
         // To do only necessary merges, track modified nodes

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -242,7 +242,7 @@ double ProofGraph::recyclePivotsIter() {
                     ProofNode * replacing = choose_ant1 ? n->getAnt1() : n->getAnt2();
                     ProofNode * other = choose_ant1 ? n->getAnt2() : n->getAnt1();
 
-                    bool identicalParents = replacing == other; // MB: This is possible, test_recyclePivots_IdenticalParents is an example.
+                    bool identicalParents = replacing == other; // MB: This is possible, test_recyclePivots_IdenticalAntecedents is an example.
 
                     replacing->remRes(id);
                     if (not identicalParents) {

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -612,10 +612,8 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
                         if (proofCheck() > 1) { checkClause(n->getId()); }
 
                         if (do_transf) {
-                            RuleContext ra1, ra2;
-                            //Look for rules applicability
-                            getRuleContext(n->getAnt1()->getId(), n->getId(), ra1);
-                            getRuleContext(n->getAnt2()->getId(), n->getId(), ra2);
+                            RuleContext ra1 = getRuleContext(n->getAnt1()->getId(), n->getId());
+                            RuleContext ra2 = getRuleContext(n->getAnt2()->getId(), n->getId());
 
                             auto chosen = handleRules(ra1, ra2);
 

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -557,11 +557,17 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
     double init_time = cpuTime();
     assert(not (max_num_loops > 0 and left_time > 0));
     //Flag to check if in a loop at least a transformation has been applied
-    bool some_transf_done;
+    bool some_transf_done = true;
     long curr_num_loops = 0;
     std::deque<clauseid_t> q;
     // Main external loop
-    do {
+    // Continue until
+    // - max number of loops reached or timeout (in case of reduction)
+    // - some transformation is done (in case of pivot reordering)
+    while ((max_num_loops == -1 ? true : curr_num_loops < max_num_loops) and
+           (left_time == -1 ? true : (cpuTime() - init_time) <= left_time) and
+           (left_time != -1 or max_num_loops != -1 or some_transf_done))
+    {
         assert(isResetVisited1() and isResetVisited2());
         // Enqueue leaves first
         q.assign(leaves_ids.begin(), leaves_ids.end());
@@ -722,12 +728,7 @@ void ProofGraph::proofTransformAndRestructure(const double left_time, const int 
             if (rem > 0) std::cerr << "; Cleaned " << rem << " residual nodes" << std::endl;
             checkProof(true);
         }
-    } while ((max_num_loops == -1 ? true : curr_num_loops < max_num_loops) and
-             (left_time == -1 ? true : (cpuTime() - init_time) <= left_time) and
-             (left_time != -1 or max_num_loops != -1 or some_transf_done));
-    //Continue until
-    // - max number of loops reached or timeout (in case of reduction)
-    // - some transformation is done (in case of pivot reordering)
+    }
 
     if (proofCheck()) {
         unsigned rem = cleanProofGraph();

--- a/test/unit/test_Proof.cc
+++ b/test/unit/test_Proof.cc
@@ -90,26 +90,51 @@ TEST(ProofTest, test_mergeClauses_PivotAfterFirstEnd) {
 }
 
 // Reduction algorithms
-TEST(ProofTest, test_recyclePivots) {
-    SMTConfig config;
+
+class ReductionTest : public ::testing::Test {
+protected:
+    ReductionTest(): logic{}, config{}, theory{config, logic}, partitionManager{logic}, termMapper{logic}, ca{}, proof{ca} {}
+    virtual void SetUp() {
+        a_term = logic.mkBoolVar("a");
+        b_term = logic.mkBoolVar("b");
+        c_term = logic.mkBoolVar("c");
+        d_term = logic.mkBoolVar("d");
+        e_term = logic.mkBoolVar("e");
+
+        a = termMapper.getOrCreateLit(a_term);
+        b = termMapper.getOrCreateLit(b_term);
+        c = termMapper.getOrCreateLit(c_term);
+        d = termMapper.getOrCreateLit(d_term);
+        e = termMapper.getOrCreateLit(e_term);
+
+        partitionManager.addIPartitions(a_term, 1);
+        partitionManager.addIPartitions(b_term, 1);
+        partitionManager.addIPartitions(c_term, 1);
+        partitionManager.addIPartitions(d_term, 1);
+        partitionManager.addIPartitions(e_term, 1);
+
+    }
     Logic logic;
-    UFTheory theory(config, logic);
-    // Terms
-    PTRef a_term = logic.mkBoolVar("a");
-    PTRef b_term = logic.mkBoolVar("b");
-    PTRef c_term = logic.mkBoolVar("c");
-    PTRef d_term = logic.mkBoolVar("d");
-    PartitionManager partitionManager(logic);
-    partitionManager.addIPartitions(a_term, 1);
-    partitionManager.addIPartitions(b_term, 1);
-    partitionManager.addIPartitions(c_term, 1);
-    partitionManager.addIPartitions(d_term, 1);
-    TermMapper termMapper(logic);
-    Lit a = termMapper.getOrCreateLit(a_term);
-    Lit b = termMapper.getOrCreateLit(b_term);
-    Lit c = termMapper.getOrCreateLit(c_term);
-    Lit d = termMapper.getOrCreateLit(d_term);
+    SMTConfig config;
+    UFTheory theory;
+    PartitionManager partitionManager;
+    TermMapper termMapper;
     ClauseAllocator ca;
+    Proof proof;
+
+    PTRef a_term;
+    PTRef b_term;
+    PTRef c_term;
+    PTRef d_term;
+    PTRef e_term;
+
+    Lit a;
+    Lit b;
+    Lit c;
+    Lit d;
+    Lit e;
+};
+TEST_F(ReductionTest, test_recyclePivots) {
     CRef a_b = ca.alloc(vec<Lit>{a,b}, false);
     CRef nb_c = ca.alloc(vec<Lit>{~b,c}, false);
     CRef nb_nc = ca.alloc(vec<Lit>{~b,~c}, false);
@@ -122,7 +147,6 @@ TEST(ProofTest, test_recyclePivots) {
     for (CRef cr : clauses) {
         partitionManager.addClauseClassMask(cr, 1);
     }
-    Proof proof(ca);
     for (CRef cr : clauses) {
         proof.newOriginalClause(cr);
     }
@@ -160,29 +184,7 @@ TEST(ProofTest, test_recyclePivots) {
     EXPECT_TRUE(true);
 }
 
-TEST(ProofTest, test_recyclePivots_IdenticalAntecedents) {
-    SMTConfig config;
-    Logic logic;
-    UFTheory theory(config, logic);
-    // Terms
-    PTRef a_term = logic.mkBoolVar("a");
-    PTRef b_term = logic.mkBoolVar("b");
-    PTRef c_term = logic.mkBoolVar("c");
-    PTRef d_term = logic.mkBoolVar("d");
-    PTRef e_term = logic.mkBoolVar("e");
-    PartitionManager partitionManager(logic);
-    partitionManager.addIPartitions(a_term, 1);
-    partitionManager.addIPartitions(b_term, 1);
-    partitionManager.addIPartitions(c_term, 1);
-    partitionManager.addIPartitions(d_term, 1);
-    partitionManager.addIPartitions(e_term, 1);
-    TermMapper termMapper(logic);
-    Lit a = termMapper.getOrCreateLit(a_term);
-    Lit b = termMapper.getOrCreateLit(b_term);
-    Lit c = termMapper.getOrCreateLit(c_term);
-    Lit d = termMapper.getOrCreateLit(d_term);
-    Lit e = termMapper.getOrCreateLit(e_term);
-    ClauseAllocator ca;
+TEST_F(ReductionTest, test_recyclePivots_IdenticalAntecedents) {
     CRef a_d = ca.alloc(vec<Lit>{a,d}, false);
     CRef b_nd = ca.alloc(vec<Lit>{b,~d}, false);
     CRef na_c = ca.alloc(vec<Lit>{~a,c}, false);
@@ -196,7 +198,6 @@ TEST(ProofTest, test_recyclePivots_IdenticalAntecedents) {
     for (CRef cr : clauses) {
         partitionManager.addClauseClassMask(cr, 1);
     }
-    Proof proof(ca);
     for (CRef cr : clauses) {
         proof.newOriginalClause(cr);
     }
@@ -243,29 +244,7 @@ TEST(ProofTest, test_recyclePivots_IdenticalAntecedents) {
     EXPECT_TRUE(true);
 }
 
-TEST(ProofTest, test_proofTransformAndRestructure) {
-    SMTConfig config;
-    Logic logic;
-    UFTheory theory(config, logic);
-    // Terms
-    PTRef a_term = logic.mkBoolVar("a");
-    PTRef b_term = logic.mkBoolVar("b");
-    PTRef c_term = logic.mkBoolVar("c");
-    PTRef d_term = logic.mkBoolVar("d");
-    PTRef e_term = logic.mkBoolVar("e");
-    PartitionManager partitionManager(logic);
-    partitionManager.addIPartitions(a_term, 1);
-    partitionManager.addIPartitions(b_term, 1);
-    partitionManager.addIPartitions(c_term, 1);
-    partitionManager.addIPartitions(d_term, 1);
-    partitionManager.addIPartitions(e_term, 1);
-    TermMapper termMapper(logic);
-    Lit a = termMapper.getOrCreateLit(a_term);
-    Lit b = termMapper.getOrCreateLit(b_term);
-    Lit c = termMapper.getOrCreateLit(c_term);
-    Lit d = termMapper.getOrCreateLit(d_term);
-    Lit e = termMapper.getOrCreateLit(e_term);
-    ClauseAllocator ca;
+TEST_F(ReductionTest, test_proofTransformAndRestructure) {
     CRef a_b = ca.alloc(vec<Lit>{a,b}, false);
     CRef na_c = ca.alloc(vec<Lit>{~a,c}, false);
     CRef na_nb_d = ca.alloc(vec<Lit>{~a,~b,d}, false);
@@ -277,7 +256,6 @@ TEST(ProofTest, test_proofTransformAndRestructure) {
     for (CRef cr : clauses) {
         partitionManager.addClauseClassMask(cr, 1);
     }
-    Proof proof(ca);
     for (CRef cr : clauses) {
         proof.newOriginalClause(cr);
     }
@@ -327,29 +305,7 @@ TEST(ProofTest, test_proofTransformAndRestructure) {
  *  However, the situation is not problematic and such node should just be replaced with its single parent.
  *
  */
-TEST(ProofTest, test_proofTransformAndRestructure_IdenticalAntecedents) {
-    SMTConfig config;
-    Logic logic;
-    UFTheory theory(config, logic);
-    // Terms
-    PTRef a_term = logic.mkBoolVar("a");
-    PTRef b_term = logic.mkBoolVar("b");
-    PTRef c_term = logic.mkBoolVar("c");
-    PTRef d_term = logic.mkBoolVar("d");
-    PTRef e_term = logic.mkBoolVar("e");
-    PartitionManager partitionManager(logic);
-    partitionManager.addIPartitions(a_term, 1);
-    partitionManager.addIPartitions(b_term, 1);
-    partitionManager.addIPartitions(c_term, 1);
-    partitionManager.addIPartitions(d_term, 1);
-    partitionManager.addIPartitions(e_term, 1);
-    TermMapper termMapper(logic);
-    Lit a = termMapper.getOrCreateLit(a_term);
-    Lit b = termMapper.getOrCreateLit(b_term);
-    Lit c = termMapper.getOrCreateLit(c_term);
-    Lit d = termMapper.getOrCreateLit(d_term);
-    Lit e = termMapper.getOrCreateLit(e_term);
-    ClauseAllocator ca;
+TEST_F(ReductionTest, test_proofTransformAndRestructure_IdenticalAntecedents) {
     CRef a_b = ca.alloc(vec<Lit>{a,b}, false);
     CRef na_c = ca.alloc(vec<Lit>{~a,c}, false);
     CRef na_nb_d = ca.alloc(vec<Lit>{~a,~b,d}, false);
@@ -362,7 +318,6 @@ TEST(ProofTest, test_proofTransformAndRestructure_IdenticalAntecedents) {
     for (CRef cr : clauses) {
         partitionManager.addClauseClassMask(cr, 1);
     }
-    Proof proof(ca);
     for (CRef cr : clauses) {
         proof.newOriginalClause(cr);
     }


### PR DESCRIPTION
This PR deals with cleaning up the method `ProofGraph::proofTransformAndRestructure`.

It adds two unit tests for checking basic functionality of the method, the second one exposing a path in the code that previously triggered error. It is a situation similar to the one in #264, i.e., while restructuring and reducing the proof, the algorithm might run into a situation where a node has identical antecedents. Previously this was reported as an error and the program terminated.
However, as the unit test shows, such a situation can occur for a valid proof as input. The same solution as in #264 can be applied, the algorithm only needs to replace the node with its (single) antecedent and continue as normal.

Apart from this, small style fixes has been applied.
Depends on #264. 