### PR TITLE
Term creation cleanup

### DIFF
--- a/src/logics/BVLogic.cc
+++ b/src/logics/BVLogic.cc
@@ -191,9 +191,7 @@ BVLogic::BVLogic(int width) :
     for (int i = 0; i < 32; i++) {
         std::string sym_name {s_uf_extract_base};
         sym_name += std::to_string(i);
-        vec<SRef> tmp;
-        tmp.push(sort_CUFNUM);
-        declareFun(sym_name.c_str(), getSort_bool(), tmp, &msg, true);
+        declareFun(sym_name.c_str(), getSort_bool(), {sort_CUFNUM}, &msg, true);
     }
 }
 
@@ -243,7 +241,6 @@ BVLogic::mkBVMinus(const vec<PTRef>& args_in)
 
     assert(args.size() == 2);
     PTRef mo = mkBVConst(-1);
-    vec<PTRef> tmp;
     PTRef fact = mkBVTimes(mo, args[1]);
     args[1] = fact;
     return mkBVPlus(args[0], args[1]);

--- a/src/logics/BVLogic.cc
+++ b/src/logics/BVLogic.cc
@@ -200,13 +200,6 @@ BVLogic::BVLogic(int width) :
 BVLogic::~BVLogic()
 {}
 
-//PTRef
-//BVLogic::insertTerm(SymRef sym, vec<PTRef>& terms, char **msg)
-//{
-//    assert(false);
-//    return PTRef_Undef;
-//}
-
 PTRef
 BVLogic::mkBVEq(PTRef a1, PTRef a2)
 {
@@ -217,10 +210,7 @@ BVLogic::mkBVEq(PTRef a1, PTRef a2)
         return (a1 == a2) ? getTerm_BVOne() : getTerm_BVZero();
     if (a1 == a2) return getTerm_BVOne();
     if (a1 == mkBVNot(a2)) return getTerm_BVZero();
-    vec<PTRef> tmp;
-    tmp.push(a1);
-    tmp.push(a2);
-    return mkFun(sym_BV_EQ, tmp);
+    return mkFun(sym_BV_EQ, {a1,a2});
 }
 
 PTRef
@@ -266,10 +256,7 @@ BVLogic::mkBVPlus(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> sum_args;
-    sum_args.push(arg1);
-    sum_args.push(arg2);
-    PTRef tr = mkFun(sym_BV_PLUS, sum_args);
+    PTRef tr = mkFun(sym_BV_PLUS, {arg1, arg2});
 //    sum_args[0] = arg2;
 //    sum_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_PLUS, sum_args, msg);
@@ -286,11 +273,7 @@ BVLogic::mkBVTimes(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> times_args;
-    times_args.push(arg1);
-    times_args.push(arg2);
-
-    PTRef tr = mkFun(sym_BV_TIMES, times_args);
+    PTRef tr = mkFun(sym_BV_TIMES, {arg1, arg2});
 //    times_args[0] = arg2;
 //    times_args[1] = arg1;
 //    PTRef tr_comm = mkFun(sym_BV_TIMES, times_args, msg);
@@ -306,10 +289,7 @@ BVLogic::mkBVDiv(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
 
-    vec<PTRef> div_args;
-    div_args.push(arg1);
-    div_args.push(arg2);
-    PTRef tr = mkFun(sym_BV_DIV, div_args);
+    PTRef tr = mkFun(sym_BV_DIV, {arg1, arg2});
     return tr;
 }
 
@@ -378,10 +358,7 @@ BVLogic::mkBVUleq(const PTRef arg1, const PTRef arg2)
         else
             return term_BV_ZERO;
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_ULEQ, args);
+    PTRef tr = mkFun(sym_BV_ULEQ, {arg1, arg2});
     return tr;
 }
 
@@ -407,10 +384,7 @@ BVLogic::mkBVSlt(const PTRef arg1, const PTRef arg2)
         else
             return term_BV_ZERO;
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_SLT, args);
+    PTRef tr = mkFun(sym_BV_SLT, {arg1, arg2});
     return tr;
 }
 
@@ -421,30 +395,21 @@ PTRef BVLogic::mkBVLshift(const PTRef arg1, const PTRef arg2)
     assert(hasSortBVNUM(arg2));
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_LSHIFT, args);
+    return mkFun(sym_BV_LSHIFT, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVLRshift(const PTRef arg1, const PTRef arg2)
 {
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_LRSHIFT, args);
+    return mkFun(sym_BV_LRSHIFT, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVARshift(const PTRef arg1, const PTRef arg2)
 {
     if (isBVNUMConst(arg2) && getBVNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_ARSHIFT, args);
+    return mkFun(sym_BV_ARSHIFT, {arg1, arg2});
 }
 
 
@@ -457,66 +422,28 @@ PTRef BVLogic::mkBVMod(const PTRef arg1, const PTRef arg2)
         return getTerm_BVZero();
     // if b > 0, then 0 <= a % b < b
     // if b < 0, then b < a % b <= 0
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_MOD, args);
+    return mkFun(sym_BV_MOD, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVBwAnd(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWAND, args);
+    return mkFun(sym_BV_BWAND, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVBwOr(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWOR, args);
+    return mkFun(sym_BV_BWOR, {arg1, arg2});
 }
-
-/*PTRef BVLogic::mkBVInc(const PTRef arg1)
-{
-    assert(hasSortBVNUM(arg1));
-    vec<PTRef> args;
-    args.push(arg1);
-    char** msg;
-    PTRef tr = mkFun(sym_BV_INC, args, msg);
-//    PTRef neq = mkBVNeq(arg1, tr);
-//    if (!inc_diseqs.has(neq))
-//        inc_diseqs.insert(neq, true);
-    return tr;
-}
-
-PTRef BVLogic::mkBVDec(const PTRef arg1)
-{
-    assert(hasSortBVNUM(arg1));
-    vec<PTRef> args;
-    args.push(arg1);
-    char** msg;
-    PTRef tr = mkFun(sym_BV_DEC, args, msg);
-//    PTRef neq = mkBVNeq(arg1, tr);
-//    if (!inc_diseqs.has(neq))
-//        inc_diseqs.insert(neq, true);
-    return tr;
-}*/
 
 PTRef BVLogic::mkBVLand(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_LAND, args);
+    PTRef tr = mkFun(sym_BV_LAND, {arg1, arg2});
     return tr;
 }
 
@@ -524,10 +451,7 @@ PTRef BVLogic::mkBVLor(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_BV_LOR, args);
+    PTRef tr = mkFun(sym_BV_LOR, {arg1, arg2});
     return tr;
 }
 
