### PR TITLE
Normalize arithmetic equalities.

### DIFF
--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -62,6 +62,27 @@ LALogic::getNumConst(PTRef tr) const
     return *numbers[id];
 }
 
+std::pair<opensmt::Number, vec<PTRef>> LALogic::getConstantAndFactors(PTRef sum) {
+    assert(isNumPlus(sum));
+    vec<PTRef> varFactors;
+    PTRef constant = PTRef_Undef;
+    Pterm const & s = getPterm(sum);
+    for (PTRef arg : s) {
+        if (isConstant(arg)) {
+            assert(constant == PTRef_Undef);
+            constant = arg;
+        } else {
+            assert(isLinearFactor(arg));
+            varFactors.push(arg);
+        }
+    }
+    if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
+    auto constantValue = getNumConst(constant);
+    assert(varFactors.size() > 0);
+    termSort(varFactors);
+    return std::pair(std::move(constantValue), std::move(varFactors));
+}
+
 void LALogic::splitTermToVarAndConst(const PTRef& term, PTRef& var, PTRef& fac) const
 {
     assert(isNumTimes(term) || isNumVarLike(term) || isConstant(term));

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -430,11 +430,7 @@ PTRef LALogic::mkBinaryEq(PTRef lhs, PTRef rhs) {
             return v1 == v2 ? getTerm_true() : getTerm_false();
         }
         // diff = rhs - lhs
-        PTRef diff = [&](){
-            if (lhs == getTerm_NumZero()) { return rhs; }
-            if (rhs == getTerm_NumZero()) { return mkNumNeg(lhs); }
-            return mkNumPlus(rhs, mkNumNeg(lhs));
-        }();
+        PTRef diff = lhs == getTerm_NumZero() ? rhs : rhs == getTerm_NumZero() ? mkNumNeg(lhs) : mkNumPlus(rhs, mkNumNeg(lhs));
         if (isConstant(diff)) {
             opensmt::Number const & v = this->getNumConst(diff);
             return v.isZero() ? getTerm_true() : getTerm_false();

--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -421,6 +421,36 @@ PTRef LALogic::mkNumGt(vec<PTRef> const & args)
     return mkAnd(std::move(binaryInequalities));
 }
 
+PTRef LALogic::mkBinaryEq(PTRef lhs, PTRef rhs) {
+    if (getSortRef(lhs) == getSort_num()) {
+        assert(getSortRef(rhs) == getSort_num());
+        if (isConstant(lhs) && isConstant(rhs)) {
+            opensmt::Number const & v1 = this->getNumConst(lhs);
+            opensmt::Number const & v2 = this->getNumConst(rhs);
+            return v1 == v2 ? getTerm_true() : getTerm_false();
+        }
+        // diff = rhs - lhs
+        PTRef diff = [&](){
+            if (lhs == getTerm_NumZero()) { return rhs; }
+            if (rhs == getTerm_NumZero()) { return mkNumNeg(lhs); }
+            return mkNumPlus(rhs, mkNumNeg(lhs));
+        }();
+        if (isConstant(diff)) {
+            opensmt::Number const & v = this->getNumConst(diff);
+            return v.isZero() ? getTerm_true() : getTerm_false();
+        } if (isNumVarLike(diff) || isNumTimes(diff)) {
+            PTRef var, constant;
+            splitTermToVarAndConst(diff, var, constant);
+            return mkFun(get_sym_Num_EQ(), {getTerm_NumZero(), var});
+        } else if (isNumPlus(diff)) {
+            return sumToNormalizedEquality(diff);
+        }
+        assert(false);
+        throw OsmtInternalException{"Unexpected situation in LALogic::mkNumLeq"};
+    }
+    return Logic::mkBinaryEq(lhs, rhs);
+}
+
 PTRef LALogic::insertTerm(SymRef sym, vec<PTRef> && terms)
 {
     if (sym == get_sym_Num_NEG())
@@ -738,42 +768,6 @@ LALogic::printTerm_(PTRef tr, bool ext, bool safe) const
     else
         out = Logic::printTerm_(tr, ext, safe);
     return out;
-}
-
-PTRef LALogic::sumToNormalizedInequality(PTRef sum) {
-    assert(isNumPlus(sum));
-    vec<PTRef> varFactors;
-    PTRef constant = PTRef_Undef;
-    Pterm const & s = getPterm(sum);
-    for (int i = 0; i < s.size(); i++) {
-        if (isConstant(s[i])) {
-            assert(constant == PTRef_Undef);
-            constant = s[i];
-        } else {
-            assert(isLinearFactor(s[i]));
-            varFactors.push(s[i]);
-        }
-    }
-
-    if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
-    opensmt::Number constantVal = getNumConst(constant);
-    assert(varFactors.size() > 0);
-    termSort(varFactors);
-    PTRef leadingFactor = varFactors[0];
-    // normalize the sum according to the leading factor
-    PTRef var, coeff;
-    splitTermToVarAndConst(leadingFactor, var, coeff);
-    opensmt::Number normalizationCoeff = abs(getNumConst(coeff));
-    // varFactors come from a normalized sum, no need to call normalization code again
-    PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), std::move(varFactors));
-    if (normalizationCoeff != 1) {
-        // normalize the whole sum
-        normalizedSum = mkNumTimes(normalizedSum, mkConst(normalizationCoeff.inverse()));
-        // DON'T forget to update also the constant factor!
-        constantVal /= normalizationCoeff;
-    }
-    constantVal.negate(); // moving the constant to the LHS of the inequality
-    return mkFun(get_sym_Num_LEQ(), {mkConst(constantVal), normalizedSum});
 }
 
 PTRef LALogic::getConstantFromLeq(PTRef leq) {

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -191,6 +191,9 @@ protected:
     PTRef mkBinaryGt(PTRef lhs, PTRef rhs);
     
     PTRef mkBinaryEq(PTRef lhs, PTRef rhs) override;
+
+    // Given a 'sum' returns its constant and the non-constant terms as a sorted vector in a form suitable for LRA and LIA normalization
+    std::pair<opensmt::Number, vec<PTRef>> getConstantAndFactors(PTRef sum);
     // Given a sum term 't' returns a normalized inequality 'c <= s' equivalent to '0 <= t'
     virtual PTRef sumToNormalizedInequality(PTRef sum) = 0;
     // Given a sum term 't' returns a normalized equality 'c = s' equivalent to '0 = t'

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -164,8 +164,6 @@ public:
     bool isLinearFactor(PTRef tr) const;
     void splitTermToVarAndConst(const PTRef &term, PTRef &var, PTRef &fac) const;
     PTRef normalizeMul(PTRef mul);
-    // Given a sum term 't' returns a normalized inequality 'c <= s' equivalent to '0 <= t'
-    virtual PTRef sumToNormalizedInequality(PTRef sum);
     virtual lbool arithmeticElimination(const vec<PTRef> & top_level_arith, SubstMap & substitutions);
 
     opensmt::pair<lbool,SubstMap> retrieveSubstitutions(const vec<PtAsgn> &facts) override;
@@ -191,6 +189,12 @@ protected:
     PTRef mkBinaryGeq(PTRef lhs, PTRef rhs);
     PTRef mkBinaryLt(PTRef lhs, PTRef rhs);
     PTRef mkBinaryGt(PTRef lhs, PTRef rhs);
+    
+    PTRef mkBinaryEq(PTRef lhs, PTRef rhs) override;
+    // Given a sum term 't' returns a normalized inequality 'c <= s' equivalent to '0 <= t'
+    virtual PTRef sumToNormalizedInequality(PTRef sum) = 0;
+    // Given a sum term 't' returns a normalized equality 'c = s' equivalent to '0 = t'
+    virtual PTRef sumToNormalizedEquality(PTRef sum) = 0;
 
 };
 

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -159,11 +159,11 @@ public:
     PTRef mkNumGt(const vec<PTRef> & args);
     PTRef mkNumGt(PTRef arg1, PTRef arg2) { return mkBinaryGt(arg1, arg2); }
 
