### PR TITLE
[CircleCI] Do not install homebrew in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,6 @@ jobs:
             xcode: 12.4.0
         steps:
             - run:
-                name: Homebrew
-                command: |
-                  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            - run:
                 name: Packages
                 command: |
                   brew install cmake


### PR DESCRIPTION
CircleCI already provides a home-brew installation so there's no need for us to explicitly fetch it.

https://circleci.com/docs/2.0/testing-ios/#using-homebrew