### PR TITLE
LIA: Remove the extended signature flag

### DIFF
--- a/regression/divmod/div-incorrect.smt2
+++ b/regression/divmod/div-incorrect.smt2
@@ -1,3 +1,0 @@
-(set-logic QF_LIA)
-(declare-fun a () Int)
-(assert (< (div a 2) 0))

--- a/regression/divmod/div-incorrect.smt2.expected.out
+++ b/regression/divmod/div-incorrect.smt2.expected.out
@@ -1,2 +1,0 @@
-(error "Unknown symbol: div")
-

--- a/regression/divmod/div_1.smt2
+++ b/regression/divmod/div_1.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status sat)
 (declare-fun x () Int)
 (assert (= 0 (div x 2)))

--- a/regression/divmod/div_2.smt2
+++ b/regression/divmod/div_2.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status sat)
 (declare-fun x () Int)
 (declare-fun b () Bool)

--- a/regression/divmod/div_3.smt2
+++ b/regression/divmod/div_3.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status unsat)
 (declare-fun x () Int)
 (declare-fun b () Bool)

--- a/regression/divmod/mod-incorrect.smt2
+++ b/regression/divmod/mod-incorrect.smt2
@@ -1,3 +1,0 @@
-(set-logic QF_LIA)
-(declare-fun a () Int)
-(assert (= (mod a 2) 0))

--- a/regression/divmod/mod-incorrect.smt2.expected.out
+++ b/regression/divmod/mod-incorrect.smt2.expected.out
@@ -1,2 +1,0 @@
-(error "Unknown symbol: mod")
-

--- a/regression/divmod/mod_1.smt2
+++ b/regression/divmod/mod_1.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status sat)
 (declare-fun x () Int)
 (assert (= 0 (mod x 2)))

--- a/regression/divmod/mod_2.smt2
+++ b/regression/divmod/mod_2.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status sat)
 (declare-fun x () Int)
 (declare-fun b () Bool)

--- a/regression/divmod/mod_3.smt2
+++ b/regression/divmod/mod_3.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status unsat)
 (declare-fun x () Int)
 (declare-fun b () Bool)

--- a/regression/divmod/mod_4.smt2
+++ b/regression/divmod/mod_4.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_LIA)
-(set-option :use-extended-signature true)
 (set-info :status unsat)
 (declare-fun x () Int)
 (assert (not (= 0 (mod x 3))))

--- a/regression/divmod/nested-div.smt2
+++ b/regression/divmod/nested-div.smt2
@@ -1,6 +1,5 @@
 (set-logic QF_LIA)
 (set-info :status unsat)
-(set-option :use-extended-signature true)
 (declare-fun a () Int)
 (assert (>= a 0))
 (assert (< (div a 2) (div (div a 2) 2)))

--- a/regression/divmod/nested-mod.smt2
+++ b/regression/divmod/nested-mod.smt2
@@ -1,6 +1,5 @@
 (set-logic QF_LIA)
 (set-info :status unsat)
