### PR TITLE
[logic] Moved LALogic::isNegated to LAVarMapper::isNegated

### DIFF
--- a/src/logics/LALogic.cc
+++ b/src/logics/LALogic.cc
@@ -10,28 +10,6 @@
 
 #include <memory>
 
-bool LALogic::isNegated(PTRef tr) const {
-    //static const opensmt::Integer zero = 0;
-    if (isNumConst(tr))
-        return getNumConst(tr) < 0; // Case (0a) and (0b)
-    if (isNumVar(tr))
-        return false; // Case (1a)
-    if (isNumTimes(tr)) {
-        // Cases (2)
-        PTRef v;
-        PTRef c;
-        splitTermToVarAndConst(tr, v, c);
-        return isNegated(c);
-    }
-    if (isIte(tr)) {
-        return false;
-    }
-    else {
-        // Cases(3)
-        return isNegated(getPterm(tr)[0]);
-    }
-}
-
 bool LALogic::isLinearFactor(PTRef tr) const {
     if (isNumConst(tr) || isNumVarLike(tr)) { return true; }
     if (isNumTimes(tr)) {

--- a/src/logics/LALogic.h
+++ b/src/logics/LALogic.h
@@ -159,7 +159,6 @@ public:
     PTRef mkNumGt(const vec<PTRef> & args);
     PTRef mkNumGt(PTRef arg1, PTRef arg2) { return mkBinaryGt(arg1, arg2); }
 
-    bool isNegated(PTRef tr) const;
     bool isLinearTerm(PTRef tr) const;
     bool isLinearFactor(PTRef tr) const;
     void splitTermToVarAndConst(const PTRef &term, PTRef &var, PTRef &fac) const;

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -15,7 +15,7 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
     auto [const_tr, sum_tr] = logic.leqToConstantAndTerm(leq_tr);
     assert(logic.isNumConst(const_tr) && logic.isLinearTerm(sum_tr));
 
-    bool sum_term_is_negated = logic.isNegated(sum_tr);
+    bool sum_term_is_negated = laVarMapper.isNegated(sum_tr);
 
     LVRef v = laVarMapper.getVarByLeqId(logic.getPterm(leq_tr).getId());
     assert(v == laVarMapper.getVarByPTId(logic.getPterm(sum_tr).getId()));
@@ -210,7 +210,7 @@ opensmt::Number LASolver::getNum(PTRef r) {
 
 
 bool LASolver::hasVar(PTRef expr) {
-    expr =  logic.isNegated(expr) ? logic.mkNumNeg(expr) : expr;
+    expr =  laVarMapper.isNegated(expr) ? logic.mkNumNeg(expr) : expr;
     PTId id = logic.getPterm(expr).getId();
     return laVarMapper.hasVar(id);
 }
@@ -224,7 +224,7 @@ LVRef LASolver::getLAVar_single(PTRef expr_in) {
         return getVarForTerm(expr_in);
     }
 
-    PTRef expr = logic.isNegated(expr_in) ? logic.mkNumNeg(expr_in) : expr_in;
+    PTRef expr = laVarMapper.isNegated(expr_in) ? logic.mkNumNeg(expr_in) : expr_in;
     LVRef x = laVarStore.getNewVar();
     laVarMapper.registerNewMapping(x, expr);
     return x;
@@ -232,7 +232,7 @@ LVRef LASolver::getLAVar_single(PTRef expr_in) {
 
 std::unique_ptr<Polynomial> LASolver::expressionToLVarPoly(PTRef term) {
     auto poly = std::make_unique<Polynomial>();
-    bool negated = logic.isNegated(term);
+    bool negated = laVarMapper.isNegated(term);
     for (int i = 0; i < logic.getPterm(term).size(); i++) {
         PTRef v;
         PTRef c;
@@ -274,7 +274,7 @@ LVRef LASolver::exprToLVar(PTRef expr) {
         PTRef c;
 
         logic.splitTermToVarAndConst(expr, v, c);
-        assert(logic.isNumVarOrIte(v) || (logic.isNegated(v) && logic.isNumVarOrIte(logic.mkNumNeg(v))));
+        assert(logic.isNumVarOrIte(v) || (laVarMapper.isNegated(v) && logic.isNumVarOrIte(logic.mkNumNeg(v))));
         x = getLAVar_single(v);
         simplex.newNonbasicVar(x);
         notifyVar(x);

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -17,7 +17,7 @@
  */
 void LAVarMapper::registerNewMapping(LVRef lv, PTRef e_orig) {
     assert(!hasVar(e_orig));
-    assert(!logic.isNegated(e_orig));
+    assert(!isNegated(e_orig));
     if (lv.x >= static_cast<unsigned int>(laVarToPTRef.size())) {
         laVarToPTRef.growTo(lv.x+1, PTRef_Undef);
     }
@@ -56,6 +56,26 @@ bool LAVarMapper::hasVar(PTRef tr) const { return hasVar(logic.getPterm(tr).getI
 
 bool   LAVarMapper::hasVar(PTId i) const {
     return static_cast<unsigned int>(ptermToLavar.size()) > Idx(i) && ptermToLavar[Idx(i)] != LVRef_Undef;
+}
+
+bool LAVarMapper::isNegated(PTRef tr) const {
+    if (logic.isNumConst(tr))
+        return logic.getNumConst(tr) < 0; // Case (0a) and (0b)
+    if (logic.isNumVar(tr))
+        return false; // Case (1a)
+    if (logic.isNumTimes(tr)) {
+        // Cases (2)
+        PTRef v;
+        PTRef c;
+        logic.splitTermToVarAndConst(tr, v, c);
+        return isNegated(c);
+    }
+    if (logic.isIte(tr)) {
+        return false;
+    } else {
+        // Cases(3)
+        return isNegated(logic.getPterm(tr)[0]);
+    }
 }
 
 void LAVarMapper::clear() {

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -51,6 +51,7 @@ public:
 
     void   clear();
 
+    bool   isNegated(PTRef tr) const;
 };
 
 

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -136,7 +136,8 @@ TEST_F(LRALogicMkTermsTest, test_mkNumNeg)
     PTRef one = logic.getTerm_NumOne();
     PTRef minus = logic.mkNumNeg(one);
     ASSERT_TRUE(logic.isConstant(minus));
-    ASSERT_TRUE(logic.isNegated(minus));
+    ASSERT_TRUE(logic.isNumConst(minus));
+    ASSERT_LT(logic.getNumConst(minus), 0);
     ASSERT_EQ(logic.mkNumNeg(minus), one);
     ASSERT_EQ(logic.getNumConst(minus), -1);
 }


### PR DESCRIPTION
`isNegated` implementation seems to fit better in the theory solver.  This PR suggests it to be implemented in `LAVarMapper` that holds the mapping between `PTRef`s and `LAVar`s and uses `isNegated` in an `assert`.