### PR TITLE
Indexed sorts

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -110,7 +110,7 @@ MainSolver::insertFormula(PTRef root, char** msg)
     if (logic.getSortRef(root) != logic.getSort_bool())
     {
         int chars_written = asprintf(msg, "Top-level assertion sort must be %s, got %s",
-                 Logic::s_sort_bool, logic.getSortName(logic.getSortRef(root)).c_str());
+                 Logic::s_sort_bool, logic.printSort(logic.getSortRef(root)).c_str());
         (void)chars_written;
         return s_Error;
     }

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -466,7 +466,7 @@ PTRef Interpret::parseTerm(const ASTNode& term, LetRecords& letRecords) {
                     const Symbol& t = logic->getSym(ctr);
                     comment_formatted(" candidate %d", j);
                     for (uint32_t k = 0; k < t.nargs(); k++) {
-                        comment_formatted("  arg %d: %s", k, logic->getSortName(t[k]).c_str());
+                        comment_formatted("  arg %d: %s", k, logic->printSort(t[k]).c_str());
                     }
                 }
             }
@@ -725,7 +725,7 @@ std::string Interpret::printDefinitionSmtlib(PTRef tr, PTRef val) {
     std::stringstream ss;
     const char *s = logic->protectName(logic->getSymName(tr));
     SRef sortRef = logic->getSym(tr).rsort();
-    ss << "  (define-fun " << s << " () " << logic->getSortName(sortRef) << '\n';
+    ss << "  (define-fun " << s << " () " << logic->printSort(sortRef) << '\n';
     char* val_string = logic->printTerm(val);
     ss << "    " << val_string << ")\n";
     free(val_string);
@@ -738,11 +738,11 @@ std::string Interpret::printDefinitionSmtlib(const TemplateFunction & templateFu
     const vec<PTRef>& args = templateFun.getArgs();
     for (int i = 0; i < args.size(); i++) {
         char* tmp = logic->pp(args[i]);
-        auto sortString = logic->getSortName(logic->getSortRef(args[i]));
+        auto sortString = logic->printSort(logic->getSortRef(args[i]));
         ss << "(" << tmp << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");
         free(tmp);
     }
-    ss << ")" << " " << logic->getSortName(templateFun.getRetSort()) << "\n";
+    ss << ")" << " " << logic->printSort(templateFun.getRetSort()) << "\n";
     char* tmp = logic->pp(templateFun.getBody());
     ss << "    " << tmp << ")\n";
     free(tmp);
@@ -881,7 +881,7 @@ bool Interpret::defineFun(const ASTNode& n)
         return false;
     }
     else if (logic->getSortRef(tr) != ret_sort) {
-        notify_formatted(true, "define-fun term and return sort do not match: %s and %s\n", logic->getSortName(logic->getSortRef(tr)).c_str(), logic->getSortName(ret_sort).c_str());
+        notify_formatted(true, "define-fun term and return sort do not match: %s and %s\n", logic->printSort(logic->getSortRef(tr)).c_str(), logic->printSort(ret_sort).c_str());
         return false;
     }
     bool rval = logic->defineFun(fname, arg_trs, ret_sort, tr);

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -122,7 +122,8 @@ public:
     PTRef            mkIntVar         (const char* name) { if (not hasIntegers()) { throw OsmtApiException("Create Int var in non-integral logic"); } return mkVar(sort_INT, name); }
     PTRef            mkRealVar        (const char* name) { if (not hasReals()) { throw OsmtApiException("Create Real var in non-real logic"); } return mkVar(sort_REAL, name); }
 
-    bool             isBuiltinSort    (SRef sr) const override { return sr == getSort_int() ||sr == getSort_real() || Logic::isBuiltinSort(sr); }
+    bool             isBuiltinSort    (SRef sr) const override { return sr == getSort_int() || sr == getSort_real() || Logic::isBuiltinSort(sr); }
+    bool             isBuiltinSortSym (SSymRef ssr) const override { return ssr == sort_store.getSortSym(getSort_int()) || ssr == sort_store.getSortSym(getSort_real()) || Logic::isBuiltinSortSym(ssr); }
     bool             isBuiltinConstant(SymRef sr) const override { return (isIntConst(sr) || isRealConst(sr) || Logic::isBuiltinConstant(sr)); }
 
     bool isNumConst (SymRef sr) const { return Logic::isConstant(sr) && yieldsSortNum(sr); }

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -107,7 +107,7 @@ class BVLogic: public CUFLogic
     virtual PTRef         mkBVNumVar  (const char* name) { return mkVar(sort_BVNUM, name); }
     virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_BVNUM)) || Logic::isBuiltinSortSym(ssr); }
     virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_BVNUM) /*|| (sr == sort_BVSTR)*/ || Logic::isBuiltinSort(sr); }
