### PR TITLE
CoreSMTSolver: Throw exception on error situation

### DIFF
--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "CoreSMTSolver.h"
 #include "TSolver.h"
 #include "ModelBuilder.h"
+#include "OsmtInternalException.h"
 
 #include <sys/wait.h>
 #include <assert.h>
@@ -268,9 +269,9 @@ void THandler::getReason( Lit l, vec< Lit > & reason)
     PtAsgn conflictingPolarity = PtAsgn(e, sign(~l) ? l_False : l_True);
     lbool res = solver->assertLit(conflictingPolarity) == false ? l_False : l_Undef;
 
-    if ( res != l_False ) {
-        std::cout << std::endl << "unknown" << std::endl;
+    if (res != l_False) {
         assert(false);
+        throw OsmtInternalException("Error in computing reason for theory-propagated literal");
     }
 
     // Get Explanation


### PR DESCRIPTION
We currently do not remember reasons for theory propagated literals and lazily re-compute them only when really needed.
The computation backtracks SAT solver before the propagated literal and asserts its negation. This *must* result in conflict from which we extract the reason.
If this operation does not result in conflict, something is broken and we should throw an exception instead of ignoring this.