-(set-option :use-extended-signature true)
 (declare-fun a () Int)
 (assert (not (= (mod a 2) (mod (mod a 2) 2))))
 (check-sat)

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -401,7 +401,6 @@ PTRef Interpret::letNameResolve(const char* s, const LetRecords& letRecords) con
 
 
 PTRef Interpret::parseTerm(const ASTNode& term, LetRecords& letRecords) {
-    logic->enableExtendedSignature(config.useExtendedSignature());
     ASTType t = term.getType();
     if (t == TERM_T) {
         const char* name = (**(term.children->begin())).getValue();

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -656,12 +656,10 @@ PTRef ArithLogic::insertTerm(SymRef sym, vec<PTRef>&& terms)
         return mkGeq(terms);
     if (isGt(sym))
         return mkGt(terms);
-    if (extendedSignatureEnabled()) {
-        if (isMod(sym))
-            return mkMod(terms[0], terms[1]);
-        if (isIntDiv(sym))
-            return mkIntDiv(std::move(terms));
-    }
+    if (isMod(sym))
+        return mkMod(std::move(terms));
+    if (isIntDiv(sym))
+        return mkIntDiv(std::move(terms));
     return Logic::insertTerm(sym, std::move(terms));
 }
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -90,7 +90,6 @@ Logic::Logic(opensmt::Logic_t _logicType) :
     , sym_IMPLIES(declareFun_NoScoping(tk_implies, sort_BOOL, {sort_BOOL, sort_BOOL}))
     , sym_DISTINCT(declareFun_Commutative_NoScoping_Pairwise(tk_distinct, sort_BOOL, {sort_BOOL, sort_BOOL}))
     , sym_ITE(declareFun_NoScoping(tk_ite, sort_BOOL, {sort_BOOL, sort_BOOL, sort_BOOL}))
-    , use_extended_signature(false)
 {
     equalities.insert(sym_EQ, true);
     disequalities.insert(sym_DISTINCT, true);

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -64,8 +64,6 @@ class Logic {
     bool isKnownToUser(SymRef sr) const { return getSymName(sr)[0] != s_abstract_value_prefix[0]; }
     int distinctClassCount;
 
-    bool extendedSignatureEnabled() const { return use_extended_signature; }
-
     class DefinedFunctions {
         std::unordered_map<std::string,TemplateFunction> defined_functions;
         std::vector<std::string> defined_functions_names;
@@ -120,8 +118,6 @@ class Logic {
     void dumpFunction(std::ostream &, const TemplateFunction&);
 
   private:
-    bool use_extended_signature;
-
     enum class UFAppearanceStatus {
         unseen, removed, appears
     };
@@ -129,7 +125,6 @@ class Logic {
     void unsetAppearsInUF(PTRef tr);
 
   public:
-    void enableExtendedSignature(bool flag) { use_extended_signature = flag; }
     vec<PTRef> propFormulasAppearingInUF;
     std::size_t getNumberOfTerms() const { return term_store.getNumberOfTerms(); }
     static const char*  tk_val_uf_default;

--- a/src/options/SMTConfig.cc
+++ b/src/options/SMTConfig.cc
@@ -535,7 +535,6 @@ const char* SMTConfig::o_respect_logic_partitioning_hints = ":respect-logic-part
 const char* SMTConfig::o_sat_lookahead_split = ":lookahead-split";
 const char* SMTConfig::o_sat_pure_lookahead = ":pure-lookahead";
 const char* SMTConfig::o_lookahead_score_deep = ":lookahead-score-deep";
-const char* SMTConfig::o_extended_signature = ":use-extended-signature";
 
 char* SMTConfig::server_host=NULL;
 uint16_t SMTConfig::server_port = 0;

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -302,7 +302,6 @@ public:
   static const char* o_respect_logic_partitioning_hints;
   static const char* o_output_dir;
   static const char* o_ghost_vars;
-  static const char* o_extended_signature;
 
 private:
 
@@ -909,24 +908,6 @@ public:
 
     int getSimplifyInterpolant() const {
         return simplify_inter();
-    }
-
-    void set_use_extended_signature(bool val)
-    {
-        if (optionTable.has(o_extended_signature)) {
-            delete optionTable[o_extended_signature];
-            optionTable[o_extended_signature] = new SMTOption(val);
-        }
-        else
-            insertOption(o_extended_signature, new SMTOption(val));
-    }
-
-    bool useExtendedSignature() const {
-        if (optionTable.has(o_extended_signature)) {
-            return optionTable[o_extended_signature]->getValue().numval != 0;
-        } else {
-            return false;
-        }
     }
 
 private:


### PR DESCRIPTION
For now we temporarily enable div and mod by default in LIA logic.
The goal is to add minimal support for non-linear arithmetic and then
allow these operations in non-linear logic only.