@@ -540,9 +464,7 @@ PTRef BVLogic::mkBVNot(const PTRef arg)
         return term_BV_ZERO;
     else if (arg == term_BV_ZERO)
         return term_BV_ONE;
-    vec<PTRef> tmp;
-    tmp.push(arg);
-    PTRef tr = mkFun(sym_BV_NOT, tmp);
+    PTRef tr = mkFun(sym_BV_NOT, {arg});
     return tr;
 }
 
@@ -550,53 +472,18 @@ PTRef BVLogic::mkBVBwXor(const PTRef arg1, const PTRef arg2)
 {
     assert(hasSortBVNUM(arg1));
     assert(hasSortBVNUM(arg2));
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_BV_BWXOR, args);
+    return mkFun(sym_BV_BWXOR, {arg1, arg2});
 }
 
 PTRef BVLogic::mkBVCompl(const PTRef arg1)
 {
     assert(hasSortBVNUM(arg1));
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_BV_COMPL, args);
+    PTRef tr = mkFun(sym_BV_COMPL, {arg1});
 //    PTRef neq = mkBVNeq(tr, arg1);
 //    if (!compl_diseqs.has(neq))
 //        compl_diseqs.insert(neq, true);
     return tr;
 }
-/*
-PTRef BVLogic::mkBVSizeof(const PTRef arg)
-{
-    vec<PTRef> args;
-    args.push(arg);
-    char** msg;
-    return mkFun(sym_BV_SIZEOF, args, msg);
-}
-
-PTRef BVLogic::mkBVAddrof(const PTRef arg)
-{
-    vec<PTRef> args;
-    args.push(arg);
-    char** msg;
-    return mkFun(sym_BV_SIZEOF, args, msg);
-}
-
-
-PTRef BVLogic::mkBVPtr(const PTRef arg)
-{
-    vec<PTRef> args;
-    args.push(arg);
-    char** msg;
-    return mkFun(sym_BV_PTR, args, msg);
-}*/
-
-/*PTRef BVLogic::mkBVCond(const PTRef cond, PTRef i_arg, PTRef e_arg)
-{
-    return mkIte(cond, i_arg, e_arg);
-}*/
 
 PTRef BVLogic::mkBVNeq(const PTRef a1, const PTRef a2)
 {
@@ -612,66 +499,3 @@ const int BVLogic::getBVNUMConst(PTRef tr) const
 {
     return atoi(getSymName(tr));
 }
-
-/*void BVLogic::conjoinExtras(PTRef root, PTRef& root_out)
-{
-    vec<PTRef> comm_eqs;
-    vec<PTRef> diseq_eqs;
-    vec<PTRef> diseq_split;
-    vec<PTRef> mod_ineqs;
-    vec<PTRef> inc_diseqs;
-    vec<PTRef> compl_diseqs;
-    getCommEqs(comm_eqs);
-    getCommEqs(diseq_eqs);
-    getCommEqs(diseq_split);
-    getCommEqs(mod_ineqs);
-    getCommEqs(inc_diseqs);
-    getCommEqs(compl_diseqs);
-    root_out = root;
-    root_out = mkAnd(root_out, mkAnd(comm_eqs));
-    root_out = mkAnd(root_out, mkAnd(diseq_eqs));
-    root_out = mkAnd(root_out, mkAnd(diseq_split));
-    root_out = mkAnd(root_out, mkAnd(mod_ineqs));
-    root_out = mkAnd(root_out, mkAnd(inc_diseqs));
-    root_out = mkAnd(root_out, mkAnd(compl_diseqs));
-    Logic::conjoinItes(root_out, root_out);
-}*/
-
-//PTRef
-//BVLogic::mkGlueBtoUF(const vec<PTRef>& bits, PTRef tr)
-//{
-//    assert(bits.size() == 32);
-//    PTRef cr = mkCollate32(bits);
-//    return mkEq(cr, tr);
-//}
-//
-//PTRef
-//BVLogic::mkGlueUFtoB(PTRef tr, const vec<PTRef>& bits)
-//{
-//    assert(bits.size() == 32);
-//    vec<PTRef> conjs;
-//    for (int i = 0; i < bits.size(); i++)
-//        conjs.push(Logic::mkEq(bits[i], mkExtract(tr, i)));
-//    return Logic::mkAnd(conjs);
-//}
-//
-//PTRef
-//BVLogic::mkCollate32(const vec<PTRef>& bits)
-//{
-//    char* msg;
-//    return mkFun(sym_BV_COLLATE32, bits, &msg);
-//}
-
-//PTRef
-//BVLogic::mkExtract(PTRef tr, int i)
-//{
-//    char* sym_name;
-//    char* msg;
-//    asprintf(&sym_name, "%s%d", s_uf_extract_base, i);
-//    vec<SymRef>& srs = symNameToRef(sym_name);
-//    SymRef sr = srs[0];
-//    free(sym_name);
-//    vec<PTRef> tmp;
-//    tmp.push(tr);
-//    return mkFun(sr, tmp, &msg);
-//}

--- a/src/logics/CUFLogic.cc
+++ b/src/logics/CUFLogic.cc
@@ -225,7 +225,6 @@ CUFLogic::mkCUFMinus(const vec<PTRef>& args_in, char** msg)
     else {
         assert(args.size() == 2);
         PTRef mo = mkCUFConst(-1);
-        vec<PTRef> tmp;
         PTRef fact = mkCUFTimes(mo, args[1], msg);
         args[1] = fact;
         return mkCUFPlus(args[0], args[1]);

--- a/src/logics/CUFLogic.cc
+++ b/src/logics/CUFLogic.cc
@@ -207,8 +207,7 @@ CUFLogic::mkCUFNeg(PTRef tr, char** msg)
         v = -v;
         PTRef nterm = mkCUFConst(v);
         SymRef s = getPterm(nterm).symb();
-        vec<PTRef> args;
-        return mkFun(s, args);
+        return mkFun(s, {});
     }
     PTRef mo = mkCUFConst(-1);
     return mkCUFTimes(mo, tr);
@@ -236,94 +235,19 @@ CUFLogic::mkCUFMinus(const vec<PTRef>& args_in, char** msg)
 PTRef
 CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
 {
-    vec<PTRef> sum_args;
-    sum_args.push(arg1);
-    sum_args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_PLUS, sum_args);
-    sum_args[0] = arg2;
-    sum_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_PLUS, sum_args);
+    PTRef tr = mkFun(sym_CUF_PLUS, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_PLUS, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
     return tr;
 }
 
