### PR TITLE
Mpq cleanup

### DIFF
--- a/src/common/FastRational.cc
+++ b/src/common/FastRational.cc
@@ -117,12 +117,8 @@ FastRational gcd(FastRational const & a, FastRational const & b)
     else {
         a.force_ensure_mpq_valid();
         b.force_ensure_mpq_valid();
-        mpz_t o;
-        mpz_init(o);
-        mpz_gcd(o, mpq_numref(a.mpq), mpq_numref(b.mpq));
-        FastRational o_gcd(o);
-        mpz_clear(o);
-        return o_gcd;
+        mpz_gcd(FastRational::mpz(), mpq_numref(a.mpq), mpq_numref(b.mpq));
+        return FastRational(FastRational::mpz());
     }
 }
 
@@ -135,12 +131,8 @@ FastRational lcm(FastRational const & a, FastRational const & b)
     else {
         a.force_ensure_mpq_valid();
         b.force_ensure_mpq_valid();
-        mpz_t o;
-        mpz_init(o);
-        mpz_lcm(o, mpq_numref(a.mpq), mpq_numref(b.mpq));
-        FastRational o_gcd(o);
-        mpz_clear(o);
-        return o_gcd;
+        mpz_lcm(FastRational::mpz(), mpq_numref(a.mpq), mpq_numref(b.mpq));
+        return FastRational(FastRational::mpz());
     }
 }
 
@@ -170,12 +162,8 @@ FastRational fastrat_fdiv_q(FastRational const & n, FastRational const & d) {
 overflow:
     n.force_ensure_mpq_valid();
     d.force_ensure_mpq_valid();
-    mpz_t t;
-    mpz_init(t);
-    mpz_fdiv_q(t, mpq_numref(n.mpq), mpq_numref(d.mpq));
-    FastRational r(t);
-    mpz_clear(t);
-    return r;
+    mpz_fdiv_q(FastRational::mpz(), mpq_numref(n.mpq), mpq_numref(d.mpq));
+    return FastRational(FastRational::mpz());
 }
 
 //void mpz_divexact (mpz_ptr, mpz_srcptr, mpz_srcptr);
@@ -199,12 +187,8 @@ FastRational divexact(FastRational const & n, FastRational const & d) {
         assert(n.mpqPartValid() || d.mpqPartValid());
         n.force_ensure_mpq_valid();
         d.force_ensure_mpq_valid();
-        mpz_t t;
-        mpz_init(t);
-        mpz_divexact(t, mpq_numref(n.mpq), mpq_numref(d.mpq));
-        FastRational r(t);
-        mpz_clear(t);
-        return r;
+        mpz_divexact(FastRational::mpz(), mpq_numref(n.mpq), mpq_numref(d.mpq));
+        return FastRational(FastRational::mpz());
     }
 }
 

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -24,15 +24,6 @@ typedef uint64_t ulword;
 #define LWORD_MIN LONG_MIN
 #define LWORD_MAX LONG_MAX
 
-class MpzUnit
-{
-private:
-    mpz_t unit;
-public:
-    MpzUnit() { mpz_init(unit); mpz_set_si(unit, 1); }
-    const mpz_t& getUnit() const { return unit; }
-};
-
 enum class State: unsigned char {
     /*
      * bit 0 - wheter word part is valid or not
@@ -92,8 +83,9 @@ class FastRational
     mpq_ptr mpq{nullptr};
 
     inline static mpqPool pool;
+    inline static thread_local mpz_class temp;
+    inline static mpz_ptr mpz() { return temp.get_mpz_t(); }
 
-    static const MpzUnit unit;
 
     // Bit masks for questioning state:
     static const unsigned char wordValidMask = 0x1;
@@ -300,9 +292,8 @@ public:
             else ++ret;
             return ret;
         } else {
-            mpz_class q;
-            mpz_cdiv_q(q.get_mpz_t(), mpq_numref(mpq), mpq_denref(mpq));
-            return FastRational(q.get_mpz_t());
+            mpz_cdiv_q(mpz(), mpq_numref(mpq), mpq_denref(mpq));
+            return FastRational(mpz());
         }
     }
     inline FastRational floor() const


### PR DESCRIPTION
Gets rid of C-style init of temporaries, by removing temporaries altogether.