### PR TITLE
CoreSMTSolver: Enable theory propagation in interpolating mode

### DIFF
--- a/regression_itp/incremental/inc_itp_theory_prop.smt2
+++ b/regression_itp/incremental/inc_itp_theory_prop.smt2
@@ -1,0 +1,10 @@
+(set-option :produce-interpolants 1)
+(set-logic QF_LRA)
+(declare-fun x () Real)
+(push 1)
+(assert (! (>= x 0) :named A))
+(push 1)
+(assert (! (<= x (- 10)) :named B))
+(check-sat)
+(get-interpolants A B)
+

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -1090,7 +1090,6 @@ void CoreSMTSolver::analyzeFinal(Lit p, vec<Lit>& out_conflict)
             {
                 if (reason(x) == CRef_Fake)
                 {
-                    assert(!logsProofForInterpolation()); // MB: If we make theory propagation work with proof logging, fix this.
                     cancelUntilVarTempInit(x);
                     vec<Lit> r;
                     theory_handler.getReason(trail[i], r);
@@ -1100,6 +1099,12 @@ void CoreSMTSolver::analyzeFinal(Lit p, vec<Lit>& out_conflict)
                         seen[var(r[j])] = 1;
                     }
                     cancelUntilVarTempDone();
+                    if (logsProofForInterpolation()) {
+                        CRef theoryClause = ca.alloc(r);
+                        vardata[x].reason = theoryClause;
+                        proof->newTheoryClause(theoryClause);
+                        proof->addResolutionStep(theoryClause, x);
+                    }
                 }
                 else
                 {

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -911,12 +911,14 @@ void CoreSMTSolver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
     }
 #endif
 
-    for (int j = 0; j < analyze_toclear.size(); j++) seen[var(analyze_toclear[j])] = 0;    // ('seen[]' is now cleared)
+    for (Lit l : analyze_toclear) {
+        seen[var(l)] = 0;
+    } // ('seen[]' is now cleared)
     assert(std::all_of(seen.begin(), seen.end(), [](char c) { return c == 0; }));
     // Cleanup generated lemmata
     if (not logsProofForInterpolation) {
-        for (int i = 0; i < cleanup.size(); i++) {
-            ca.free(cleanup[i]);
+        for (CRef cref : cleanup) {
+            ca.free(cref);
         }
     }
     cleanup.clear();

--- a/src/smtsolvers/Proof.cc
+++ b/src/smtsolvers/Proof.cc
@@ -38,7 +38,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 void Proof::newLeafClause(CRef c, clause_type t)
 {
     assert(c != CRef_Undef);
-    assert(!hasOpenChain());
     assert(clause_to_proof_der.find(c) == clause_to_proof_der.end());
     clause_to_proof_der.emplace(c, ProofDer{t});
 }

--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -148,10 +148,30 @@ CoreSMTSolver::handleSat()
         vec<LitLev> deds;
         deduceTheory(deds); // deds will be ordered by decision levels
         for (int i = 0; i < deds.size(); i++) {
+            Lit l = deds[i].l;
             if (deds[i].lev != decisionLevel()) {
                 // Maybe do something someday?
             }
-            uncheckedEnqueue(deds[i].l, CRef_Fake);
+            CRef deducedReason = CRef_Fake;
+            if (decisionLevel() == 0 and logsProofForInterpolation()) {
+                vec<Lit> reasonLits;
+                theory_handler.getReason(l, reasonLits);
+                assert(reasonLits.size() > 0);
+                CRef theoryReason = ca.alloc(reasonLits);
+                CRef unit = ca.alloc(vec<Lit>{l});
+                proof->newTheoryClause(theoryReason);
+                proof->beginChain(theoryReason);
+                Clause const & clause = ca[theoryReason];
+                for (unsigned j = 0; j < clause.size(); ++j) {
+                    if (clause[j] != l) {
+                        proof->addResolutionStep(reason(var(clause[j])), var(clause[j]));
+                    }
+                }
+                proof->endChain(unit);
+                vardata[var(l)].reason = unit;
+                deducedReason = unit;
+            }
+            uncheckedEnqueue(l, deducedReason);
         }
         if (deds.size() > 0) {
             return TPropRes::Propagate;


### PR DESCRIPTION
Not having theory propagation in interpolating mode slows down the solving on some instances significantly.
The motivation for this change were some CHC benchmark where solver during many incremental calls accumulated a lot of binary clauses corresponding to theory propagation in arithmetic theories.
These accumulated clauses were slowing down solving significantly as the SAT solver were trying to reduce the number of learnt clauses before *every* decision, but did not succeed as these were all binary clauses.

The change in the code turned out to be not not complicated at all. The only difficult thing was maintaining specific invariant for learning unary clauses at level 0.
To maintain it, we need to log in the proof derivation of unary clause when theory propagation occurs at level 0.