### PR TITLE
Proof: Relax rules on leaf types

### DIFF
--- a/src/proof/PGHelp.cc
+++ b/src/proof/PGHelp.cc
@@ -71,7 +71,7 @@ void ProofGraph::getGraphInfo()
             }
             else
             {
-                assert(n->getType()==clause_type::CLA_ORIG || n->getType() == clause_type::CLA_THEORY);
+                assert(isLeafClauseType(n->getType()));
                 num_leaves++;
             }
 

--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -279,8 +279,8 @@ double ProofGraph::recyclePivotsIter() {
                     if (proofCheck() > 1) checkClause(replacing->getId());
                 }
             }
-        } else {
-            assert(n->getType() == clause_type::CLA_ORIG or n->getType() == clause_type::CLA_THEORY);
+        } else { // Leaf node
+            assert(isLeafClauseType(n->getType()));
             assert(n->getNumResolvents() > 0);
             for (clauseid_t clauseid : n->getResolvents()) {
                 if (getNode(clauseid)) { q.push_back(clauseid); }


### PR DESCRIPTION
Beside the original and theory clauses, split clauses and assumptions clauses can now occur as leaves in the proof.