### PR TITLE
IteHandler: Initializing NodeAllocator with smaller initial capacity

### DIFF
--- a/src/itehandler/IteToSwitch.h
+++ b/src/itehandler/IteToSwitch.h
@@ -61,7 +61,7 @@ namespace ite {
         }
     public:
         void clear() override { n_nodes = 0; RegionAllocator::clear(); }
-        NodeAllocator() : n_nodes(0) {}
+        NodeAllocator() : RegionAllocator<uint32_t>(1024), n_nodes(0) {}
         unsigned getNumNodes() const { return n_nodes; }
 
         NodeRef alloc(PTRef term, PTRef cond, NodeRef trueChild, NodeRef falseChild) {


### PR DESCRIPTION
`NodeAllocator` for `IteSwitch` is using the default constructor of RegionAllocator which initializes the capacity to 1024*1024. This seems excessive.
I believe initial capacity of 1024 should be enough.