-    virtual bool          isBuiltinConstant(SymRef sr) const override { return isBVNUMConst(sr) || Logic::isBuiltinConstant(sr); }
+    virtual bool          isBuiltinConstant(SymRef sr) const override { return isBVNUMConst(sr) || CUFLogic::isBuiltinConstant(sr); }
 
 //    virtual void conjoinExtras(PTRef root, PTRef& root_out) { root_out = root; }
 

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -105,6 +105,7 @@ class BVLogic: public CUFLogic
     PTRef         mkBVConst   (const int c) { char* num; opensmt::wordToBinary(c, num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the int c to binary
     PTRef         mkBVConst   (const char* c) { char* num; opensmt::wordToBinary(opensmt::Integer(c), num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the string c to binary
     virtual PTRef         mkBVNumVar  (const char* name) { return mkVar(sort_BVNUM, name); }
+    virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_BVNUM)) || Logic::isBuiltinSortSym(ssr); }
     virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_BVNUM) /*|| (sr == sort_BVSTR)*/ || Logic::isBuiltinSort(sr); }
     virtual bool          isBuiltinConstant(SymRef sr) const override { return isBVNUMConst(sr) || Logic::isBuiltinConstant(sr); }
 

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -105,8 +105,8 @@ class BVLogic: public CUFLogic
     PTRef         mkBVConst   (const int c) { char* num; opensmt::wordToBinary(c, num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the int c to binary
     PTRef         mkBVConst   (const char* c) { char* num; opensmt::wordToBinary(opensmt::Integer(c), num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the string c to binary
     virtual PTRef         mkBVNumVar  (const char* name) { return mkVar(sort_BVNUM, name); }
-    virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_BVNUM)) || Logic::isBuiltinSortSym(ssr); }
-    virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_BVNUM) /*|| (sr == sort_BVSTR)*/ || Logic::isBuiltinSort(sr); }
+    virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_BVNUM)) || CUFLogic::isBuiltinSortSym(ssr); }
+    virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_BVNUM) /*|| (sr == sort_BVSTR)*/ || CUFLogic::isBuiltinSort(sr); }
     virtual bool          isBuiltinConstant(SymRef sr) const override { return isBVNUMConst(sr) || CUFLogic::isBuiltinConstant(sr); }
 
 //    virtual void conjoinExtras(PTRef root, PTRef& root_out) { root_out = root; }

--- a/src/logics/CUFLogic.h
+++ b/src/logics/CUFLogic.h
@@ -115,6 +115,7 @@ class CUFLogic: public Logic
     PTRef                 mkCUFConst   (const int c) { std::string num = std::to_string(c); PTRef tr = Logic::mkConst(sort_CUFNUM, num.c_str()); return tr; }
     virtual PTRef         mkCUFNumVar(const char* name) { return mkVar(sort_CUFNUM, name); }
     virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_CUFNUM) || Logic::isBuiltinSort(sr); }
