### PR TITLE
Tiny cleanup in Egraph

### DIFF
--- a/src/tsolvers/egraph/Enode.h
+++ b/src/tsolvers/egraph/Enode.h
@@ -38,9 +38,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 struct ERef {
     uint32_t x;
     void operator= (uint32_t v) { x = v; }
-    inline friend bool operator<  (const ERef& a1, const ERef& a2) {return a1.x < a2.x;  }
-    inline friend bool operator== (const ERef& a1, const ERef& a2) {return a1.x == a2.x; }
-    inline friend bool operator!= (const ERef& a1, const ERef& a2) {return a1.x != a2.x; }
+    inline friend bool operator<  (ERef a1, ERef a2) {return a1.x < a2.x;  }
+    inline friend bool operator== (ERef a1, ERef a2) {return a1.x == a2.x; }
+    inline friend bool operator!= (ERef a1, ERef a2) {return a1.x != a2.x; }
 };
 static struct ERef ERef_Undef = {UINT32_MAX};
 

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -77,7 +77,9 @@ ERef EnodeStore::addTerm(PTRef term) {
     ERef newEnode = ea.alloc(symref, opensmt::span(args.begin(), args.size_()) , term);
     // Term's signature must not exist.  Otherwise the term would have two different signatures.
     assert(not containsSig(newEnode));
-    insertSig(newEnode);
+    if (args.size() > 0) { // MB: No need to insert signatures of terms who cannot be parents
+        insertSig(newEnode);
+    }
     termToERef.insert(term, newEnode);
     assert(not ERefToTerm.has(newEnode));
     ERefToTerm.insert(newEnode, term);

--- a/src/tsolvers/egraph/EnodeStore.h
+++ b/src/tsolvers/egraph/EnodeStore.h
@@ -58,6 +58,7 @@ class EnodeStore {
         SignatureEqual(EnodeAllocator const & ea) : ea{ea} {}
 
         bool operator()(ERef a, ERef b) const {
+            if (a == b) { return true; }
             Enode const & anode = ea[a];
             Enode const & bnode = ea[b];
             if (anode.getSize() != bnode.getSize() or anode.getSymbol() != bnode.getSymbol()) { return false; }


### PR DESCRIPTION
The small changes are: 
* Passing `ERef`s by value instead of by reference.
* Do not insert constant terms into signature map. Signatures are only important for detecting congruence and constants cannot become congruent since they have no children.
* Early detection of signature-based equality by true equality.

I got 1% speedup on QF_UF, which may be just noise, but I'd like to think it's more than that :)