### PR TITLE
Logic: Refactor functionality regarding interpreted/uninterpreted symbols

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1555,7 +1555,7 @@ bool         Logic::isBuiltinSort      (const SRef sr)   const { return sr == so
 bool         Logic::isBuiltinConstant  (const SymRef sr) const { return isConstant(sr) && (sr == sym_TRUE || sr == sym_FALSE); }
 bool         Logic::isBuiltinConstant  (const PTRef tr)  const { return isBuiltinConstant(getPterm(tr).symb()); }
 bool         Logic::isConstant         (PTRef tr)        const { return isConstant(getPterm(tr).symb()); }
-bool         Logic::yieldsSortUF       (PTRef tr)        const { return isUFSort(getSortRef(tr)); }
+bool         Logic::yieldsSortUninterpreted (PTRef tr)   const { return isUFSort(getSortRef(tr)); }
 bool         Logic::isUFSort           (const SRef sr)   const { return ufsorts.has(sr); }
 
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -91,7 +91,6 @@ class Logic {
     DefinedFunctions defined_functions;
 
     vec<bool>           constants;
-    vec<bool>           interpreted_functions;
 
 
     SStore              sort_store;
@@ -157,7 +156,8 @@ class Logic {
     const opensmt::Logic_t getLogic() const { return logicType; }
 
   protected:
-    SymRef      newSymb       (const char* name, vec<SRef> const & sort_args) { return sym_store.newSymb(name, sort_args); }
+    SymRef      newSymb       (const char* name, vec<SRef> const & sort_args, bool isInterpreted = false);
+
     PTRef       mkFun         (SymRef f, vec<PTRef>&& args);
     void        markConstant  (PTRef ptr);
     void        markConstant  (SymId sid);
@@ -324,9 +324,9 @@ public:
     bool         isBuiltinConstant  (const PTRef tr)  const;// { return isBuiltinConstant(getPterm(tr).symb()); }
     virtual bool isBuiltinFunction  (const SymRef sr) const;
     bool         isConstant         (const SymRef sr) const;
-    bool         isConstant         (PTRef tr)        const;// { return isConstant(getPterm(tr).symb()); }
-    bool         isUFTerm           (PTRef tr)        const;// { return isUFSort(getSortRef(tr)); }
-    bool         isUFSort           (const SRef sr)   const;// { return ufsorts.has(sr); }
+    bool         isConstant         (PTRef tr)        const;
+    bool         yieldsSortUF       (PTRef tr)        const;
+    bool         isUFSort           (const SRef sr)   const;
 
     bool         appearsInUF        (PTRef tr)        const;
     void         setAppearsInUF     (PTRef tr);
@@ -339,6 +339,7 @@ public:
     virtual bool isAtom            (PTRef tr)      const;
     bool        isBoolAtom         (PTRef tr)      const;// { return hasSortBool(tr) && isVar(tr); }
     // Check if term is an uninterpreted predicate.
+    bool        isInterpreted      (SymRef sr)     const { return sym_store.isInterpreted(sr); }
     virtual bool isUP              (PTRef)         const;
     virtual bool isUF              (PTRef)         const;
     virtual bool isUF              (SymRef)        const;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -173,7 +173,6 @@ class Logic {
     SRef        getUniqueArgSort(PTRef tr)            const { return getUniqueArgSort(getSymRef(tr)); }
 
     // Symbols
-    Symbol& getSym              (const SymRef s)        { return sym_store[s]; }
     const Symbol& getSym        (const SymRef s)        const { return sym_store[s]; }
     const Symbol& getSym        (const PTRef tr)        const { return getSym(getPterm(tr).symb()); }
     SymRef      getSymRef       (const PTRef tr)        const { return getPterm(tr).symb(); }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -324,7 +324,7 @@ public:
     virtual bool isBuiltinFunction  (const SymRef sr) const;
     bool         isConstant         (const SymRef sr) const;
     bool         isConstant         (PTRef tr)        const;
-    bool         yieldsSortUF       (PTRef tr)        const;
+    bool         yieldsSortUninterpreted (PTRef tr)   const;
     bool         isUFSort           (const SRef sr)   const;
 
     bool         appearsInUF        (PTRef tr)        const;

--- a/src/symbols/SymStore.cc
+++ b/src/symbols/SymStore.cc
@@ -38,7 +38,7 @@ SymStore::~SymStore() {
         free(idToName[i]);
 }
 
-SymRef SymStore::newSymb(const char * fname, vec<SRef> const & args) {
+SymRef SymStore::newSymb(const char * fname, vec<SRef> const & args, bool isInterpreted) {
     // Check if there already is a term called fname with same number of arguments of the same sort
     auto* symrefs = getRefOrNull(fname);
 
@@ -68,6 +68,7 @@ SymRef SymStore::newSymb(const char * fname, vec<SRef> const & args) {
     char* tmp_name = strdup(fname);
     idToName.push(tmp_name);            // Map the id to name, used in error reporting
     ta[tr].id = id;                     // Tell the term its id, used in error reporting, and checking whether two terms could be equal in future?
+    ta[tr].header.interpreted = isInterpreted ? 1 : 0;
     if (newsym) {
         vec<SymRef> trs;
         trs.push(tr);

--- a/src/symbols/SymStore.h
+++ b/src/symbols/SymStore.h
@@ -41,7 +41,7 @@ class SymStore {
     ~SymStore();
     // Construct a new symbol.  The first argument in args is the return
     // sort of the symbol
-    SymRef newSymb(const char * fname, vec<SRef> const & args);
+    SymRef newSymb(const char *fname, vec<SRef> const & args, bool isInterpreted = false);
     bool contains(const char* fname)            const { return symbolTable.has(fname); }
     const vec<SymRef>& nameToRef(const char* s) const { return symbolTable[s]; }
     vec<SymRef>& nameToRef(const char* s)             { return symbolTable[s]; }
@@ -55,7 +55,8 @@ class SymStore {
 
     const vec<SymRef>& getSymbols()             const { return symbols; }
 
-    void setInterpreted(SymRef sr)                    { ta[sr].header.interpreted = true; }
+    bool isInterpreted(SymRef sr)               const { return ta[sr].isInterpreted(); }
+
 #ifdef PEDANTIC_DEBUG
     void compare(SymStore&);
     void check() const;

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -96,7 +96,7 @@ ERef EnodeStore::addTerm(PTRef term) {
 bool EnodeStore::needsEnode(PTRef tr) const {
     if (logic.isTrue(tr) || logic.isFalse(tr)) {
         return true;
-    } else if (logic.isUFTerm(tr)) {
+    } else if (logic.yieldsSortUF(tr)) {
         return true;
     } else if (logic.isUFEquality(tr)) {
         return true;

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -96,7 +96,7 @@ ERef EnodeStore::addTerm(PTRef term) {
 bool EnodeStore::needsEnode(PTRef tr) const {
     if (logic.isTrue(tr) || logic.isFalse(tr)) {
         return true;
-    } else if (logic.yieldsSortUF(tr)) {
+    } else if (logic.yieldsSortUninterpreted(tr)) {
         return true;
     } else if (logic.isUFEquality(tr)) {
         return true;


### PR DESCRIPTION
Changes in this PR:
* Remove the information about interpreted symbols from `Logic`. This information is stored in `SymbolStore` and was duplicated in `Logic`.
* Pass the `interpreted` flag directly when requesting new symbol from `SymbolStore`, do not set it up afterwards.
* Clean up a few functions regarding inquiring whether something is interpreted or uninterpreted.