### PR TITLE
Do not include headers of line editing library when disabled

### DIFF
--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -32,12 +32,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <csignal>
 #include <iostream>
 
+#ifdef ENABLE_LINE_EDITING
 #if !defined(USE_READLINE)
 #include <editline/readline.h>
 #else
 #include <readline/readline.h>
 #include <readline/history.h>
 #endif
+#endif // ENABLE_LINE_EDITING
 
 #if defined(__linux__)
 #include <fpu_control.h>


### PR DESCRIPTION
It looks like in #318 we forget to hide include of headers behind `ifdef`.
I got compilation error on the cluster.
It was most likely not detected because the headers could be found in the standard system paths, but that's not the case in the cluster.