-// We need this since CUF wants to take care of commutativity on its own
-//PTRef
-//CUFLogic::insertTermHash(SymRef sym, const vec<PTRef>& terms_in)
-//{
-//    vec<PTRef> terms;
-//    terms_in.copyTo(terms);
-//    PTRef res = PTRef_Undef;
-//    char **msg;
-//    if (terms.size() == 0) {
-//        if (term_store.hasCtermKey(sym)) //cterm_map.contains(sym))
-//            res = term_store.getFromCtermMap(sym); //cterm_map[sym];
-//        else {
-//            res = term_store.newTerm(sym, terms);
-//            term_store.addToCtermMap(sym, res); //cterm_map.insert(sym, res);
-//        }
-//    }
-//    else if (!isBooleanOperator(sym)) {
-//        if (!sym_store[sym].left_assoc() &&
-//            !sym_store[sym].right_assoc() &&
-//            !sym_store[sym].chainable() &&
-//            !sym_store[sym].pairwise() &&
-//            sym_store[sym].nargs() != terms.size_())
-//        {
-//            *msg = (char*)malloc(strlen(e_argnum_mismatch)+1);
-//            strcpy(*msg, e_argnum_mismatch);
-//            return PTRef_Undef;
-//        }
-//        PTLKey k;
-//        k.sym = sym;
-//        terms.copyTo(k.args);
-//        if (term_store.hasCplxKey(k))
-//            res = term_store.getFromCplxMap(k);
-//        else {
-//            res = term_store.newTerm(sym, terms);
-//            term_store.addToCplxMap(k, res);
-//        }
-//    }
-//    else {
-//        // Boolean operator
-//        PTLKey k;
-//        k.sym = sym;
-//        terms.copyTo(k.args);
-//        if (term_store.hasBoolKey(k)) {
-//            res = term_store.getFromBoolMap(k); //bool_map[k];
-//#ifdef SIMPLIFY_DEBUG
-//            char* ts = printTerm(res);
-//            cerr << "duplicate: " << ts << endl;
-//            ::free(ts);
-//#endif
-//        }
-//        else {
-//            res = term_store.newTerm(sym, terms);
-//            term_store.addToBoolMap(k, res); //bool_map.insert(k, res);
-//#ifdef SIMPLIFY_DEBUG
-//            char* ts = printTerm(res);
-//            cerr << "new: " << ts << endl;
-//            ::free(ts);
-//#endif
-//        }
-//    }
-//    return res;
-//}
-
-
 PTRef
 CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
 {
-    vec<PTRef> times_args;
-    times_args.push(arg1);
-    times_args.push(arg2);
-
-    PTRef tr = mkFun(sym_CUF_TIMES, times_args);
-    times_args[0] = arg2;
-    times_args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_TIMES, times_args);
+    PTRef tr = mkFun(sym_CUF_TIMES, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_TIMES, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -333,10 +257,7 @@ CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
 PTRef
 CUFLogic::mkCUFDiv(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> div_args;
-    div_args.push(arg1);
-    div_args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_DIV, div_args);
+    PTRef tr = mkFun(sym_CUF_DIV, {arg1, arg2});
     return tr;
 }
 
@@ -357,10 +278,7 @@ CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2, char** msg)
         else
             return getTerm_false();
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef leq_tr = mkFun(sym_CUF_LEQ, args);
+    PTRef leq_tr = mkFun(sym_CUF_LEQ, {arg1, arg2});
     return mkOr(leq_tr, mkEq(arg1, arg2));
 }
 
@@ -375,10 +293,7 @@ CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2, char** msg)
         else
             return getTerm_false();
     }
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_GT, args);
+    PTRef tr = mkFun(sym_CUF_GT, {arg1, arg2});
     // a>b -> a != b
     PTRef tr_eq = mkEq(arg1, arg2);
     PTRef n_tr_eq = mkCUFNot(tr_eq);
