### PR TITLE
Egraph: Do not backtrack on destruction

### DIFF
--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -225,7 +225,6 @@ public:
     Egraph(SMTConfig & c, Logic & l);
 
     virtual ~Egraph() {
-        backtrackToStackSize(0);
 #ifdef STATISTICS
         tsolver_stats.printStatistics(std::cerr);
 #endif // STATISTICS


### PR DESCRIPTION
I don't see any reason now why the `Egraph` should be backtracking in destructor.
QF_UF SMT-LIB benchmarks are fine with this change.