-    virtual bool isNegated(PTRef tr) const;
-    virtual bool isLinearTerm(PTRef tr) const;
-    virtual bool isLinearFactor(PTRef tr) const;
-    virtual void splitTermToVarAndConst(const PTRef &term, PTRef &var, PTRef &fac) const;
-    virtual PTRef normalizeMul(PTRef mul);
+    bool isNegated(PTRef tr) const;
+    bool isLinearTerm(PTRef tr) const;
+    bool isLinearFactor(PTRef tr) const;
+    void splitTermToVarAndConst(const PTRef &term, PTRef &var, PTRef &fac) const;
+    PTRef normalizeMul(PTRef mul);
     // Given a sum term 't' returns a normalized inequality 'c <= s' equivalent to '0 <= t'
     virtual PTRef sumToNormalizedInequality(PTRef sum);
     virtual lbool arithmeticElimination(const vec<PTRef> & top_level_arith, SubstMap & substitutions);

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -120,7 +120,17 @@ LIALogic::LIALogic() :
     sym_Int_EQ = term_store.lookupSymbol(tk_equals, {term_Int_ZERO, term_Int_ZERO});
 }
 
+/**
+ * Normalizes a sum term a1x1 + a2xn + ... + anxn + c such that the coefficients of non-constant terms are coprime integers
+ * Additionally, the normalized term is separated to constant and non-constant part, and the constant is modified as if
+ * it was placed on the other side of an equality.
+ * Note that the constant part can be a non-integer number after normalization.
+ *
+ * @param sum
+ * @return Constant part of the normalized sum as LHS and non-constant part of the normalized sum as RHS
+ */
 opensmt::pair<FastRational, PTRef> LIALogic::sumToNormalizedPair(PTRef sum) {
+    assert(isNumPlus(sum));
     vec<PTRef> varFactors;
     PTRef constant = PTRef_Undef;
     Pterm const & s = getPterm(sum);

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -116,6 +116,8 @@ LIALogic::LIALogic() :
     //sym_store[sym_Real_ITE].setLeftAssoc();
     sym_store[sym_Int_ITE].setNoScoping();
     sym_store.setInterpreted(sym_Int_ITE);
+
+    sym_Int_EQ = term_store.lookupSymbol(tk_equals, {term_Int_ZERO, term_Int_ZERO});
 }
 
 

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -134,13 +134,13 @@ opensmt::pair<FastRational, PTRef> LIALogic::sumToNormalizedPair(PTRef sum) {
     vec<PTRef> varFactors;
     PTRef constant = PTRef_Undef;
     Pterm const & s = getPterm(sum);
-    for (int i = 0; i < s.size(); i++) {
-        if (isConstant(s[i])) {
+    for (PTRef arg : s) {
+        if (isConstant(arg)) {
             assert(constant == PTRef_Undef);
-            constant = s[i];
+            constant = arg;
         } else {
-            assert(isLinearFactor(s[i]));
-            varFactors.push(s[i]);
+            assert(isLinearFactor(arg));
+            varFactors.push(arg);
         }
     }
     if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
@@ -209,20 +209,18 @@ opensmt::pair<FastRational, PTRef> LIALogic::sumToNormalizedPair(PTRef sum) {
     }
     PTRef normalizedSum = varFactors.size() == 1 ? varFactors[0] : mkFun(get_sym_Num_PLUS(), std::move(varFactors));
     // 0 <= normalizedSum + constatValue
-    // in LIA we can strengthen the inequality to
-    // ceiling(-constantValue) <= normalizedSum
     constantValue.negate();
     return {std::move(constantValue), normalizedSum};
 }
 
 
 PTRef LIALogic::sumToNormalizedInequality(PTRef sum) {
-    auto[lhsVal, rhs] = sumToNormalizedPair(sum);
+    auto [lhsVal, rhs] = sumToNormalizedPair(sum);
     return mkFun(get_sym_Num_LEQ(), {mkConst(lhsVal.ceil()), rhs});
 }
 
 PTRef LIALogic::sumToNormalizedEquality(PTRef sum) {
-    auto[lhsVal, rhs] = sumToNormalizedPair(sum);
+    auto [lhsVal, rhs] = sumToNormalizedPair(sum);
     if (not lhsVal.isInteger()) { return getTerm_false(); }
     return mkFun(get_sym_Num_EQ(), {mkConst(lhsVal), rhs});
 }

--- a/src/logics/LIALogic.cc
+++ b/src/logics/LIALogic.cc
@@ -130,22 +130,9 @@ LIALogic::LIALogic() :
  * @return Constant part of the normalized sum as LHS and non-constant part of the normalized sum as RHS
  */
 opensmt::pair<FastRational, PTRef> LIALogic::sumToNormalizedPair(PTRef sum) {
-    assert(isNumPlus(sum));
-    vec<PTRef> varFactors;
-    PTRef constant = PTRef_Undef;
-    Pterm const & s = getPterm(sum);
-    for (PTRef arg : s) {
-        if (isConstant(arg)) {
-            assert(constant == PTRef_Undef);
-            constant = arg;
-        } else {
-            assert(isLinearFactor(arg));
-            varFactors.push(arg);
-        }
-    }
-    if (constant == PTRef_Undef) { constant = getTerm_NumZero(); }
-    auto constantValue = getNumConst(constant);
-    termSort(varFactors);
+
+    auto [constantValue, varFactors] = getConstantAndFactors(sum);
+
     vec<PTRef> vars; vars.capacity(varFactors.size());
     std::vector<opensmt::Number> coeffs; coeffs.reserve(varFactors.size());
     for (PTRef factor : varFactors) {

--- a/src/logics/LIALogic.h
+++ b/src/logics/LIALogic.h
@@ -103,11 +103,14 @@ public:
     PTRef mkIntDiv(PTRef dividend, PTRef divisor);
 
     PTRef insertTerm (SymRef sym, vec<PTRef>&& terms) override;
-    virtual PTRef sumToNormalizedInequality(PTRef sum) override;
 
-private:
+protected:
     PTRef _mkIntMod(vec<PTRef> && args);
     PTRef _mkIntDiv(vec<PTRef> && args);
+
+    PTRef sumToNormalizedInequality(PTRef sum) override;
+    PTRef sumToNormalizedEquality(PTRef sum) override;
+    opensmt::pair<FastRational, PTRef> sumToNormalizedPair(PTRef sum);
 };
 
 #endif

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -173,18 +173,18 @@ PTRef LRALogic::insertTerm(SymRef sym, vec<PTRef> &&terms) {
  * @param sum
  * @return Constant part of the normalized sum as LHS and non-constant part of the normalized sum as RHS
  */
-opensmt::pair<PTRef, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
+opensmt::pair<opensmt::Number, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
     assert(isNumPlus(sum));
     vec<PTRef> varFactors;
     PTRef constant = PTRef_Undef;
     Pterm const & s = getPterm(sum);
-    for (int i = 0; i < s.size(); i++) {
-        if (isConstant(s[i])) {
+    for (PTRef arg : s) {
+        if (isConstant(arg)) {
             assert(constant == PTRef_Undef);
-            constant = s[i];
+            constant = arg;
         } else {
-            assert(isLinearFactor(s[i]));
-            varFactors.push(s[i]);
+            assert(isLinearFactor(arg));
+            varFactors.push(arg);
         }
     }
 
@@ -206,15 +206,15 @@ opensmt::pair<PTRef, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
         constantVal /= normalizationCoeff;
     }
     constantVal.negate(); // moving the constant to the LHS of the inequality
-    return {mkConst(constantVal), normalizedSum};
+    return {std::move(constantVal), normalizedSum};
 }
 
 PTRef LRALogic::sumToNormalizedInequality(PTRef sum) {
-    auto [lhs, rhs] = sumToNormalizedPair(sum);
-    return mkFun(get_sym_Num_LEQ(), {lhs, rhs});
+    auto [lhsVal, rhs] = sumToNormalizedPair(sum);
+    return mkFun(get_sym_Num_LEQ(), {mkConst(lhsVal), rhs});
 }
 
 PTRef LRALogic::sumToNormalizedEquality(PTRef sum) {
-    auto [lhs, rhs] = sumToNormalizedPair(sum);
-    return mkFun(get_sym_Num_EQ(), {lhs, rhs});
+    auto [lhsVal, rhs] = sumToNormalizedPair(sum);
+    return mkFun(get_sym_Num_EQ(), {mkConst(lhsVal), rhs});
 }

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -174,7 +174,7 @@ PTRef LRALogic::insertTerm(SymRef sym, vec<PTRef> &&terms) {
  * @return Constant part of the normalized sum as LHS and non-constant part of the normalized sum as RHS
  */
 
-opensmt::pair<FastRational, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
+opensmt::pair<opensmt::Number, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
 
     auto [constantValue, varFactors] = getConstantAndFactors(sum);
 

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -165,6 +165,14 @@ PTRef LRALogic::insertTerm(SymRef sym, vec<PTRef> &&terms) {
     return LALogic::insertTerm(sym, std::move(terms));
 }
 
+/**
+ * Normalizes a sum term a1x1 + a2xn + ... + anxn + c such that the leading coefficient is either 1 or -1.
+ * Additionally, the normalized term is separated to constant and non-constant part, and the constant is modified as if
+ * it was placed on the other side of an equality.
+ *
+ * @param sum
+ * @return Constant part of the normalized sum as LHS and non-constant part of the normalized sum as RHS
+ */
 opensmt::pair<PTRef, PTRef> LRALogic::sumToNormalizedPair(PTRef sum) {
     assert(isNumPlus(sum));
     vec<PTRef> varFactors;

--- a/src/logics/LRALogic.cc
+++ b/src/logics/LRALogic.cc
@@ -131,6 +131,8 @@ LRALogic::LRALogic() :
     ites.insert(sym_Real_ITE, true);
     sortToIte.insert(sort_REAL, sym_Real_ITE);
     sym_store.setInterpreted(sym_Real_ITE);
+
+    sym_Real_EQ = term_store.lookupSymbol(tk_equals, {term_Real_ZERO, term_Real_ZERO});
 }
 
 PTRef LRALogic::mkRealDiv(vec<PTRef> const & args)

--- a/src/logics/LRALogic.h
+++ b/src/logics/LRALogic.h
@@ -123,6 +123,12 @@ public:
 
     PTRef insertTerm(SymRef sym, vec<PTRef> &&terms) override;
 
+protected:
+    PTRef sumToNormalizedInequality(PTRef sum) override;
+    PTRef sumToNormalizedEquality(PTRef sum) override;
+
+    opensmt::pair<PTRef, PTRef> sumToNormalizedPair(PTRef sum);
+
 };
 
 #endif

--- a/src/logics/LRALogic.h
+++ b/src/logics/LRALogic.h
@@ -127,7 +127,7 @@ protected:
     PTRef sumToNormalizedInequality(PTRef sum) override;
     PTRef sumToNormalizedEquality(PTRef sum) override;
 
-    opensmt::pair<PTRef, PTRef> sumToNormalizedPair(PTRef sum);
+    opensmt::pair<opensmt::Number, PTRef> sumToNormalizedPair(PTRef sum);
 
 };
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -732,7 +732,7 @@ PTRef Logic::mkImpl(vec<PTRef> && args) {
         return tr;
 }
 
-PTRef Logic::mkEq(PTRef lhs, PTRef rhs) {
+PTRef Logic::mkBinaryEq(PTRef lhs, PTRef rhs) {
     if (lhs == rhs) return getTerm_true();
     if (isConstant(lhs) && isConstant(rhs))
         return getTerm_false();
@@ -755,12 +755,12 @@ PTRef Logic::mkEq(vec<PTRef>&& args) {
     if (args.size() > 2) { // split to chain of equalities with 2 arguments
         vec<PTRef> binaryEqualities;
         for (int i = 0; i < args.size() - 1; ++i) {
-            binaryEqualities.push(mkEq(args[i], args[i + 1]));
+            binaryEqualities.push(mkBinaryEq(args[i], args[i + 1]));
         }
         return mkAnd(std::move(binaryEqualities));
     }
     assert(args.size() == 2);
-    return mkEq(args[0], args[1]);
+    return mkBinaryEq(args[0], args[1]);
 }
 
 // Given args = {a_1, ..., a_n}, distinct(args) holds iff

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -230,7 +230,10 @@ class Logic {
     // Generic equalities
     PTRef       mkEq          (vec<PTRef>&& args);
     PTRef       mkEq          (vec<PTRef> const & args) { vec<PTRef> tmp; args.copyTo(tmp); return mkEq(std::move(tmp)); }
-    PTRef       mkEq          (PTRef a1, PTRef a2);
+    PTRef       mkEq          (PTRef a1, PTRef a2) { return mkBinaryEq(a1, a2); }
+protected:
+    virtual PTRef mkBinaryEq(PTRef lhs, PTRef rhs);
+public:
 
     // General disequalities
     PTRef       mkDistinct    (vec<PTRef>&& args);

--- a/test/unit/test_LIALogicMkTerms.cc
+++ b/test/unit/test_LIALogicMkTerms.cc
@@ -125,3 +125,12 @@ TEST_F(LIALogicMkTermsTest, test_Inequality_Simplification)
             )
     );
 }
+
+TEST_F(LIALogicMkTermsTest, test_EqualityNormalization) {
+    PTRef two = logic.mkConst(2);
+    PTRef eq1 = logic.mkEq(x, y);
+    PTRef eq2 = logic.mkEq(logic.mkNumTimes(x, two), logic.mkNumTimes(y, two));
+//    std::cout << logic.printTerm(eq1) << std::endl;
+//    std::cout << logic.printTerm(eq2) << std::endl;
+    EXPECT_EQ(eq1, eq2);
+}

--- a/test/unit/test_LIALogicMkTerms.cc
+++ b/test/unit/test_LIALogicMkTerms.cc
@@ -134,3 +134,19 @@ TEST_F(LIALogicMkTermsTest, test_EqualityNormalization) {
 //    std::cout << logic.printTerm(eq2) << std::endl;
     EXPECT_EQ(eq1, eq2);
 }
+
+TEST_F(LIALogicMkTermsTest, test_EqualityNormalization_ToConstantExpression) {
+    PTRef two = logic.mkConst(2);
+    PTRef eq1 = logic.mkEq(x, logic.mkNumPlus(x, two));
+    EXPECT_EQ(eq1, logic.getTerm_false());
+    PTRef eq2 = logic.mkEq(logic.mkNumTimes(x, two), logic.getTerm_NumOne());
+    EXPECT_EQ(eq2, logic.getTerm_false());
+}
+
+TEST_F(LIALogicMkTermsTest, test_EqualityNormalization_AlreadyNormalized) {
+    PTRef two = logic.mkConst(2);
+    PTRef three = logic.mkConst(3);
+    PTRef eq1 = logic.mkEq(logic.mkNumPlus(logic.mkNumTimes(x, two), logic.mkNumTimes(y, three)), logic.getTerm_NumOne());
+    ASSERT_NE(eq1, logic.getTerm_false());
+    EXPECT_EQ(logic.getSymRef(eq1), logic.get_sym_Num_EQ());
+}

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -251,3 +251,9 @@ TEST_F(LRALogicMkTermsTest, test_EqualityNormalization) {
 //    std::cout << logic.printTerm(eq2) << std::endl;
     EXPECT_EQ(eq1, eq2);
 }
+
+TEST_F(LRALogicMkTermsTest, test_EqualityNormalization_ToConstantExpression) {
+    PTRef two = logic.mkConst(2);
+    PTRef eq1 = logic.mkEq(x, logic.mkNumPlus(x, two));
+    EXPECT_EQ(eq1, logic.getTerm_false());
+}

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -242,3 +242,12 @@ TEST_F(LRALogicMkTermsTest, test_ChainableInequality) {
     PTRef expandedGt = logic.mkAnd(logic.mkNumGt(x,y), logic.mkNumGt(y,z));
     EXPECT_EQ(multiArgsGt, expandedGt);
 }
+
+TEST_F(LRALogicMkTermsTest, test_EqualityNormalization) {
+    PTRef two = logic.mkConst(2);
+    PTRef eq1 = logic.mkEq(x, y);
+    PTRef eq2 = logic.mkEq(logic.mkNumTimes(x, two), logic.mkNumTimes(y, two));
+//    std::cout << logic.printTerm(eq1) << std::endl;
+//    std::cout << logic.printTerm(eq2) << std::endl;
+    EXPECT_EQ(eq1, eq2);
+}


### PR DESCRIPTION
Depends on #292.
Resolves #267.

Currently, arithmetic equalities are not normalized, they are created as given, in the same way as equalities for uninterpreted sorts.
This PR adds normalization process to arithmetic equalities on creation, which works almost the same as the normalization for arithmetic inequalities.