### PR TITLE
Introduce and use Span data structure

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -15,13 +15,14 @@ target_sources(common
     "${CMAKE_CURRENT_LIST_DIR}/Timer.h"
     "${CMAKE_CURRENT_LIST_DIR}/TreeOps.h"
     "${CMAKE_CURRENT_LIST_DIR}/NatSet.h"
+    "${CMAKE_CURRENT_LIST_DIR}/Span.h"
     "${CMAKE_CURRENT_LIST_DIR}/PartitionInfo.cc"
     "${CMAKE_CURRENT_LIST_DIR}/VerificationUtils.cc"
 )
 
 install(FILES 
     Global.h Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h SigMap.h Timer.h osmtinttypes.h
-    TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h
+    TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h Span.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/Span.h
+++ b/src/common/Span.h
@@ -40,6 +40,12 @@ struct Span {
     T const & operator[](std::size_t i) const { return *(pointer + i); }
 };
 
+template<typename T>
+inline Span<T> make_span(vec<T> const & v) { return Span<T>(v); }
+
+template<typename T>
+inline Span<T> make_span(std::vector<T> const & v) { return Span<T>(v); }
+
 }
 
 #endif //OPENSMT_SPAN_H

--- a/src/common/Span.h
+++ b/src/common/Span.h
@@ -20,6 +20,14 @@ struct Span {
     template<typename U,
         std::enable_if_t<std::is_const<element_type>::value and std::is_convertible_v<U,T>,
             int> = 0>
+    Span(Span<U> other) noexcept {
+        length = other.length;
+        pointer = other.pointer;
+    }
+
+    template<typename U,
+        std::enable_if_t<std::is_const<element_type>::value and std::is_convertible_v<U,T>,
+            int> = 0>
     Span(std::initializer_list<U> list) noexcept {
         length = list.size();
         pointer = list.begin();
@@ -64,7 +72,13 @@ template<typename T>
 inline Span<const T> make_span(vec<T> const & v) { return Span<const T>(v); }
 
 template<typename T>
+inline Span<T> make_span(vec<T> & v) { return Span<T>(v); }
+
+template<typename T>
 inline Span<const T> make_span(std::vector<T> const & v) { return Span<const T>(v); }
+
+template<typename T>
+inline Span<T> make_span(std::vector<T> & v) { return Span<T>(v); }
 
 }
 

--- a/src/common/Span.h
+++ b/src/common/Span.h
@@ -1,0 +1,45 @@
+//
+// Created by Martin Blicha on 03.09.21.
+//
+
+#ifndef OPENSMT_SPAN_H
+#define OPENSMT_SPAN_H
+
+namespace opensmt {
+
+template<typename T>
+struct Span {
+    T const * pointer = nullptr;
+    std::size_t length = 0;
+
+    using iterator = T const *;
+
+    Span() = default;
+
+    Span(std::initializer_list<T> list) noexcept {
+        length = list.size();
+        pointer = list.begin();
+    }
+
+    explicit Span(vec<T> const & v) noexcept {
+        length = v.size();
+        pointer = v.begin();
+    }
+
+    explicit Span(std::vector<T> const & v) noexcept {
+        length = v.size();
+        pointer = &v[0];
+    }
+
+
+    std::size_t size() const { return length; }
+
+    iterator begin() const { return pointer; }
+    iterator end() const { return pointer + length; }
+
+    T const & operator[](std::size_t i) const { return *(pointer + i); }
+};
+
+}
+
+#endif //OPENSMT_SPAN_H

--- a/src/common/Span.h
+++ b/src/common/Span.h
@@ -9,26 +9,46 @@ namespace opensmt {
 
 template<typename T>
 struct Span {
-    T const * pointer = nullptr;
+    T * pointer = nullptr;
     std::size_t length = 0;
 
-    using iterator = T const *;
+    using iterator = T *;
+    using element_type = T;
 
     Span() = default;
 
-    Span(std::initializer_list<T> list) noexcept {
+    template<typename U,
+        std::enable_if_t<std::is_const<element_type>::value and std::is_convertible_v<U,T>,
+            int> = 0>
+    Span(std::initializer_list<U> list) noexcept {
         length = list.size();
         pointer = list.begin();
     }
 
-    explicit Span(vec<T> const & v) noexcept {
+    template<typename U,
+        std::enable_if_t<std::is_const<element_type>::value and std::is_convertible_v<U,T>,
+            int> = 0>
+    explicit Span(vec<U> const & v) noexcept {
         length = v.size();
         pointer = v.begin();
     }
 
-    explicit Span(std::vector<T> const & v) noexcept {
+    explicit Span(vec<T> & v) noexcept {
         length = v.size();
-        pointer = &v[0];
+        pointer = v.begin();
+    }
+
+    template<typename U,
+    std::enable_if_t<std::is_const<element_type>::value and std::is_convertible_v<U,T>,
+        int> = 0>
+    explicit Span(std::vector<U> const & v) noexcept {
+        length = v.size();
+        pointer = v.data();
+    }
+
+    explicit Span(std::vector<T> & v) noexcept {
+        length = v.size();
+        pointer = v.data();
     }
 
 
@@ -41,10 +61,10 @@ struct Span {
 };
 
 template<typename T>
-inline Span<T> make_span(vec<T> const & v) { return Span<T>(v); }
+inline Span<const T> make_span(vec<T> const & v) { return Span<const T>(v); }
 
 template<typename T>
-inline Span<T> make_span(std::vector<T> const & v) { return Span<T>(v); }
+inline Span<const T> make_span(std::vector<T> const & v) { return Span<const T>(v); }
 
 }
 

--- a/src/logics/BVLogic.cc
+++ b/src/logics/BVLogic.cc
@@ -217,10 +217,7 @@ BVLogic::mkBVEq(PTRef a1, PTRef a2)
         return (a1 == a2) ? getTerm_BVOne() : getTerm_BVZero();
     if (a1 == a2) return getTerm_BVOne();
     if (a1 == mkBVNot(a2)) return getTerm_BVZero();
-    vec<PTRef> tmp;
-    tmp.push(a1);
-    tmp.push(a2);
-    return mkFun(sym_BV_EQ, tmp);
+    return mkFun(sym_BV_EQ, {a1,a2});
 }
 
 PTRef
@@ -266,10 +263,7 @@ BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> sum_args;
-    sum_args.push(arg1);
-    sum_args.push(arg2);
-    PTRef tr = mkFun(sym_BV_PLUS, sum_args);
+    PTRef tr = mkFun(sym_BV_PLUS, {arg1, arg2});
 //    sum_args[0] = arg2;
 //    sum_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_PLUS, sum_args, msg);
@@ -286,11 +280,7 @@ BVLogic::mkBVTimes(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> times_args;
-    times_args.push(arg1);
-    times_args.push(arg2);
-
-    PTRef tr = mkFun(sym_BV_TIMES, times_args);
+    PTRef tr = mkFun(sym_BV_TIMES, {arg1, arg2});
 //    times_args[0] = arg2;
 //    times_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_TIMES, times_args, msg);
@@ -306,10 +296,7 @@ BVLogic::mkBVDiv(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> div_args;
-    div_args.push(arg1);
-    div_args.push(arg2);
-    PTRef tr = mkFun(sym_BV_DIV, div_args);
+    PTRef tr = mkFun(sym_BV_DIV, {arg1, arg2});
     return tr;
 }
 
@@ -378,10 +365,7 @@ BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2)
         else
             return term_BV_ZERO;
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_ULEQ, args);
+    PTRef tr = mkFun(sym_BV_ULEQ, {arg1, arg2});
     return tr;
 }
 
@@ -407,10 +391,7 @@ BVLogic::mkBVSlt(const PTRef arg1, const PTRef arg2)
         else
             return term_BV_ZERO;
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_SLT, args);
+    PTRef tr = mkFun(sym_BV_SLT, {arg1, arg2});
     return tr;
 }
 
