### PR TITLE
Proof transformations cleanup - part 6 of N 

### DIFF
--- a/src/proof/PGTransformationAlgorithms.cc
+++ b/src/proof/PGTransformationAlgorithms.cc
@@ -191,7 +191,6 @@ double ProofGraph::recyclePivotsIter() {
                     if (res->getAnt1() == n) { res->setAnt1(replacing); }
                     else if (res->getAnt2() == n) { res->setAnt2(replacing); }
                     else { throw OsmtInternalException("Invalid proof structure " + std::string(__FILE__) + ", " + std::to_string(__LINE__)); }
-                    assert(res->getAnt1() != res->getAnt2());
                     replacing->addRes(resId);
                     assert(not isSetVisited2(resId));
                     q.push_back(resId);


### PR DESCRIPTION
It is possible that a node marked for removal in
recyclePivotsIter_RecyclePhase will cause one of its children to have
identical antecedents. This is already handled correctly in the
algorithm. Unit test test_recyclePivots_IdenticalAntecedents_AfterPhaseOneReplace shows how
this situation can occur.

Thus, the assertion in recyclePivotsIter does not hold in all circumstances and should be removed.