+    virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_CUFNUM)) || Logic::isBuiltinSortSym(ssr); }
     virtual bool          isBuiltinConstant(SymRef sr) const override { return isCUFNUMConst(sr) || Logic::isBuiltinConstant(sr); }
 
     PTRef conjoinExtras(PTRef root) override;

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1310,9 +1310,9 @@ Logic::dumpHeaderToFile(ostream& dump_out) const
         Symbol const & symb = sym_store[s];
         dump_out << "(";
         for (SRef sr : symb) {
-            dump_out << sort_store.printSort(sr) << " ";
+            dump_out << printSort(sr) << " ";
         }
-        dump_out << ") " << sort_store.printSort(symb.rsort()) << ")" << endl;
+        dump_out << ") " << printSort(symb.rsort()) << ")" << endl;
     }
 }
 
@@ -1420,10 +1420,10 @@ Logic::dumpFunction(ostream& dump_out, const TemplateFunction& tpl_fun)
     const vec<PTRef>& args = tpl_fun.getArgs();
     for (PTRef arg : args) {
         char* arg_name = printTerm(arg);
-        dump_out << '(' << arg_name << ' ' <<  sort_store.printSort(getSortRef(arg)) << ") ";
+        dump_out << '(' << arg_name << ' ' <<  printSort(getSortRef(arg)) << ") ";
         free(arg_name);
     }
-    dump_out << ") " << sort_store.printSort(tpl_fun.getRetSort());
+    dump_out << ") " << printSort(tpl_fun.getRetSort());
     dumpFormulaToFile(dump_out, tpl_fun.getBody(), false, false);
     dump_out << ')' << endl;
 }