@@ -421,30 +402,21 @@ PTRef BVLogic::mkBVLshift(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg2));
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_LSHIFT, args);
+    return mkFun(sym_BV_LSHIFT, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVLRshift(const PTRef arg1, const PTRef arg2)
 {
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_LRSHIFT, args);
+    return mkFun(sym_BV_LRSHIFT, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVARshift(const PTRef arg1, const PTRef arg2)
 {
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_ARSHIFT, args);
+    return mkFun(sym_BV_ARSHIFT, {arg1, arg2});
 }
 
 
@@ -457,30 +429,21 @@ PTRef BVLogic::mkBVMod(const PTRef arg1, const PTRef arg2)
         return getTerm_BVZero();
     // if b > 0, then 0 <= a % b < b
     // if b < 0, then b < a % b <= 0
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_MOD, args);
+    return mkFun(sym_BV_MOD, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVBwAnd(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWAND, args);
+    return mkFun(sym_BV_BWAND, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVBwOr(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWOR, args);
+    return mkFun(sym_BV_BWOR, {arg1, arg2});
 }
 
 /*PTRef BVLogic::mkBVInc(const PTRef arg1)
@@ -513,10 +476,7 @@ PTRef BVLogic::mkBVLand(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_LAND, args);
+    PTRef tr = mkFun(sym_BV_LAND, {arg1, arg2});
     return tr;
 }
 
@@ -524,10 +484,7 @@ PTRef BVLogic::mkBVLor(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_LOR, args);
+    PTRef tr = mkFun(sym_BV_LOR, {arg1, arg2});
     return tr;
 }
 
@@ -540,9 +497,7 @@ PTRef BVLogic::mkBVNot(const PTRef arg)
         return term_BV_ZERO;
     else if (arg == term_BV_ZERO)
         return term_BV_ONE;
-    vec<PTRef> tmp;
-    tmp.push(arg);
-    PTRef tr = mkFun(sym_BV_NOT, tmp);
+    PTRef tr = mkFun(sym_BV_NOT, {arg});
     return tr;
 }
 
@@ -550,18 +505,13 @@ PTRef BVLogic::mkBVBwXor(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWXOR, args);
+    return mkFun(sym_BV_BWXOR, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVCompl(const PTRef arg1)
 {
     assert(hasSortBVNUM(arg1));
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_BV_COMPL, args);
+    PTRef tr = mkFun(sym_BV_COMPL, {arg1});
 //    PTRef neq = mkBVNeq(tr, arg1);
 //    if (!compl_diseqs.has(neq))
 //        compl_diseqs.insert(neq, true);

--- a/src/logics/CUFLogic.cc
+++ b/src/logics/CUFLogic.cc
@@ -207,8 +207,7 @@ CUFLogic::mkCUFNeg(PTRef tr, char** msg)
         v = -v;
         PTRef nterm = mkCUFConst(v);
         SymRef s = getPterm(nterm).symb();
-        vec<PTRef> args;
-        return mkFun(s, args);
+        return mkFun(s, {});
     }
     PTRef mo = mkCUFConst(-1);
     return mkCUFTimes(mo, tr);
@@ -236,13 +235,8 @@ CUFLogic::mkCUFMinus(const vec<PTRef>& args_in, char** msg)
 PTRef
 CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
 {
-    vec<PTRef> sum_args;
-    sum_args.push(arg1);
-    sum_args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_PLUS, sum_args);
-    sum_args[0] = arg2;
-    sum_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_PLUS, sum_args);
+    PTRef tr = mkFun(sym_CUF_PLUS, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_PLUS, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -316,14 +310,8 @@ CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
 PTRef
 CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
 {
-    vec<PTRef> times_args;
-    times_args.push(arg1);
-    times_args.push(arg2);
-
-    PTRef tr = mkFun(sym_CUF_TIMES, times_args);
-    times_args[0] = arg2;
-    times_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_TIMES, times_args);
+    PTRef tr = mkFun(sym_CUF_TIMES, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_TIMES, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -333,10 +321,7 @@ CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
 PTRef
 CUFLogic::mkCUFDiv(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> div_args;
-    div_args.push(arg1);
-    div_args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_DIV, div_args);
+    PTRef tr = mkFun(sym_CUF_DIV, {arg1, arg2});
     return tr;
 }
 
@@ -357,10 +342,7 @@ CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2, char** msg)
         else
             return getTerm_false();
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef leq_tr = mkFun(sym_CUF_LEQ, args);
+    PTRef leq_tr = mkFun(sym_CUF_LEQ, {arg1, arg2});
     return mkOr(leq_tr, mkEq(arg1, arg2));
 }
 
@@ -375,10 +357,7 @@ CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2, char** msg)
         else
             return getTerm_false();
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_GT, args);
+    PTRef tr = mkFun(sym_CUF_GT, {arg1, arg2});
     // a>b -> a != b
     PTRef tr_eq = mkEq(arg1, arg2);
     PTRef n_tr_eq = mkCUFNot(tr_eq);
@@ -397,30 +376,21 @@ PTRef CUFLogic::mkCUFLshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_LSHIFT, args);
+    return mkFun(sym_CUF_LSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFLRshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_LRSHIFT, args);
+    return mkFun(sym_CUF_LRSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFARshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_ARSHIFT, args);
+    return mkFun(sym_CUF_ARSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
@@ -429,21 +399,13 @@ PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
         return getTerm_CUFZero();
     // if b > 0, then 0 <= a % b < b
     // if b < 0, then b < a % b <= 0
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_MOD, args);
+    return mkFun(sym_CUF_MOD, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWAND, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWAND, args);
+    PTRef tr = mkFun(sym_CUF_BWAND, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWAND, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -452,13 +414,8 @@ PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFBwOr(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWOR, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWOR, args);
+    PTRef tr = mkFun(sym_CUF_BWOR, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWOR, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -467,9 +424,7 @@ PTRef CUFLogic::mkCUFBwOr(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFInc(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_INC, args);
+    PTRef tr = mkFun(sym_CUF_INC, {arg1});
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -478,9 +433,7 @@ PTRef CUFLogic::mkCUFInc(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFDec(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_DEC, args);
+    PTRef tr = mkFun(sym_CUF_DEC, {arg1});
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -489,19 +442,13 @@ PTRef CUFLogic::mkCUFDec(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFLand(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_LAND, args);
+    PTRef tr = mkFun(sym_CUF_LAND, {arg1, arg2});
     return tr;
 }
 
 PTRef CUFLogic::mkCUFLor(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_LOR, args);
+    PTRef tr = mkFun(sym_CUF_LOR, {arg1, arg2});
     return tr;
 }
 
@@ -512,13 +459,8 @@ PTRef CUFLogic::mkCUFNot(const PTRef arg)
 
 PTRef CUFLogic::mkCUFBwXor(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWXOR, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWXOR, args);
+    PTRef tr = mkFun(sym_CUF_BWXOR, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWXOR, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -527,9 +469,7 @@ PTRef CUFLogic::mkCUFBwXor(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFCompl(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_COMPL, args);
+    PTRef tr = mkFun(sym_CUF_COMPL, {arg1});
     PTRef neq = mkCUFNeq(tr, arg1);
     if (!compl_diseqs.has(neq))
         compl_diseqs.insert(neq, true);
@@ -538,24 +478,18 @@ PTRef CUFLogic::mkCUFCompl(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFSizeof(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_SIZEOF, args);
+    return mkFun(sym_CUF_SIZEOF, {arg});
 }
 
 PTRef CUFLogic::mkCUFAddrof(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_SIZEOF, args);
+    return mkFun(sym_CUF_SIZEOF, {arg});
 }
 
 
 PTRef CUFLogic::mkCUFPtr(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_PTR, args);
+    return mkFun(sym_CUF_PTR, {arg});
 }
 
 PTRef CUFLogic::mkCUFCond(const PTRef cond, PTRef i_arg, PTRef e_arg)

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -284,7 +284,7 @@ PTRef LALogic::mkNumMinus(const vec<PTRef>& args_in, char** msg)
     return mkNumPlus(args);
 }
 
-PTRef LALogic::mkNumPlus(opensmt::Span<PTRef> const & args)
+PTRef LALogic::mkNumPlus(opensmt::Span<const PTRef> args)
 {
     vec<PTRef> new_args;
     new_args.capacity(args.size());
@@ -348,7 +348,7 @@ PTRef LALogic::mkNumPlus(opensmt::Span<PTRef> const & args)
     PTRef tr = mkFun(s_new, opensmt::make_span(sum_args));
     return tr;
 }
-PTRef LALogic::mkNumTimes(opensmt::Span<PTRef> const & tmp_args)
+PTRef LALogic::mkNumTimes(opensmt::Span<const PTRef> tmp_args)
 {
     vec<PTRef> args;
     // Flatten possible internal multiplications

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -191,7 +191,7 @@ PTRef LALogic::mkNumNeg(PTRef tr)
             assert(tr_arg != PTRef_Undef);
             args.push(tr_arg);
         }
-        PTRef tr_n = mkFun(get_sym_Num_PLUS(), opensmt::Span<PTRef>(args));
+        PTRef tr_n = mkFun(get_sym_Num_PLUS(), opensmt::make_span(args));
         assert(tr_n == mkNumPlus(args));
         assert(tr_n != PTRef_Undef);
         return tr_n;
@@ -307,7 +307,7 @@ PTRef LALogic::mkNumPlus(opensmt::Span<PTRef> const & args)
     if (args_new.size() == 1)
         return args_new[0];
     if (s_new != get_sym_Num_PLUS()) {
-        return mkFun(s_new, opensmt::Span<PTRef>(args_new));
+        return mkFun(s_new, opensmt::make_span(args_new));
     }
     // This code takes polynomials (+ (* v c1) (* v c2)) and converts them to the form (* v c3) where c3 = c1+c2
     VecMap<PTRef,PTRef,PTRefHash> s2t;
@@ -345,7 +345,7 @@ PTRef LALogic::mkNumPlus(opensmt::Span<PTRef> const & args)
     }
     if (sum_args.size() == 0) return getTerm_NumZero();
     if (sum_args.size() == 1) return sum_args[0];
-    PTRef tr = mkFun(s_new, opensmt::Span<PTRef>(sum_args));
+    PTRef tr = mkFun(s_new, opensmt::make_span(sum_args));
     return tr;
 }
 PTRef LALogic::mkNumTimes(opensmt::Span<PTRef> const & tmp_args)
@@ -365,7 +365,7 @@ PTRef LALogic::mkNumTimes(opensmt::Span<PTRef> const & tmp_args)
     vec<PTRef> args_new;
     SymRef s_new;
     simp.simplify(get_sym_Num_TIMES(), args, s_new, args_new);
-    PTRef tr = mkFun(s_new, opensmt::Span<PTRef>(args_new));
+    PTRef tr = mkFun(s_new, opensmt::make_span(args_new));
     // Either a real term or, if we constructed a multiplication of a
     // constant and a sum, a real sum.
     if (isNumTerm(tr) || isNumPlus(tr) || isUF(tr) || isIte(tr))
@@ -788,7 +788,7 @@ PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
     splitTermToVarAndConst(leadingFactor, var, coeff);
     opensmt::Number normalizationCoeff = abs(getNumConst(coeff));
     // varFactors come from a normalized sum, no need to call normalization code again
-    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : insertTermHash(get_sym_Num_PLUS(), opensmt::Span<PTRef>(varFactors));
+    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : insertTermHash(get_sym_Num_PLUS(), opensmt::make_span(varFactors));
     if (normalizationCoeff != 1) {
         // normalize the whole sum
         normalizedSum = mkNumTimes(normalizedSum, mkConst(normalizationCoeff.inverse()));
@@ -796,7 +796,7 @@ PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
         constantVal /= normalizationCoeff;
     }
     constantVal.negate(); // moving the constant to the LHS of the inequality
-    return insertTermHash(get_sym_Num_LEQ(), opensmt::Span<PTRef>{mkConst(constantVal), normalizedSum});
+    return insertTermHash(get_sym_Num_LEQ(), {mkConst(constantVal), normalizedSum});
 }
 
 PTRef LALogic::getConstantFromLeq(PTRef leq) {

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -130,14 +130,14 @@ public:
     virtual PTRef mkNumMinus(const vec<PTRef> &, char **);
     virtual PTRef mkNumMinus(const vec<PTRef> &args);
     virtual PTRef mkNumMinus(const PTRef a1, const PTRef a2);
-    virtual PTRef mkNumPlus(opensmt::Span<PTRef> const & args);
-    inline PTRef mkNumPlus(std::initializer_list<PTRef> l) { return mkNumPlus(opensmt::Span<PTRef>(l)); }
+    virtual PTRef mkNumPlus(opensmt::Span<const PTRef> args);
+    inline PTRef mkNumPlus(std::initializer_list<PTRef> l) { return mkNumPlus(opensmt::Span<const PTRef>(l)); }
     inline PTRef mkNumPlus(const vec<PTRef> &args) { return mkNumPlus(opensmt::make_span(args)); }
     inline PTRef mkNumPlus(const std::vector<PTRef> &args) { return mkNumPlus(opensmt::make_span(args)); }
     inline PTRef mkNumPlus(const PTRef p1, const PTRef p2) { return mkNumPlus({p1,p2}); }
-    virtual PTRef mkNumTimes(const opensmt::Span<PTRef> &args);
-    inline PTRef mkNumTimes(std::initializer_list<PTRef> l) { return mkNumTimes(opensmt::Span<PTRef>(l)); }
+    virtual PTRef mkNumTimes(opensmt::Span<const PTRef> args);
     inline PTRef mkNumTimes(const vec<PTRef> &args) { return mkNumTimes(opensmt::make_span(args)); }
+    inline PTRef mkNumTimes(std::initializer_list<PTRef> l) { return mkNumTimes(opensmt::Span<const PTRef>(l)); }
     inline PTRef mkNumTimes(const std::vector<PTRef> &args) { return mkNumTimes(opensmt::make_span(args)); }
     inline PTRef mkNumTimes(const PTRef p1, const PTRef p2) { return mkNumTimes({p1, p2}); }
     virtual PTRef mkNumDiv(const vec<PTRef> &args) = 0;

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -126,19 +126,20 @@ public:
     virtual PTRef getTerm_NumZero() const = 0;
     virtual PTRef getTerm_NumOne() const = 0;
     virtual PTRef getTerm_NumMinusOne() const = 0;
-    virtual PTRef mkNumNeg(PTRef, char **);
     virtual PTRef mkNumNeg(PTRef tr);
     virtual PTRef mkNumMinus(const vec<PTRef> &, char **);
     virtual PTRef mkNumMinus(const vec<PTRef> &args);
     virtual PTRef mkNumMinus(const PTRef a1, const PTRef a2);
-    virtual PTRef mkNumPlus(const vec<PTRef> &, char **);
-    virtual PTRef mkNumPlus(const vec<PTRef> &args);
-    virtual PTRef mkNumPlus(const std::vector<PTRef> &args);
-    virtual PTRef mkNumPlus(const PTRef p1, const PTRef p2);
-    virtual PTRef mkNumTimes(const vec<PTRef> &, char **);
-    virtual PTRef mkNumTimes(const vec<PTRef> &args);
-    virtual PTRef mkNumTimes(const PTRef p1, const PTRef p2);
-    virtual PTRef mkNumTimes(const std::vector<PTRef> &args);
+    virtual PTRef mkNumPlus(opensmt::Span<PTRef> const & args);
+    inline PTRef mkNumPlus(std::initializer_list<PTRef> l) { return mkNumPlus(opensmt::Span<PTRef>(l)); }
+    inline PTRef mkNumPlus(const vec<PTRef> &args) { return mkNumPlus(opensmt::Span<PTRef>(args)); }
+    inline PTRef mkNumPlus(const std::vector<PTRef> &args) { return mkNumPlus(opensmt::Span<PTRef>(args)); }
+    inline PTRef mkNumPlus(const PTRef p1, const PTRef p2) { return mkNumPlus({p1,p2}); }
+    virtual PTRef mkNumTimes(const opensmt::Span<PTRef> &args);
+    inline PTRef mkNumTimes(std::initializer_list<PTRef> l) { return mkNumTimes(opensmt::Span<PTRef>(l)); }
+    inline PTRef mkNumTimes(const PTRef p1, const PTRef p2) { return mkNumTimes({p1, p2}); }
+    inline PTRef mkNumTimes(const vec<PTRef> &args) { return mkNumTimes(opensmt::Span<PTRef>(args)); }
+    inline PTRef mkNumTimes(const std::vector<PTRef> &args) { return mkNumTimes(opensmt::Span<PTRef>(args)); }
     virtual PTRef mkNumDiv(const vec<PTRef> &args) = 0;
     virtual PTRef mkNumDiv(const PTRef nom, const PTRef den) = 0;
     virtual PTRef mkNumLeq(const vec<PTRef> &args);

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -132,14 +132,14 @@ public:
     virtual PTRef mkNumMinus(const PTRef a1, const PTRef a2);
     virtual PTRef mkNumPlus(opensmt::Span<PTRef> const & args);
     inline PTRef mkNumPlus(std::initializer_list<PTRef> l) { return mkNumPlus(opensmt::Span<PTRef>(l)); }
-    inline PTRef mkNumPlus(const vec<PTRef> &args) { return mkNumPlus(opensmt::Span<PTRef>(args)); }
-    inline PTRef mkNumPlus(const std::vector<PTRef> &args) { return mkNumPlus(opensmt::Span<PTRef>(args)); }
+    inline PTRef mkNumPlus(const vec<PTRef> &args) { return mkNumPlus(opensmt::make_span(args)); }
+    inline PTRef mkNumPlus(const std::vector<PTRef> &args) { return mkNumPlus(opensmt::make_span(args)); }
     inline PTRef mkNumPlus(const PTRef p1, const PTRef p2) { return mkNumPlus({p1,p2}); }
     virtual PTRef mkNumTimes(const opensmt::Span<PTRef> &args);
     inline PTRef mkNumTimes(std::initializer_list<PTRef> l) { return mkNumTimes(opensmt::Span<PTRef>(l)); }
+    inline PTRef mkNumTimes(const vec<PTRef> &args) { return mkNumTimes(opensmt::make_span(args)); }
+    inline PTRef mkNumTimes(const std::vector<PTRef> &args) { return mkNumTimes(opensmt::make_span(args)); }
     inline PTRef mkNumTimes(const PTRef p1, const PTRef p2) { return mkNumTimes({p1, p2}); }
-    inline PTRef mkNumTimes(const vec<PTRef> &args) { return mkNumTimes(opensmt::Span<PTRef>(args)); }
-    inline PTRef mkNumTimes(const std::vector<PTRef> &args) { return mkNumTimes(opensmt::Span<PTRef>(args)); }
     virtual PTRef mkNumDiv(const vec<PTRef> &args) = 0;
     virtual PTRef mkNumDiv(const PTRef nom, const PTRef den) = 0;
     virtual PTRef mkNumLeq(const vec<PTRef> &args);

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -196,7 +196,7 @@ PTRef LIALogic::sumToNormalizedInequality(PTRef sum) {
             varFactors[i] = mkNumTimes(vars[i], mkConst(coeffs[i]));
         }
     }
-    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), opensmt::Span<PTRef>(varFactors));
+    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), opensmt::make_span(varFactors));
     // 0 <= normalizedSum + constatValue
     // in LIA we can strengthen the inequality to
     // ceiling(-constantValue) <= normalizedSum

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -196,7 +196,7 @@ PTRef LIALogic::sumToNormalizedInequality(PTRef sum) {
             varFactors[i] = mkNumTimes(vars[i], mkConst(coeffs[i]));
         }
     }
-    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), varFactors);
+    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), opensmt::Span<PTRef>(varFactors));
     // 0 <= normalizedSum + constatValue
     // in LIA we can strengthen the inequality to
     // ceiling(-constantValue) <= normalizedSum
@@ -217,17 +217,14 @@ PTRef LIALogic::insertTerm(SymRef sym, vec<PTRef> &terms) {
 
 PTRef LIALogic::mkIntDiv(vec<PTRef> const & args) {
     if (args.size() != 2) { throw OsmtApiException("Incorrect number of arguments for DIV operator"); }
-    return _mkIntDiv(args);
+    return _mkIntDiv(args[0], args[1]);
 }
 
 PTRef LIALogic::mkIntDiv(PTRef dividend, PTRef divisor) {
-    return _mkIntDiv({dividend, divisor});
+    return _mkIntDiv(dividend, divisor);
 }
 
-PTRef LIALogic::_mkIntDiv(const vec<PTRef> & args) {
-    assert(args.size() == 2);
-    PTRef dividend = args[0];
-    PTRef divisor = args[1];
+PTRef LIALogic::_mkIntDiv(PTRef dividend, PTRef divisor) {
     if (not isConstant(divisor)) { throw LANonLinearException("Divisor must be constant in linear logic"); }
     if (isNumZero(divisor)) { throw LADivisionByZeroException(); }
 
@@ -240,22 +237,19 @@ PTRef LIALogic::_mkIntDiv(const vec<PTRef> & args) {
         auto intDiv = divisorValue.sign() > 0 ? realDiv.floor() : realDiv.ceil();
         return mkConst(intDiv);
     }
-    return insertTermHash(sym_Int_DIV, args);
+    return insertTermHash(sym_Int_DIV, {dividend, divisor});
 }
 
 PTRef LIALogic::mkIntMod(vec<PTRef> const & args) {
     if (args.size() != 2) { throw OsmtApiException("Incorrect number of arguments for MOD operator"); }
-    return _mkIntMod(args);
+    return _mkIntMod(args[0], args[1]);
 }
 
 PTRef LIALogic::mkIntMod(PTRef dividend, PTRef divisor) {
-    return _mkIntMod({dividend, divisor});
+    return _mkIntMod(dividend, divisor);
 }
 
-PTRef LIALogic::_mkIntMod(vec<PTRef> const & args) {
-    assert(args.size() == 2);
-    PTRef dividend = args[0];
-    PTRef divisor = args[1];
+PTRef LIALogic::_mkIntMod(PTRef dividend, PTRef divisor) {
     if (not isNumConst(divisor)) { throw OsmtApiException("Divisor must be constant in linear logic"); }
     if (isNumZero(divisor)) { throw LADivisionByZeroException(); }
 
@@ -270,5 +264,5 @@ PTRef LIALogic::_mkIntMod(vec<PTRef> const & args) {
         assert(intMod.sign() >= 0 and intMod < abs(divisorValue));
         return mkConst(intMod);
     }
-    return insertTermHash(sym_Int_MOD, args);
+    return insertTermHash(sym_Int_MOD, {dividend, divisor});
 }

--- a/src/logics/LIALogic.h
+++ b/src/logics/LIALogic.h
@@ -106,8 +106,8 @@ public:
     virtual PTRef sumToNormalizedInequality(PTRef sum) override;
 
 private:
-    PTRef _mkIntMod(vec<PTRef> const & args);
-    PTRef _mkIntDiv(vec<PTRef> const & args);
+    PTRef _mkIntMod(PTRef dividend, PTRef divisor);
+    PTRef _mkIntDiv(PTRef dividend, PTRef divisor);
 };
 
 #endif

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -153,7 +153,7 @@ PTRef LRALogic::mkRealDiv(const vec<PTRef>& args)
         args_new[1] = mkConst(FastRational_inverse(getNumConst(args_new[1]))); //mkConst(1/getRealConst(args_new[1]));
         return mkNumTimes(args_new);
     }
-    PTRef tr = mkFun(s_new, opensmt::Span<PTRef>(args_new));
+    PTRef tr = mkFun(s_new, opensmt::make_span(args_new));
     return tr;
 }
 

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -153,7 +153,7 @@ PTRef LRALogic::mkRealDiv(const vec<PTRef>& args)
         args_new[1] = mkConst(FastRational_inverse(getNumConst(args_new[1]))); //mkConst(1/getRealConst(args_new[1]));
         return mkNumTimes(args_new);
     }
-    PTRef tr = mkFun(s_new, args_new);
+    PTRef tr = mkFun(s_new, opensmt::Span<PTRef>(args_new));
     return tr;
 }
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -590,7 +590,7 @@ Logic::mkIte(const vec<PTRef>& args)
 
     assert(sortToIte.has(sr));
     SymRef iteSym = sortToIte[sr];
-    return mkFun(iteSym, opensmt::Span<PTRef>(args));
+    return mkFun(iteSym, opensmt::make_span(args));
 
 }
 
@@ -638,7 +638,7 @@ PTRef Logic::mkAnd(const vec<PTRef>& args) {
     for (int k = 0; k < tmp_args.size(); k++) {
         newargs.push(tmp_args[k].sgn == l_True ? tmp_args[k].tr : mkNot(tmp_args[k].tr));
     }
-    return mkFun(getSym_and(), opensmt::Span<PTRef>(newargs));
+    return mkFun(getSym_and(), opensmt::make_span(newargs));
 }
 
 PTRef Logic::mkOr(const vec<PTRef>& args) {
@@ -683,7 +683,7 @@ PTRef Logic::mkOr(const vec<PTRef>& args) {
     for (int k = 0; k < tmp_args.size(); k++) {
         newargs.push(tmp_args[k].sgn == l_True ? tmp_args[k].tr : mkNot(tmp_args[k].tr));
     }
-    return mkFun(getSym_or(), opensmt::Span<PTRef>(newargs));
+    return mkFun(getSym_or(), opensmt::make_span(newargs));
 }
 
 PTRef Logic::mkXor(const vec<PTRef>& args) {
@@ -707,7 +707,7 @@ PTRef Logic::mkXor(const vec<PTRef>& args) {
     vec<PTRef> newargs;
     args.copyTo(newargs);
     sort(newargs);
-    tr = mkFun(getSym_xor(), opensmt::Span<PTRef>(newargs));
+    tr = mkFun(getSym_xor(), opensmt::make_span(newargs));
 
     if(tr == PTRef_Undef) {
         printf("Error in mkXor");
@@ -783,7 +783,7 @@ PTRef Logic::mkEq(const vec<PTRef>& args) {
             return args[0] == getTerm_false() ? mkNot(args[1]) : mkNot(args[0]);
     }
     SymRef eq_sym = term_store.lookupSymbol(tk_equals, args);
-    return mkFun(eq_sym, opensmt::Span<PTRef>(args));
+    return mkFun(eq_sym, opensmt::make_span(args));
 }
 
 // Given args = {a_1, ..., a_n}, distinct(args) holds iff
@@ -819,7 +819,7 @@ PTRef Logic::mkDistinct(vec<PTRef>& args) {
     }
     else {
         if (distinctClassCount < maxDistinctClasses) {
-            PTRef res = term_store.newTerm(diseq_sym, opensmt::Span<PTRef>(args));
+            PTRef res = term_store.newTerm(diseq_sym, opensmt::make_span(args));
             term_store.addToCplxMap(std::move(key), res);
             distinctClassCount++;
             return res;
@@ -1026,7 +1026,7 @@ PTRef Logic::insertTerm(SymRef sym, vec<PTRef>& terms)
         assert(terms.size() == 0);
         return mkFun(sym, {});
     }
-    return mkUninterpFun(sym, opensmt::Span<PTRef>(terms));
+    return mkUninterpFun(sym, opensmt::make_span(terms));
 }
 
 namespace {
@@ -1073,7 +1073,7 @@ Logic::insertTermHash(SymRef sym, const opensmt::Span<PTRef>& terms)
         if (term_store.hasCplxKey(k))
             res = term_store.getFromCplxMap(k);
         else {
-            res = term_store.newTerm(sym, opensmt::Span<PTRef>(k.args));
+            res = term_store.newTerm(sym, opensmt::make_span(k.args));
             term_store.addToCplxMap(std::move(k), res);
         }
     }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -923,7 +923,7 @@ void Logic::markConstant(SymId id) {
     constants[id] = true;
 }
 
-PTRef Logic::mkUninterpFun(SymRef f, opensmt::Span<PTRef> const & args) {
+PTRef Logic::mkUninterpFun(SymRef f, opensmt::Span<const PTRef> args) {
     PTRef tr = mkFun(f, args);
     if (not isUFTerm(tr) and not isUP(tr)) {
         char * name = printSym(f);
@@ -934,7 +934,7 @@ PTRef Logic::mkUninterpFun(SymRef f, opensmt::Span<PTRef> const & args) {
     return tr;
 }
 
-PTRef Logic::mkFun(SymRef f, const opensmt::Span<PTRef>& args)
+PTRef Logic::mkFun(SymRef f, opensmt::Span<const PTRef> args)
 {
     PTRef tr;
     if (f == SymRef_Undef)
@@ -1030,7 +1030,7 @@ PTRef Logic::insertTerm(SymRef sym, vec<PTRef>& terms)
 }
 
 namespace {
-void copyTo(opensmt::Span<PTRef> const & what, vec<PTRef> & to) {
+void copyTo(opensmt::Span<const PTRef> what, vec<PTRef> & to) {
     std::size_t sz = what.size();
     to.clear();
     to.growTo(sz);
@@ -1041,7 +1041,7 @@ void copyTo(opensmt::Span<PTRef> const & what, vec<PTRef> & to) {
 }
 
 PTRef
-Logic::insertTermHash(SymRef sym, const opensmt::Span<PTRef>& terms)
+Logic::insertTermHash(SymRef sym, opensmt::Span<const PTRef> terms)
 {
     PTRef res = PTRef_Undef;
     char *msg;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -115,7 +115,7 @@ class Logic {
     PTRef               term_FALSE;
 
 
-    virtual PTRef insertTermHash(SymRef, const opensmt::Span<PTRef>&);
+    virtual PTRef insertTermHash(SymRef, opensmt::Span<const PTRef>);
 
     void dumpFunction(ostream &, const TemplateFunction&);
 
@@ -170,7 +170,7 @@ class Logic {
   protected:
     SymRef      newSymb       (const char* name, vec<SRef> const & sort_args) { return sym_store.newSymb(name, sort_args); }
     SRef        newSort       (IdRef idr, const char* name, vec<SRef>& tmp);// { return sort_store.newSort(idr, name, tmp); }
-    PTRef       mkFun         (SymRef f, const opensmt::Span<PTRef>& args);
+    PTRef       mkFun         (SymRef f, opensmt::Span<const PTRef> args);
     void        markConstant  (PTRef ptr);
     void        markConstant  (SymId sid);
 
@@ -208,7 +208,7 @@ class Logic {
     // Returns the default value of the given sort
     virtual PTRef getDefaultValuePTRef(const SRef sref) const;
 
-    PTRef       mkUninterpFun (SymRef f, opensmt::Span<PTRef> const & args);
+    PTRef       mkUninterpFun (SymRef f, opensmt::Span<const PTRef> args);
     // Boolean term generation
     PTRef       mkAnd         (const vec<PTRef>&);
     PTRef       mkAnd         (PTRef a1, PTRef a2) { return mkAnd({a1, a2}); }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -115,7 +115,7 @@ class Logic {
     PTRef               term_FALSE;
 
 
-    virtual PTRef insertTermHash(SymRef, const vec<PTRef>&);
+    virtual PTRef insertTermHash(SymRef, const opensmt::Span<PTRef>&);
 
     void dumpFunction(ostream &, const TemplateFunction&);
 
@@ -170,7 +170,7 @@ class Logic {
   protected:
     SymRef      newSymb       (const char* name, vec<SRef> const & sort_args) { return sym_store.newSymb(name, sort_args); }
     SRef        newSort       (IdRef idr, const char* name, vec<SRef>& tmp);// { return sort_store.newSort(idr, name, tmp); }
-    PTRef       mkFun         (SymRef f, const vec<PTRef>& args);
+    PTRef       mkFun         (SymRef f, const opensmt::Span<PTRef>& args);
     void        markConstant  (PTRef ptr);
     void        markConstant  (SymId sid);
 
@@ -208,7 +208,7 @@ class Logic {
     // Returns the default value of the given sort
     virtual PTRef getDefaultValuePTRef(const SRef sref) const;
 
-    PTRef       mkUninterpFun (SymRef f, const vec<PTRef>& args);
+    PTRef       mkUninterpFun (SymRef f, opensmt::Span<PTRef> const & args);
     // Boolean term generation
     PTRef       mkAnd         (const vec<PTRef>&);
     PTRef       mkAnd         (PTRef a1, PTRef a2) { return mkAnd({a1, a2}); }

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -125,7 +125,7 @@ const PtermIter& PtermIter::operator++ () { i++; return *this; }
 
 
 
-PTRef PtStore::newTerm(const SymRef sym, const opensmt::Span<PTRef>& ps) {
+PTRef PtStore::newTerm(const SymRef sym, opensmt::Span<const PTRef> ps) {
     PTRef tr = pta.alloc(sym, ps); idToPTRef.push(tr);
     assert(idToPTRef.size_() == pta.getNumTerms());
     return tr;

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -124,7 +124,8 @@ PTRef PtermIter::operator* () {
 const PtermIter& PtermIter::operator++ () { i++; return *this; }
 
 
-PTRef PtStore::newTerm(const SymRef sym, const vec<PTRef>& ps) {
+
+PTRef PtStore::newTerm(const SymRef sym, const opensmt::Span<PTRef>& ps) {
     PTRef tr = pta.alloc(sym, ps); idToPTRef.push(tr);
     assert(idToPTRef.size_() == pta.getNumTerms());
     return tr;

--- a/src/pterms/PtStore.h
+++ b/src/pterms/PtStore.h
@@ -29,6 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "Pterm.h"
 #include "SymStore.h"
+#include "Span.h"
 #include <unordered_map>
 
 class SStore; // forward declaration
@@ -67,11 +68,7 @@ class PtStore {
   public:
     PtStore(SymStore& symstore) : symstore(symstore) {}
 
-    PTRef newTerm(const SymRef sym, const vec<PTRef>& ps);/* {
-        PTRef tr = pta.alloc(sym, ps); idToPTRef.push(tr);
-        assert(idToPTRef.size() == pta.getNumTerms());
-        return tr;
-    }*/
+    PTRef newTerm(const SymRef sym, const opensmt::Span<PTRef>& ps);
 
     void   free(PTRef r);// { pta.free(r); }  // this is guaranteed to be lazy
 

--- a/src/pterms/PtStore.h
+++ b/src/pterms/PtStore.h
@@ -68,7 +68,7 @@ class PtStore {
   public:
     PtStore(SymStore& symstore) : symstore(symstore) {}
 
-    PTRef newTerm(const SymRef sym, const opensmt::Span<PTRef>& ps);
+    PTRef newTerm(const SymRef sym, opensmt::Span<const PTRef> ps);
 
     void   free(PTRef r);// { pta.free(r); }  // this is guaranteed to be lazy
 

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -33,6 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "SolverTypes.h"
 #include "SymRef.h"
 #include "PtStructs.h"
+#include "Span.h"
 
 
 // A key used for pterm resolve lookups
@@ -147,14 +148,14 @@ class Pterm {
 #endif
 private:
     // MB: Constructor is private to forbid any use outside PtermAllocator, which is a friend
-    Pterm(const SymRef sym_, const vec<PTRef> & ps) : sym(sym_) {
+    Pterm(const SymRef sym_, opensmt::Span<PTRef> const & ps) : sym(sym_) {
         header.type      = 0;
         header.has_extra = 0;
         header.reloced   = 0;
         header.noscoping = 0;           // This is an optimization to avoid expensive name lookup on logic operations
         header.size      = ps.size();
 
-        for (int i = 0; i < ps.size(); i++) { args[i] = ps[i]; }
+        for (std::size_t i = 0; i < ps.size(); ++i) { args[i] = ps[i]; }
     }
 };
 
@@ -200,9 +201,9 @@ class PtermAllocator : public RegionAllocator<uint32_t>
         RegionAllocator<uint32_t>::moveTo(to);
     }
 
-    PTRef alloc(const SymRef sym, const vec<PTRef> & ps)
+    PTRef alloc(const SymRef sym, const opensmt::Span<PTRef> & ps)
     {
-        assert(sizeof(PTRef) == sizeof(uint32_t));
+        static_assert(sizeof(PTRef) == sizeof(uint32_t), "Unexpected size of PTRef");
 
         uint32_t v = RegionAllocator<uint32_t>::alloc(ptermWord32Size(ps.size()));
         PTRef tid = {v};

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -148,7 +148,7 @@ class Pterm {
 #endif
 private:
     // MB: Constructor is private to forbid any use outside PtermAllocator, which is a friend
-    Pterm(const SymRef sym_, opensmt::Span<PTRef> const & ps) : sym(sym_) {
+    Pterm(const SymRef sym_, opensmt::Span<const PTRef> ps) : sym(sym_) {
         header.type      = 0;
         header.has_extra = 0;
         header.reloced   = 0;
@@ -201,7 +201,7 @@ class PtermAllocator : public RegionAllocator<uint32_t>
         RegionAllocator<uint32_t>::moveTo(to);
     }
 
-    PTRef alloc(const SymRef sym, const opensmt::Span<PTRef> & ps)
+    PTRef alloc(const SymRef sym, opensmt::Span<const PTRef> ps)
     {
         static_assert(sizeof(PTRef) == sizeof(uint32_t), "Unexpected size of PTRef");
 

--- a/src/simplifiers/LA.cc
+++ b/src/simplifiers/LA.cc
@@ -152,13 +152,9 @@ PTRef LAExpression::getPTRefNonConstant()
         if ( it->first == PTRef_Undef )
             constant = it->second;
         else {
-            char* msg;
             PTRef coeff = logic.mkConst(it->second);
             PTRef vv = it->first;
-            vec<PTRef> term;
-            term.push(coeff);
-            term.push(vv);
-            sum_list.push( logic.mkNumTimes(term, &msg) );
+            sum_list.push( logic.mkNumTimes({coeff, vv}) );
         }
     }
     if ( sum_list.size() == 0) {
@@ -180,13 +176,9 @@ PTRef LAExpression::toPTRef() const {
         if ( it->first == PTRef_Undef )
             constant = it->second;
         else {
-            char* msg;
             PTRef coeff = logic.mkConst(it->second);
             PTRef vv = it->first;
-            vec<PTRef> term;
-            term.push(coeff);
-            term.push(vv);
-            sum_list.push( logic.mkNumTimes(term, &msg) );
+            sum_list.push( logic.mkNumTimes({coeff, vv}) );
         }
     }
     if ( sum_list.size() == 0) {

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -264,7 +264,7 @@ bool UFInterpolator::colorEdgesFrom(CNode * x) {
                     }
                 }
 
-                PTRef nn = logic.mkUninterpFun(logic.getPterm(x->e).symb(), opensmt::Span<PTRef>(new_args));
+                PTRef nn = logic.mkUninterpFun(logic.getPterm(x->e).symb(), opensmt::make_span(new_args));
                 if (nn == x->e) {
                     x->color = I_AB;
                 } else if (nn == n->e) {

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -264,7 +264,7 @@ bool UFInterpolator::colorEdgesFrom(CNode * x) {
                     }
                 }
 
-                PTRef nn = logic.mkUninterpFun(logic.getPterm(x->e).symb(), new_args);
+                PTRef nn = logic.mkUninterpFun(logic.getPterm(x->e).symb(), opensmt::Span<PTRef>(new_args));
                 if (nn == x->e) {
                     x->color = I_AB;
                 } else if (nn == n->e) {


### PR DESCRIPTION
I would like to propose our version of `Span` object, which is basically a (non-owning) view over a contiguous range of  elements in memory (same as C++20's `std::span`).
The proposed version contains only the bare minimum we require and corresponds to `ConstSpan`, where the elements in memory cannot be modified.

In my opinion this can save us a bunch of temporary `vec`s that we now create when creating terms.