@@ -397,30 +312,21 @@ PTRef CUFLogic::mkCUFLshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_LSHIFT, args);
+    return mkFun(sym_CUF_LSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFLRshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_LRSHIFT, args);
+    return mkFun(sym_CUF_LRSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFARshift(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg2) && getCUFNUMConst(arg2) == 0)
         return arg1;
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_ARSHIFT, args);
+    return mkFun(sym_CUF_ARSHIFT, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
@@ -429,21 +335,13 @@ PTRef CUFLogic::mkCUFMod(const PTRef arg1, const PTRef arg2)
         return getTerm_CUFZero();
     // if b > 0, then 0 <= a % b < b
     // if b < 0, then b < a % b <= 0
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    return mkFun(sym_CUF_MOD, args);
+    return mkFun(sym_CUF_MOD, {arg1, arg2});
 }
 
 PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWAND, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWAND, args);
+    PTRef tr = mkFun(sym_CUF_BWAND, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWAND, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -452,13 +350,8 @@ PTRef CUFLogic::mkCUFBwAnd(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFBwOr(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWOR, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWOR, args);
+    PTRef tr = mkFun(sym_CUF_BWOR, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWOR, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -467,9 +360,7 @@ PTRef CUFLogic::mkCUFBwOr(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFInc(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_INC, args);
+    PTRef tr = mkFun(sym_CUF_INC, {arg1});
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -478,9 +369,7 @@ PTRef CUFLogic::mkCUFInc(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFDec(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_DEC, args);
+    PTRef tr = mkFun(sym_CUF_DEC, {arg1});
     PTRef neq = mkCUFNeq(arg1, tr);
     if (!inc_diseqs.has(neq))
         inc_diseqs.insert(neq, true);
@@ -489,19 +378,13 @@ PTRef CUFLogic::mkCUFDec(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFLand(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_LAND, args);
+    PTRef tr = mkFun(sym_CUF_LAND, {arg1, arg2});
     return tr;
 }
 
 PTRef CUFLogic::mkCUFLor(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_LOR, args);
+    PTRef tr = mkFun(sym_CUF_LOR, {arg1, arg2});
     return tr;
 }
 
@@ -512,13 +395,8 @@ PTRef CUFLogic::mkCUFNot(const PTRef arg)
 
 PTRef CUFLogic::mkCUFBwXor(const PTRef arg1, const PTRef arg2)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    args.push(arg2);
-    PTRef tr = mkFun(sym_CUF_BWXOR, args);
-    args[0] = arg2;
-    args[1] = arg1;
-    PTRef tr_comm = mkFun(sym_CUF_BWXOR, args);
+    PTRef tr = mkFun(sym_CUF_BWXOR, {arg1, arg2});
+    PTRef tr_comm = mkFun(sym_CUF_BWXOR, {arg2, arg1});
     PTRef tr_comm_eq = mkEq(tr, tr_comm);
     if (!comm_eqs.has(tr_comm_eq))
         comm_eqs.insert(tr_comm_eq, true);
@@ -527,9 +405,7 @@ PTRef CUFLogic::mkCUFBwXor(const PTRef arg1, const PTRef arg2)
 
 PTRef CUFLogic::mkCUFCompl(const PTRef arg1)
 {
-    vec<PTRef> args;
-    args.push(arg1);
-    PTRef tr = mkFun(sym_CUF_COMPL, args);
+    PTRef tr = mkFun(sym_CUF_COMPL, {arg1});
     PTRef neq = mkCUFNeq(tr, arg1);
     if (!compl_diseqs.has(neq))
         compl_diseqs.insert(neq, true);
@@ -538,24 +414,18 @@ PTRef CUFLogic::mkCUFCompl(const PTRef arg1)
 
 PTRef CUFLogic::mkCUFSizeof(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_SIZEOF, args);
+    return mkFun(sym_CUF_SIZEOF, {arg});
 }
 
 PTRef CUFLogic::mkCUFAddrof(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_SIZEOF, args);
+    return mkFun(sym_CUF_SIZEOF, {arg});
 }
 
 
 PTRef CUFLogic::mkCUFPtr(const PTRef arg)
 {
-    vec<PTRef> args;
-    args.push(arg);
-    return mkFun(sym_CUF_PTR, args);
+    return mkFun(sym_CUF_PTR, {arg});
 }
 
 PTRef CUFLogic::mkCUFCond(const PTRef cond, PTRef i_arg, PTRef e_arg)

--- a/src/logics/CUFLogic.h
+++ b/src/logics/CUFLogic.h
@@ -209,7 +209,7 @@ class CUFLogic: public Logic
     //PTRef mkCUFMinus(const vec<PTRef>& args) { assert(args.size() == 2); return mkCUFMinus(args[0], args[1]); }
     PTRef mkCUFMinus(const vec<PTRef>&, char**);
     PTRef mkCUFMinus(const vec<PTRef>& args) { char *msg; PTRef tr = mkCUFMinus(args, &msg); assert(tr != PTRef_Undef); return tr; }
-    PTRef mkCUFMinus(const PTRef a1, const PTRef a2) { vec<PTRef> tmp; tmp.push(a1); tmp.push(a2); return mkCUFMinus(tmp); }
+    PTRef mkCUFMinus(const PTRef a1, const PTRef a2) { return mkCUFMinus({a1, a2}); }
 
     PTRef mkCUFPlus(const vec<PTRef>& args) { assert(args.size() == 2); return mkCUFPlus(args[0], args[1]); }
     PTRef mkCUFPlus(const PTRef arg1, const PTRef arg2, char**);

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -237,15 +237,11 @@ PTRef LALogic::mkNumMinus(const vec<PTRef> &args) {
     return tr;
 }
 PTRef LALogic::mkNumMinus(const PTRef a1, const PTRef a2) {
-    vec<PTRef> tmp;
-    tmp.push(a1);
-    tmp.push(a2);
-    return mkNumMinus(tmp);
+    return mkNumMinus({a1, a2});
 }
 
 PTRef LALogic::mkNumPlus(const PTRef p1, const PTRef p2) {
-    vec<PTRef> tmp {p1, p2};
-    return mkNumPlus(tmp);
+    return mkNumPlus(vec<PTRef>({p1, p2}));
 }
 
 PTRef LALogic::mkNumPlus(const vec<PTRef> &args) {
@@ -267,10 +263,7 @@ PTRef LALogic::mkNumTimes(const vec<PTRef> &args) {
     return tr;
 }
 PTRef LALogic::mkNumTimes(const PTRef p1, const PTRef p2) {
-    vec<PTRef> tmp;
-    tmp.push(p1);
-    tmp.push(p2);
-    return mkNumTimes(tmp);
+    return mkNumTimes(vec<PTRef>({p1, p2}));
 }
 PTRef LALogic::mkNumTimes(const std::vector<PTRef> &args) {
     vec<PTRef> tmp;
@@ -290,17 +283,11 @@ PTRef LALogic::mkNumGeq(const PTRef arg1, const PTRef arg2) {
 }
 
 PTRef LALogic::mkNumLt(const PTRef arg1, const PTRef arg2) {
-    vec<PTRef> tmp;
-    tmp.push(arg1);
-    tmp.push(arg2);
-    return mkNumLt(tmp);
+    return mkNumLt({arg1, arg2});
 }
 
 PTRef LALogic::mkNumGt(const PTRef arg1, const PTRef arg2) {
-    vec<PTRef> tmp;
-    tmp.push(arg1);
-    tmp.push(arg2);
-    return mkNumGt(tmp);
+    return mkNumGt({arg1, arg2});
 }
 
 char* LALogic::printTerm(PTRef tr) const { return printTerm_(tr, false, false); }
@@ -318,10 +305,7 @@ PTRef LALogic::mkNumMinus(const vec<PTRef>& args_in, char** msg)
         printf("Error: %s\n", *msg);
         assert(false);
     }
-    vec<PTRef> tmp;
-    tmp.push(mo);
-    tmp.push(args[1]);
-    PTRef fact = mkNumTimes(tmp, msg);
+    PTRef fact = mkNumTimes({mo, args[1]}, msg);
     if (fact == PTRef_Undef) {
         printf("Error: %s\n", *msg);
         assert(false);
@@ -365,9 +349,7 @@ PTRef LALogic::mkNumPlus(const vec<PTRef>& args, char** msg)
         assert(c != PTRef_Undef);
         assert(isConstant(c));
         if (!s2t.has(v)) {
-            vec<PTRef> tmp;
-            tmp.push(c);
-            s2t.insert(v, tmp);
+            s2t.insert(v, {c});
             keys.push(v);
         } else
             s2t[v].push(c);

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -850,9 +850,7 @@ PTRef Logic::mkNot(PTRef arg) {
     else if (isTrue(arg)) return getTerm_false();
     else if (isFalse(arg)) return getTerm_true();
     else {
-        vec<PTRef> tmp;
-        tmp.push(arg);
-        tr = mkFun(getSym_not(), tmp);
+        tr = mkFun(getSym_not(), {arg});
     }
 
     if(tr == PTRef_Undef) {
@@ -884,8 +882,7 @@ PTRef Logic::mkVar(SRef s, const char* name) {
         assert(symNameToRef(name).size() == 1);
         sr = symNameToRef(name)[0];
     }
-    vec<PTRef> tmp;
-    PTRef ptr = mkFun(sr, tmp);
+    PTRef ptr = mkFun(sr, {});
     assert (ptr != PTRef_Undef);
 
     return ptr;
@@ -950,13 +947,10 @@ PTRef Logic::mkFun(SymRef f, const vec<PTRef>& args)
 
 PTRef Logic::mkBoolVar(const char* name)
 {
-    vec<SRef> tmp;
     char* msg;
-    SymRef sr = declareFun(name, sort_BOOL, tmp, &msg);
+    SymRef sr = declareFun(name, sort_BOOL, {}, &msg);
     assert(sr != SymRef_Undef);
-    vec<PTRef> tmp2;
-    PTRef tr = mkFun(sr, tmp2);
-    return tr;
+    return mkFun(sr, {});
 }
 
 SRef Logic::declareSort(const char* id, char** msg)

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1135,30 +1135,6 @@ bool Logic::isUP(PTRef ptr) const {
     return true;
 }
 
-// Adds the uninterpreted predicate if ptr is an uninterpreted predicate.
-// Returns reference to corresponding equality term or PTRef_Undef.  Creates
-// the eq term if it does not exist.
-// If the term is an equality (disequality), it must be an equality
-// (disequality) over terms with non-boolean return type.  Those must be then
-// returned as is.
-PTRef Logic::lookupUPEq(PTRef ptr) {
-    assert(isUP(ptr));
-    // already seen
-//    if (UP_map.contains(ptr)) return UP_map[ptr];
-    // already an equality
-    Pterm& t = term_store[ptr];
-    if (isEquality(t.symb()) | isDisequality(t.symb()))
-        return ptr;
-
-    // Create a new equality
-//    Symbol& sym = sym_store[t.symb()];
-    vec<PTRef> args;
-    args.push(ptr);
-    args.push(getTerm_true());
-    return mkEq(args);
-//    return resolveTerm(tk_equals, args);
-}
-
 // Check if the term store contains an equality over the given arguments
 // Return the reference if yes, return PTRef_Undef if no
 // Changes the argument!

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -132,7 +132,6 @@ class Logic {
     void enableExtendedSignature(bool flag) { use_extended_signature = flag; }
     vec<PTRef> propFormulasAppearingInUF;
     std::size_t getNumberOfTerms() const { return term_store.getNumberOfTerms(); }
-    bool existsTermHash(SymRef, const vec<PTRef>&);
     static const char*  tk_val_uf_default;
     static const char*  tk_val_bool_default;
     static const char*  tk_true;
@@ -343,12 +342,7 @@ class Logic {
 
     bool        hasSortBool(PTRef tr) const;// { return sym_store[getPterm(tr).symb()].rsort() == sort_BOOL; }
     bool        hasSortBool(SymRef sr) const;// { return sym_store[sr].rsort() == sort_BOOL; }
-    //bool        hasSortInt (PTRef tr) const { return sym_store[getPterm(tr).symb()].rsort() == sort_INTEGER; }
 
-
-    // Return the corresponding equivalence term if yes,
-    // PTRef_Undef otherwise.
-    PTRef       lookupUPEq         (PTRef tr);
 
     // Returns an equality over args if term store contains one, otherwise returns PTRef_Undef.
     // args is sorted before lookup, but not simplified otherwise
@@ -356,11 +350,6 @@ class Logic {
     // Override for different logics...
     virtual bool declare_sort_hook  (SRef sr);
     inline bool isPredef           (string&)        const ;//{ return false; };
-
-    // Simplify a term tree.  Return l_True, l_False, or l_Undef, if
-    // simplification resulted in constant true or false, or neither,
-    // respectively
-    void        simplifyTree       (PTRef tr, PTRef& root_out);
 
     PTRef       resolveTerm        (const char* s, vec<PTRef>& args, char** msg);
 

--- a/src/proof/PGInterpolator.cc
+++ b/src/proof/PGInterpolator.cc
@@ -902,20 +902,14 @@ PTRef ProofGraph::compInterpLabelingInnerSimple ( ProofNode *n, const ipartition
     // Pivot class A -> interpolant = interpolant of ant1 OR interpolant of ant2
     if ( pivot_class == I_A )
     {
-        vec<PTRef> or_args;
-        or_args.push (partial_interp_ant1);
-        or_args.push (partial_interp_ant2);
-        partial_interp = logic_.mkOr (or_args);
+        partial_interp = logic_.mkOr({partial_interp_ant1, partial_interp_ant2});
         assert (partial_interp != PTRef_Undef);
 //        cout << "Class A inner" << endl;
     }
     // Pivot class B -> interpolant = interpolant of ant1 AND interpolant of ant2
     else if ( pivot_class == I_B )
     {
-        vec<PTRef> and_args;
-        and_args.push (partial_interp_ant1);
-        and_args.push (partial_interp_ant2);
-        partial_interp = logic_.mkAnd (and_args);
+        partial_interp = logic_.mkAnd({partial_interp_ant1, partial_interp_ant2});
         assert (partial_interp != PTRef_Undef);
 //        cout << "Class B inner" << endl;
     }
@@ -940,18 +934,9 @@ PTRef ProofGraph::compInterpLabelingInnerSimple ( ProofNode *n, const ipartition
             // Equivalent formula (I_1 /\ ~p) \/ (I_2 /\ p)
             if ( choose_alternative )
             {
-                vec<PTRef> and1_args;
-                and1_args.push (partial_interp_ant1);
-                and1_args.push (logic_.mkNot (piv));
-                PTRef and_1 = logic_.mkAnd (and1_args);
-                vec<PTRef> and2_args;
-                and2_args.push (partial_interp_ant2);
-                and2_args.push (piv);
-                PTRef and_2 = logic_.mkAnd (and2_args);
-                vec<PTRef> or_args;
-                or_args.push (and_1);
-                or_args.push (and_2);
-                partial_interp = logic_.mkOr (or_args);
+                PTRef and_1 = logic_.mkAnd({partial_interp_ant1, logic_.mkNot(piv)});
+                PTRef and_2 = logic_.mkAnd({partial_interp_ant2, piv});
+                partial_interp = logic_.mkOr({and_1, and_2});
 
 //              PTRef and_1 = logic_.mkAnd( logic_.cons( partial_interp_ant1, logic_.cons( logic_.mkNot( logic_.cons( piv ) ) ) ) );
 //              PTRef and_2 = logic_.mkAnd( logic_.cons( partial_interp_ant2, logic_.cons( piv ) ) );
@@ -965,20 +950,9 @@ PTRef ProofGraph::compInterpLabelingInnerSimple ( ProofNode *n, const ipartition
             // Standard interpolation (I_1 \/ p) /\ (I_2 \/ ~p)
             else
             {
-                vec<PTRef> or1_args;
-                or1_args.push (partial_interp_ant1);
-                or1_args.push (piv);
-                PTRef or_1 = logic_.mkOr (or1_args);
-
-                vec<PTRef> or2_args;
-                or2_args.push (partial_interp_ant2);
-                or2_args.push (logic_.mkNot (piv));
-                PTRef or_2 = logic_.mkOr (or2_args);
-
-                vec<PTRef> args;
-                args.push (or_1);
-                args.push (or_2);
-                partial_interp = logic_.mkAnd (args); // FIXME used to be a new declaration
+                PTRef or_1 = logic_.mkOr({partial_interp_ant1, piv});
+                PTRef or_2 = logic_.mkOr({partial_interp_ant2, logic_.mkNot(piv)});
+                partial_interp = logic_.mkAnd({or_1, or_2});
 
 //              PTRef or_1 = logic_.mkOr( logic_.cons( partial_interp_ant1, logic_.cons( piv ) ) );
 //              PTRef or_2 = logic_.mkOr( logic_.cons( partial_interp_ant2, logic_.cons( logic_.mkNot( logic_.cons( piv ) ) ) ) );
@@ -991,20 +965,13 @@ PTRef ProofGraph::compInterpLabelingInnerSimple ( ProofNode *n, const ipartition
         }
         else if ( usingMcMillanInterpolation( ) )
         {
-            vec<PTRef> args;
-            args.push (partial_interp_ant1);
-            args.push (partial_interp_ant2);
-
-            partial_interp = logic_.mkAnd (args); // logic_.cons( partial_interp_ant1, logic_.cons( partial_interp_ant2 ) ) );
+            partial_interp = logic_.mkAnd({partial_interp_ant1, partial_interp_ant2});
             assert (partial_interp != PTRef_Undef);
 //            cout << "Class AB McMillan inner" << endl;
         }
         else if ( usingMcMillanPrimeInterpolation( ) )
         {
-            vec<PTRef> args;
-            args.push (partial_interp_ant1);
-            args.push (partial_interp_ant2);
-            partial_interp = logic_.mkOr (args); // logic_.cons( partial_interp_ant1, logic_.cons( partial_interp_ant2 ) ) );
+            partial_interp = logic_.mkOr({partial_interp_ant1, partial_interp_ant2});
             assert (partial_interp != PTRef_Undef);
 //            cout << "Class AB McMillan' inner" << endl;
         }
@@ -1254,19 +1221,15 @@ PTRef ProofGraph::compInterpLabelingInner ( ProofNode *n )
         }
     }
 
-    vec<PTRef> args;
-    args.push (partial_interp_ant1);
-    args.push (partial_interp_ant2);
-
     // Pivot colored a -> interpolant = interpolant of ant1 OR interpolant of ant2
     if ( pivot_color == I_A)
     {
-        partial_interp = logic_.mkOr (args);
+        partial_interp = logic_.mkOr({partial_interp_ant1, partial_interp_ant2});
     }
     // Pivot colored b -> interpolant = interpolant of ant1 AND interpolant of ant2
     else if ( pivot_color == I_B )
     {
-        partial_interp = logic_.mkAnd (args);
+        partial_interp = logic_.mkAnd({partial_interp_ant1, partial_interp_ant2});
     }
     // Pivot colored ab -> interpolant = (pivot OR interpolant of ant1) AND ((NOT pivot) OR interpolant of ant2)
     // Alternative interpolant = ((NOT pivot) AND interpolant of ant1) OR (pivot AND interpolant of ant2)
@@ -1283,17 +1246,8 @@ PTRef ProofGraph::compInterpLabelingInner ( ProofNode *n )
         // Equivalent formula (I_1 /\ ~p) \/ (I_2 /\ p)
         if ( choose_alternative )
         {
-            vec<PTRef> and1_args;
-            vec<PTRef> and2_args;
-            vec<PTRef> or_args;
-
-            and1_args.push (partial_interp_ant1);
-            and1_args.push (logic_.mkNot (piv));
-            PTRef and_1 = logic_.mkAnd (and1_args);
-
-            and2_args.push (partial_interp_ant2);
-            and2_args.push (piv);
-            PTRef and_2 = logic_.mkAnd (and2_args);
+            PTRef and_1 = logic_.mkAnd({partial_interp_ant1, logic_.mkNot(piv)});
+            PTRef and_2 = logic_.mkAnd({partial_interp_ant2, piv});
 
             if (logic_.isNot (and_1) && (logic_.getPterm (and_1)[0] == and_2))
                 partial_interp = logic_.getTerm_true();
@@ -1301,29 +1255,15 @@ PTRef ProofGraph::compInterpLabelingInner ( ProofNode *n )
                 partial_interp = logic_.getTerm_true();
             else
             {
-                or_args.push (and_1);
-                or_args.push (and_2);
-                partial_interp = logic_.mkOr (or_args);
-
-                // TODO ~piv \/ piv is not simplified, but should be!
-                // now it should be
+                partial_interp = logic_.mkOr({and_1, and_2});
                 assert (partial_interp != logic_.getTerm_true());
             }
         }
         // Standard interpolation (I_1 \/ p) /\ (I_2 \/ ~p)
         else
         {
-            vec<PTRef> or1_args;
-            vec<PTRef> or2_args;
-            vec<PTRef> and_args;
-
-            or1_args.push (partial_interp_ant1);
-            or1_args.push (piv);
-            PTRef or_1 = logic_.mkOr (or1_args);
-
-            or2_args.push (partial_interp_ant2);
-            or2_args.push (logic_.mkNot (piv));
-            PTRef or_2 = logic_.mkOr (or2_args);
+            PTRef or_1 = logic_.mkOr({partial_interp_ant1, piv});
+            PTRef or_2 = logic_.mkOr({partial_interp_ant2, logic_.mkNot(piv)});
 
             if (logic_.isNot (or_1) && (logic_.getPterm (or_1)[0] == or_2))
                 partial_interp = logic_.getTerm_false();
@@ -1331,9 +1271,7 @@ PTRef ProofGraph::compInterpLabelingInner ( ProofNode *n )
                 partial_interp = logic_.getTerm_false();
             else
             {
-                and_args.push (or_1);
-                and_args.push (or_2);
-                partial_interp = logic_.mkAnd (and_args);
+                partial_interp = logic_.mkAnd({or_1, or_2});
                 assert (partial_interp != logic_.getTerm_false());
             }
 

--- a/src/tsolvers/bvsolver/BitBlaster.cc
+++ b/src/tsolvers/bvsolver/BitBlaster.cc
@@ -304,8 +304,7 @@ BitBlaster::bbEq(PTRef tr)
         result_args.push(logic.mkEq(bs[bb_lhs][i], bs[bb_rhs][i]));
     }
     PTRef res = simplify( logic.mkAnd( result_args ) );
-    vec<PTRef> tmp;
-    tmp.growTo(bitwidth, logic.getTerm_false());
+    vec<PTRef> tmp(bitwidth, logic.getTerm_false());
     tmp[0] = res;
     return bs.newBvector(names, tmp, mkActVar(s_bbEq), tr);
 }

--- a/test/unit/test_Ites.cc
+++ b/test/unit/test_Ites.cc
@@ -49,26 +49,14 @@ TEST_F(LogicIteTest, test_UFIte) {
     PTRef y = logic.mkVar(ufsort, "y");
     PTRef cond = logic.mkEq(x, y);
 
-    vec<PTRef> args;
-    args.push(cond);
-    args.push(x);
-    args.push(y);
-    PTRef ite = logic.mkIte(args);
+    PTRef ite = logic.mkIte(cond, x, y);
     ASSERT_TRUE(logic.isIte(ite));
     std::cout << logic.pp(ite) << endl;
 
-    args.clear();
-    args.push(logic.getTerm_true());
-    args.push(x);
-    args.push(y);
-    ite = logic.mkIte(args);
+    ite = logic.mkIte(logic.getTerm_true(), x, y);
     ASSERT_EQ(ite, x);
 
-    args.clear();
-    args.push(logic.getTerm_false());
-    args.push(x);
-    args.push(y);
-    ite = logic.mkIte(args);
+    ite = logic.mkIte(logic.getTerm_false(), x, y);
     ASSERT_EQ(ite, y);
 
 }
@@ -80,11 +68,7 @@ TEST_F(LogicIteTest, test_BoolIte) {
     PTRef y = logic.mkVar(boolsort, "y");
     PTRef cond = logic.mkEq(x, y);
 
-    vec<PTRef> args;
-    args.push(cond);
-    args.push(x);
-    args.push(y);
-    PTRef ite = logic.mkIte(args);
+    PTRef ite = logic.mkIte(cond, x, y);
     ASSERT_TRUE(logic.isIte(ite));
     std::cout << logic.pp(ite) << endl;
 }
@@ -96,11 +80,7 @@ TEST_F(LRAIteTest, test_LRAIte) {
     PTRef y = logic.mkVar(lrasort, "y");
     PTRef cond = logic.mkEq(x, y);
 
-    vec<PTRef> args;
-    args.push(cond);
-    args.push(x);
-    args.push(y);
-    PTRef ite = logic.mkIte(args);
+    PTRef ite = logic.mkIte(cond, x, y);
     ASSERT_TRUE(logic.isIte(ite));
     std::cout << logic.pp(ite) << endl;
 }

--- a/test/unit/test_LogicMkTerms.cc
+++ b/test/unit/test_LogicMkTerms.cc
@@ -17,40 +17,23 @@ TEST_F(LogicMkTermsTest, test_Distinct){
     SRef ufsort = logic.declareSort("U", nullptr);
     PTRef x = logic.mkVar(ufsort, "x");
     PTRef y = logic.mkVar(ufsort, "y");
-    vec<PTRef> args;
-    args.push(x);
-    args.push(y);
-    PTRef distinct = logic.mkDistinct(args);
+    PTRef distinct = logic.mkDistinct({x,y});
     ASSERT_NE(distinct, logic.getTerm_false());
     ASSERT_NE(distinct, logic.getTerm_true());
 
-    args.clear();
-    args.push(x);
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({x});
     ASSERT_EQ(distinct, logic.getTerm_true());
 
-    args.clear();
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({});
     ASSERT_EQ(distinct, logic.getTerm_true());
 
-    args.push(x);
-    args.push(x);
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({x,x});
     ASSERT_EQ(distinct, logic.getTerm_false());
 
-    args.clear();
-    args.push(x);
-    args.push(y);
-    args.push(x);
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({x,y,x});
     ASSERT_EQ(distinct, logic.getTerm_false());
 
-
-
-    args.clear();
-    args.push(x);
-    args.push(y);
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({x,y});
     // MB: dinstinct(x,y) is equivalent to not equal(x,y) and the second version is preferred
     ASSERT_TRUE(logic.isNot(distinct) && logic.isEquality(logic.getPterm(distinct)[0]));
 
@@ -58,11 +41,7 @@ TEST_F(LogicMkTermsTest, test_Distinct){
     PTRef b2 = logic.mkBoolVar("b2");
     PTRef b3 = logic.mkBoolVar("b3");
 
-    args.clear();
-    args.push(b1);
-    args.push(b2);
-    args.push(b3);
-    distinct = logic.mkDistinct(args);
+    distinct = logic.mkDistinct({b1,b2,b3});
     ASSERT_EQ(distinct, logic.getTerm_false());
 
     PTRef z = logic.mkVar(ufsort, "z");
@@ -81,8 +60,7 @@ TEST_F(LogicMkTermsTest, test_ManyDistinct) {
     for (int i = 0; i < 9; i++) {
         for (int j = i+1; j < 9; j++) {
             for (int k = j+1; k < 9; k++) {
-                vec<PTRef> triple{names[i], names[j], names[k]};
-                distincts1.push(logic.mkDistinct(triple));
+                distincts1.push(logic.mkDistinct({names[i], names[j], names[k]}));
             }
         }
     }
@@ -90,8 +68,7 @@ TEST_F(LogicMkTermsTest, test_ManyDistinct) {
     for (int i = 0; i < 9; i++) {
         for (int j = i+1; j < 9; j++) {
             for (int k = j+1; k < 9; k++) {
-                vec<PTRef> triple{names[j], names[i], names[k]};
-                distincts2.push(logic.mkDistinct(triple));
+                distincts2.push(logic.mkDistinct({names[j], names[i], names[k]}));
             }
         }
     }
@@ -99,8 +76,7 @@ TEST_F(LogicMkTermsTest, test_ManyDistinct) {
     for (int i = 0; i < 9; i++) {
         for (int j = i+1; j < 9; j++) {
             for (int k = j+1; k < 9; k++) {
-                vec<PTRef> triple{names[k], names[i], names[j]};
-                distincts3.push(logic.mkDistinct(triple));
+                distincts3.push(logic.mkDistinct({names[k], names[i], names[j]}));
             }
         }
     }


### PR DESCRIPTION
In many places, when creating terms, the code does not use more compact and readable way of using initializer lists.
This PR represents a small cleanup to use initializer lists where possible and avoid explicit temporary `vec`s.

This should help experimenting with further changes in term creation in the future.