@@ -1615,7 +1615,7 @@ bool Logic::typeCheck(SymRef sym, vec<PTRef> const & args, std::string & why) co
 
         std::string argSorts;
         for (PTRef tr : args) {
-            argSorts += std::string(printSort(getSortRef(tr))) + " ";
+            argSorts += printSort(getSortRef(tr)) + " ";
         }
         return "Symbol " + symStr + " instantiated with arguments of sort " + argSorts;
     };

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1502,7 +1502,6 @@ SRef        Logic::getSortRef    (const PTRef tr)        const { return getSortR
 SRef        Logic::getSortRef    (const SymRef sr)       const { return getSym(sr).rsort(); }
 
 std::string Logic::printSort(SRef s) const { return sort_store.printSort(s); }
-size_t Logic::getSortSize(SRef s)    const { return sort_store.getSize(s); }
 
 SRef Logic::getUniqueArgSort(SymRef sr) const {
     SRef res = SRef_Undef;

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1598,18 +1598,18 @@ bool Logic::typeCheck(SymRef sym, vec<PTRef> const & args, std::string & why) co
         Symbol const & symbol = sym_store[sym];
         if (symbol.chainable() or symbol.pairwise()) {
             for (int i = 0; i < args.size(); i++) {
-                symStr += " " + std::string(printSort(symbol[0]));
+                symStr += " " + printSort(symbol[0]);
             }
         } else if (symbol.left_assoc()) {
-            symStr += " " + std::string(printSort(symbol[0]));
+            symStr += " " + printSort(symbol[0]);
             for (int i = 1; i < args.size(); i++) {
-                symStr += " " + std::string(printSort(symbol[1]));
+                symStr += " " + printSort(symbol[1]);
             }
         } else if (symbol.right_assoc()) {
             for (int i = 0; i < args.size() - 1; i++) {
-                symStr += " " + std::string(printSort(symbol[0]));
+                symStr += " " + printSort(symbol[0]);
             }
-            symStr += " " + std::string(printSort(symbol[1]));
+            symStr += " " + printSort(symbol[1]);
         }
 
         std::string argSorts;

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1501,7 +1501,7 @@ PTRef Logic::conjoinExtras(PTRef root) { return root; }
 SRef        Logic::getSortRef    (const PTRef tr)        const { return getSortRef(getPterm(tr).symb()); }
 SRef        Logic::getSortRef    (const SymRef sr)       const { return getSym(sr).rsort(); }
 
-std::string const & Logic::getSortName(const SRef s) const { return sort_store.getName(s); }
+std::string Logic::getSortName(const SRef s) const { return sort_store.getName(s); }
 size_t Logic::getSortSize(const SRef s) const { return sort_store.getSize(s); }
 
 SRef Logic::getUniqueArgSort(SymRef sr) const {

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -61,6 +61,7 @@ const char* Logic::tk_or       = "or";
 const char* Logic::tk_xor      = "xor";
 const char* Logic::tk_distinct = "distinct";
 const char* Logic::tk_ite      = "ite";
+const char* Logic::tk_indexed  = "_";
 
 const char* Logic::s_sort_bool = "Bool";
 const char* Logic::s_ite_prefix = ".oite";
@@ -75,6 +76,7 @@ Logic::Logic(opensmt::Logic_t _logicType) :
     , distinctClassCount(0)
     , sort_store()
     , term_store(sym_store)
+    , sym_IndexedSort(sort_store.newSortSymbol(SortSymbol(tk_indexed, 2, SortSymbol::INTERNAL)))
     , sort_BOOL(sort_store.getOrCreateSort(sort_store.newSortSymbol(SortSymbol(s_sort_bool, 0, SortSymbol::INTERNAL)), {}).first)
     , term_TRUE(mkConst(getSort_bool(), tk_true))
     , term_FALSE(mkConst(getSort_bool(), tk_false))

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -97,6 +97,8 @@ class Logic {
     SymStore            sym_store;
     PtStore             term_store;
 
+    SSymRef             sym_IndexedSort;
+
     SRef                sort_BOOL;
     PTRef               term_TRUE;
     PTRef               term_FALSE;
@@ -140,6 +142,7 @@ class Logic {
     static const char*  tk_xor;
     static const char*  tk_distinct;
     static const char*  tk_ite;
+    static const char*  tk_indexed;
 
 
     static const char*  s_sort_bool;
@@ -278,6 +281,7 @@ public:
     PTRef instantiateFunctionTemplate(TemplateFunction const & tmplt, vec<PTRef> const & args);
     PTRef instantiateFunctionTemplate(const char * name, vec<PTRef> const & args);
 
+    SSymRef       getSortSymIndexed()              const { return sym_IndexedSort; }
 
     // The Boolean connectives
     SymRef        getSym_true      ()              const;// { return sym_TRUE;     }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -166,7 +166,7 @@ class Logic {
   public:
     SRef                getSortRef (PTRef tr)  const;
     SRef                getSortRef (SymRef sr) const;
-    std::string         getSortName(SRef s)    const;
+    std::string         printSort  (SRef s)    const;
     std::size_t         getSortSize(SRef s)    const;
     SRef declareUninterpretedSort(std::string const &);
 
@@ -322,6 +322,7 @@ public:
     bool         isBooleanOperator  (SymRef tr)       const;
     bool         isBooleanOperator  (PTRef tr)        const;// { return isBooleanOperator(term_store[tr].symb()); }
     virtual bool isBuiltinSort      (const SRef sr)   const;// { return sr == sort_BOOL; }
+    virtual bool isBuiltinSortSym   (const SSymRef ssr) const;
     virtual bool isBuiltinConstant  (const SymRef sr) const;// { return isConstant(sr) && (sr == sym_TRUE || sr == sym_FALSE); }
     bool         isBuiltinConstant  (const PTRef tr)  const;// { return isBuiltinConstant(getPterm(tr).symb()); }
     virtual bool isBuiltinFunction  (const SymRef sr) const;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -166,7 +166,7 @@ class Logic {
   public:
     SRef                getSortRef (PTRef tr)  const;
     SRef                getSortRef (SymRef sr) const;
-    std::string const & getSortName(SRef s)    const;
+    std::string         getSortName(SRef s)    const;
     std::size_t         getSortSize(SRef s)    const;
     SRef declareUninterpretedSort(std::string const &);
 

--- a/src/sorts/SStore.cc
+++ b/src/sorts/SStore.cc
@@ -43,6 +43,7 @@ SSymRef SStore::newSortSymbol(SortSymbol symbol) {
     assert(not peek(symbol, res));
     res = ssa.alloc(symbol);
     sortSymbolTable.insert({std::move(symbol.name), res});
+    sortSymbols.push(res);
     return res;
 }
 
@@ -59,13 +60,4 @@ opensmt::pair<SRef,bool> SStore::getOrCreateSort(SSymRef symbolRef, vec<SRef> &&
     auto emplaceRes = sortTable.emplace(std::move(key), sr);
     assert(emplaceRes.second); (void)emplaceRes;
     return {sr, true};
-}
-
-void
-SStore::dumpSortsToFile ( std::ostream & dump_out )
-{
-    for(int i = 1; i < sorts.size(); ++i)
-	{
-		dump_out << "(declare-sort " << getName(sorts[i]) << " " << getSize(sorts[i]) << std::endl;
-	}
 }

--- a/src/sorts/SStore.h
+++ b/src/sorts/SStore.h
@@ -54,6 +54,7 @@ class SStore
     std::unordered_map<SortKey, SRef, SortHash> sortTable;
     std::unordered_map<std::string, SSymRef> sortSymbolTable;
     vec<SRef> sorts;
+    vec<SSymRef> sortSymbols;
   public:
 
     SStore() = default;
@@ -69,12 +70,16 @@ class SStore
     SortSymbol const & operator [](SSymRef sr)      const { return ssa[sr]; }
 
     opensmt::pair<SRef,bool> getOrCreateSort(SSymRef symbolRef, vec<SRef> && rest);
-    std::string getName (SRef sr) const {
-        std::string name = ssa[sa[sr].getSymRef()].name;
+    SSymRef getSortSym(SRef sr) const { return sa[sr].getSymRef(); }
+    std::string getSortSymName(SSymRef ssr) const { return ssa[ssr].name; }
+    std::string getSortSymName(SRef sr) const { return getSortSymName(getSortSym(sr)); }
+    unsigned int getSortSymSize(SSymRef ssr) const { return ssa[ssr].arity; }
+    std::string printSort (SRef sr) const {
+        std::string name = getSortSymName(sr);
         if (sa[sr].getSize() > 0) {
             name = "(" + name + " ";
             for (unsigned i = 0; i < sa[sr].getSize(); i++) {
-                name += getName(sa[sr][i]) + (i == sa[sr].getSize() - 1 ? "" : " ");
+                name += printSort(sa[sr][i]) + (i == sa[sr].getSize() - 1 ? "" : " ");
             }
             name += ")";
         }
@@ -83,8 +88,8 @@ class SStore
 
     int  getSize(SRef sr) const { return sa[sr].getSize(); }
     const vec<SRef>& getSorts() const { return sorts; }
+    const vec<SSymRef>& getSortSyms() const { return sortSymbols; }
     int     numSorts() const { return sorts.size(); }
-    void dumpSortsToFile(std::ostream&);
 };
 
 #endif

--- a/src/sorts/SStore.h
+++ b/src/sorts/SStore.h
@@ -69,7 +69,18 @@ class SStore
     SortSymbol const & operator [](SSymRef sr)      const { return ssa[sr]; }
 
     opensmt::pair<SRef,bool> getOrCreateSort(SSymRef symbolRef, vec<SRef> && rest);
-    std::string const & getName (SRef sr) const { return ssa[sa[sr].getSymRef()].name; }
+    std::string getName (SRef sr) const {
+        std::string name = ssa[sa[sr].getSymRef()].name;
+        if (sa[sr].getSize() > 0) {
+            name = "(" + name + " ";
+            for (unsigned i = 0; i < sa[sr].getSize(); i++) {
+                name += getName(sa[sr][i]) + (i == sa[sr].getSize() - 1 ? "" : " ");
+            }
+            name += ")";
+        }
+        return name;
+    }
+
     int  getSize(SRef sr) const { return sa[sr].getSize(); }
     const vec<SRef>& getSorts() const { return sorts; }
     int     numSorts() const { return sorts.size(); }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -211,3 +211,11 @@ target_sources(ArithLogicApiTest
 
 target_link_libraries(ArithLogicApiTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET ArithLogicApiTest)
+
+add_executable(SortsTest)
+target_sources(SortsTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Sorts.cc"
+        )
+
+target_link_libraries(SortsTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET SortsTest)

--- a/test/unit/test_Sorts.cc
+++ b/test/unit/test_Sorts.cc
@@ -21,7 +21,7 @@ TEST_F(SortTest, test_indexedSort) {
     SRef barSort = logic.getSort(logic.declareSortSymbol({"Bar", 0}), {});
     SRef indexedSort = logic.getSort(logic.getSortSymIndexed(), {fooSort, barSort});
     ASSERT_NE(indexedSort, SRef_Undef);
-    std::cout << logic.getSortName(indexedSort) << std::endl;
+    std::cout << logic.printSort(indexedSort) << std::endl;
 
     PTRef foo = logic.mkConst(fooSort, "foo");
     PTRef bar = logic.mkConst(barSort, "bar");
@@ -30,13 +30,13 @@ TEST_F(SortTest, test_indexedSort) {
 
     SRef indexedSort2 = logic.getSort(logic.getSortSymIndexed(), {barSort, fooSort});
     ASSERT_NE(indexedSort2, indexedSort);
-    std::cout << logic.getSortName(indexedSort2) << std::endl;
+    std::cout << logic.printSort(indexedSort2) << std::endl;
 
     SRef quuxSort = logic.getSort(logic.declareSortSymbol({"Quux", 0}), {});
     SRef frobbozSort = logic.getSort(logic.declareSortSymbol({"Frobboz", 0}), {});
     SRef indexedSort3 = logic.getSort(logic.getSortSymIndexed(), {quuxSort, frobbozSort});
     ASSERT_NE(indexedSort, indexedSort3);
-    std::cout << logic.getSortName(indexedSort3) << std::endl;
+    std::cout << logic.printSort(indexedSort3) << std::endl;
 }
 
 TEST_F(SortTest, test_parametricSort) {
@@ -66,10 +66,10 @@ TEST_F(SortTest, test_parametricSort) {
     rval = logic.peekSortSymbol(symbolU2, symbolRefU);
     ASSERT_TRUE(rval);
     SRef sortU_V = logic.getSort(symbolRefU, {sortV});
-    std::cout << logic.getSortName(sortU_V) << std::endl;
+    std::cout << logic.printSort(sortU_V) << std::endl;
     SRef sortU_W = logic.getSort(symbolRefU, {sortW});
-    std::cout << logic.getSortName(sortU_V) << std::endl;
-    std::cout << logic.getSortName(sortU_W) << std::endl;
+    std::cout << logic.printSort(sortU_V) << std::endl;
+    std::cout << logic.printSort(sortU_W) << std::endl;
 
     ASSERT_NE(sortU_V, SRef_Undef);
     ASSERT_NE(sortU_W, SRef_Undef);

--- a/test/unit/test_Sorts.cc
+++ b/test/unit/test_Sorts.cc
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2021, Antti Hyvarinen <antti.hyvarinen@gmail.com>
- * Copyright (c) 2021, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */

--- a/test/unit/test_Sorts.cc
+++ b/test/unit/test_Sorts.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2021, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+
+#include <gtest/gtest.h>
+#include <Logic.h>
+#include <SSort.h>
+
+class SortTest : public ::testing::Test {
+protected:
+    SortTest(): logic{opensmt::Logic_t::QF_UF} {}
+    Logic logic;
+};
+
+TEST_F(SortTest, test_indexedSort) {
+    SRef fooSort = logic.getSort(logic.declareSortSymbol({"Foo", 0}), {});
+    SRef barSort = logic.getSort(logic.declareSortSymbol({"Bar", 0}), {});
+    SRef indexedSort = logic.getSort(logic.getSortSymIndexed(), {fooSort, barSort});
+    ASSERT_NE(indexedSort, SRef_Undef);
+    std::cout << logic.getSortName(indexedSort) << std::endl;
+
+    PTRef foo = logic.mkConst(fooSort, "foo");
+    PTRef bar = logic.mkConst(barSort, "bar");
+    std::cout << logic.pp(foo) << std::endl;
+    std::cout << logic.pp(bar) << std::endl;
+
+    SRef indexedSort2 = logic.getSort(logic.getSortSymIndexed(), {barSort, fooSort});
+    ASSERT_NE(indexedSort2, indexedSort);
+    std::cout << logic.getSortName(indexedSort2) << std::endl;
+
+    SRef quuxSort = logic.getSort(logic.declareSortSymbol({"Quux", 0}), {});
+    SRef frobbozSort = logic.getSort(logic.declareSortSymbol({"Frobboz", 0}), {});
+    SRef indexedSort3 = logic.getSort(logic.getSortSymIndexed(), {quuxSort, frobbozSort});
+    ASSERT_NE(indexedSort, indexedSort3);
+    std::cout << logic.getSortName(indexedSort3) << std::endl;
+}
+
+TEST_F(SortTest, test_parametricSort) {
+    SortSymbol symbolU("U", 1);
+    logic.declareSortSymbol(std::move(symbolU));
+    SortSymbol symbolV("V", 0);
+    logic.declareSortSymbol(std::move(symbolV));
+    SortSymbol symbolW("W", 0);
+    logic.declareSortSymbol(std::move(symbolW));
+
+    SortSymbol symbolV2("V", 0);
+    SSymRef symbolRefV;
+    bool rval = logic.peekSortSymbol(symbolV2, symbolRefV);
+    ASSERT_TRUE(rval);
+    SRef sortV = logic.getSort(symbolRefV, {});
+    ASSERT_NE(sortV, SRef_Undef);
+
+    SortSymbol symbolW2("W", 0);
+    SSymRef symbolRefW;
+    rval = logic.peekSortSymbol(symbolW2, symbolRefW);
+    ASSERT_TRUE(rval);
+    SRef sortW = logic.getSort(symbolRefW, {});
+    ASSERT_NE(sortW, SRef_Undef);
+
+    SortSymbol symbolU2("U", 1);
+    SSymRef symbolRefU;
+    rval = logic.peekSortSymbol(symbolU2, symbolRefU);
+    ASSERT_TRUE(rval);
+    SRef sortU_V = logic.getSort(symbolRefU, {sortV});
+    std::cout << logic.getSortName(sortU_V) << std::endl;
+    SRef sortU_W = logic.getSort(symbolRefU, {sortW});
+    std::cout << logic.getSortName(sortU_V) << std::endl;
+    std::cout << logic.getSortName(sortU_W) << std::endl;
+
+    ASSERT_NE(sortU_V, SRef_Undef);
+    ASSERT_NE(sortU_W, SRef_Undef);
+
+    logic.declareFun("a", sortU_V, {});
+    logic.declareFun("b", sortU_W, {});
+
+}


### PR DESCRIPTION
This PR makes the building blocks for indexed sorts (e.g. `(_ BitVec 32)`) available through `Logic` API.  In addition it implements the printing of sorts such parametric sorts.