### PR TITLE
Egraph: Avoid creating unnecessary enodes for boolean terms

### DIFF
--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -183,7 +183,7 @@ private:
     bool childDuplicatesClass(ERef parent, uint32_t childIndex);
 
     //***************************************************************************************************************
-    Map<PTRef, ERef, PTRefHash> boolTermToERef;
+    Map<PTRef, ERef, PTRefHash> negatedTermToERef;
 
     ELAllocator forbid_allocator;
 

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -329,9 +329,9 @@ void Egraph::declareTerm(PTRef tr) {
     }
 
     if (logic.hasSortBool(tr) and not logic.isDisequality(tr) and PTRefERefPairVec.size() == 2) {
-        for (auto [child_tr, child_er] : PTRefERefPairVec) {
-            boolTermToERef.insert(child_tr, child_er);
-        }
+        auto [negated_tr, negated_er] = PTRefERefPairVec[1];
+        assert(logic.isNot(negated_tr));
+        negatedTermToERef.insert(negated_tr, negated_er);
         assert(PTRefERefPairVec[0].tr == logic.mkNot(PTRefERefPairVec[1].tr));
         assertNEq(PTRefERefPairVec[0].er, PTRefERefPairVec[1].er, Expl(Expl::Type::pol, PtAsgn_Undef, PTRefERefPairVec[0].tr));
     }
@@ -410,7 +410,7 @@ bool Egraph::addTrue(PTRef term) {
     assert(logic.hasSortBool(term));
     assert(not logic.isNot(term));
     bool res = assertEq(term, logic.getTerm_true(), PtAsgn(term, l_True));
-    if (res and boolTermToERef.has(logic.mkNot(term))) {
+    if (res and negatedTermToERef.has(logic.mkNot(term))) {
         res = assertEq(logic.mkNot(term), logic.getTerm_false(), PtAsgn(term, l_True));
     }
 #ifdef STATISTICS
@@ -427,7 +427,7 @@ bool Egraph::addFalse(PTRef term) {
     assert(logic.hasSortBool(term));
     assert(not logic.isNot(term));
     bool res = assertEq(term, logic.getTerm_false(), PtAsgn(term, l_False));
-    if (res and boolTermToERef.has(logic.mkNot(term))) {
+    if (res and negatedTermToERef.has(logic.mkNot(term))) {
         res = assertEq(logic.mkNot(term), logic.getTerm_true(), PtAsgn(term, l_False));
     }
 #ifdef STATISTICS

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -328,8 +328,7 @@ void Egraph::declareTerm(PTRef tr) {
         updateUseVectors(term); (void)eref;
     }
 
-    if (logic.hasSortBool(tr) and not logic.isDisequality(tr)) {
-        assert(PTRefERefPairVec.size() == 2);
+    if (logic.hasSortBool(tr) and not logic.isDisequality(tr) and PTRefERefPairVec.size() == 2) {
         for (auto [child_tr, child_er] : PTRefERefPairVec) {
             boolTermToERef.insert(child_tr, child_er);
         }
@@ -408,6 +407,8 @@ bool Egraph::addDisequality(PtAsgn pa) {
 }
 
 bool Egraph::addTrue(PTRef term) {
+    assert(logic.hasSortBool(term));
+    assert(not logic.isNot(term));
     bool res = assertEq(term, logic.getTerm_true(), PtAsgn(term, l_True));
     if (res and boolTermToERef.has(logic.mkNot(term))) {
         res = assertEq(logic.mkNot(term), logic.getTerm_false(), PtAsgn(term, l_True));
@@ -423,6 +424,8 @@ bool Egraph::addTrue(PTRef term) {
 }
 
 bool Egraph::addFalse(PTRef term) {
+    assert(logic.hasSortBool(term));
+    assert(not logic.isNot(term));
     bool res = assertEq(term, logic.getTerm_false(), PtAsgn(term, l_False));
     if (res and boolTermToERef.has(logic.mkNot(term))) {
         res = assertEq(logic.mkNot(term), logic.getTerm_true(), PtAsgn(term, l_False));

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -142,8 +142,10 @@ vec<PTRefERefPair> EnodeStore::constructTerm(PTRef tr) {
         assert(logic.isBooleanOperator(tr) || logic.isBoolAtom(tr) || logic.isTrue(tr) || logic.isFalse(tr) || logic.isEquality(tr) || logic.isUP(tr) || logic.isDisequality(tr));
         assert(not logic.isNot(tr));
         PTRef tr_neg = logic.mkNot(tr);
-        ERef er_neg = addTerm(tr_neg);
-        new_enodes.push({tr_neg, er_neg});
+        if (needsEnode(tr_neg)) {
+            ERef er_neg = addTerm(tr_neg);
+            new_enodes.push({tr_neg, er_neg});
+        }
     }
 
     return new_enodes;


### PR DESCRIPTION
Enodes for negative boolean terms are needed only when these terms are
themselves arguments of other enodes. In most cases, we do not need to
create enodes for negative boolean terms.
Positive boolean terms still need enodes since these are used for theory
deductions.