### PR TITLE
Model fix

### DIFF
--- a/regression/QF_UF/get-value.smt2.expected.out
+++ b/regression/QF_UF/get-value.smt2.expected.out
@@ -1,2 +1,2 @@
 sat
-((f @2)(g @2)(h @3)(true true)(false false))
+((f (as @2 U))(g (as @2 U))(h (as @3 U))(true true)(false false))

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -363,9 +363,8 @@ Logic::printTerm_(PTRef tr, bool ext, bool safe) const
         bool first = true;
         for (auto arg : t) {
             char *current_term_p = printTerm_(arg, ext, safe);
-            std::string current_term = current_term_p;
+            ss << (first ? "" : " ") << current_term_p;
             free(current_term_p);
-            ss << (first ? "" : " ") << current_term;
             first = false;
         }
         ss << ")" << (ext ? " <" + std::to_string(tr.x) + ">" : "");


### PR DESCRIPTION
A recent fix on model printing broke UF models so that sort information was no longer printed for models.  This PR enables back their printing.

While preparing the fix I noticed a regression test where (as far as I understand) the sort was incorrectly omitted for UF models when queried with `get-value`.  This is now fixed.