### PR TITLE
TSolver: Cleanup of reason computation and statistics 

### DIFF
--- a/src/tsolvers/TSolver.cc
+++ b/src/tsolvers/TSolver.cc
@@ -1,5 +1,6 @@
 #include "TSolver.h"
 #include "Logic.h"
+#include "OsmtInternalException.h"
 
 void TSolver::clearSolver()
 {
@@ -81,4 +82,19 @@ PtAsgn_reason TSolver::getDeduction() {
         return PtAsgn_reason_Undef;
     }
     return th_deductions[deductions_next++];
+}
+
+vec<PtAsgn> TSolver::getReasonFor(PtAsgn lit) {
+    pushBacktrackPoint();
+    // assert with negated polarity
+    assert(lit.sgn != l_Undef);
+    bool sat = assertLit(PtAsgn(lit.tr, lit.sgn == l_True ? l_False : l_True));
+    if (sat) {
+        assert(false);
+        throw OsmtInternalException("Error in computing reason for theory-propagated literal");
+    }
+    vec<PtAsgn> conflict;
+    getConflict(conflict);
+    popBacktrackPoint();
+    return conflict;
 }

--- a/src/tsolvers/TSolver.cc
+++ b/src/tsolvers/TSolver.cc
@@ -96,5 +96,20 @@ vec<PtAsgn> TSolver::getReasonFor(PtAsgn lit) {
     vec<PtAsgn> conflict;
     getConflict(conflict);
     popBacktrackPoint();
+#ifdef STATISTICS
+    if (conflict.size() > generalTSolverStats.max_reas_size)
+        generalTSolverStats.max_reas_size = conflict.size();
+    if (conflict.size() < generalTSolverStats.min_reas_size)
+        generalTSolverStats.min_reas_size = conflict.size();
+    generalTSolverStats.reasons_sent ++;
+    generalTSolverStats.avg_reas_size += conflict.size();
+#endif // STATISTICS
     return conflict;
+}
+
+void TSolver::printStatistics(std::ostream & os) {
+    os << "; -------------------------\n";
+    os << "; STATISTICS FOR " << getName() << '\n';
+    os << "; -------------------------\n";
+    generalTSolverStats.printStatistics(os);
 }

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -187,7 +187,8 @@ public:
     inline string               getName             ( ) { return name; }         // The name of the solver
     virtual void fillTheoryFunctions(ModelBuilder &) const { throw std::logic_error{"Model computation not supported for the used theory yet!"}; }
     virtual void computeModel() = 0;                      // Compute model for variables
-    virtual void getConflict(bool, vec<PtAsgn>&) = 0;     // Return conflict
+    virtual void getConflict(vec<PtAsgn> &) = 0;          // Return conflict
+    virtual vec<PtAsgn> getReasonFor(PtAsgn lit);
     virtual bool hasNewSplits();                          // Are there new splits?
     virtual void getNewSplits(vec<PTRef>&);               // Return new splits if any
     virtual PtAsgn_reason getDeduction();                 // Return an implied literal based on the current state

--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -59,15 +59,10 @@ class TSolverStats
     , avg_reas_size     ( 0 )
     , max_reas_size     ( 0 )
     , min_reas_size     ( 32767 )
-    , sod_done          ( 0 )
-    , sod_sent          ( 0 )
-    , avg_sod_size      ( 0 )
-    , max_sod_size      ( 0 )
-    , min_sod_size      ( 32767 )
     {}
 
     // Statistics for theory solvers
-    virtual void printStatistics ( ostream & os )
+    void printStatistics ( ostream & os )
     {
         os << "; Satisfiable calls........: " << sat_calls << endl;
         os << "; Unsatisfiable calls......: " << unsat_calls << endl;
@@ -92,14 +87,6 @@ class TSolverStats
                 os << "; Max reason size..........: " << max_reas_size << endl;
                 os << "; Min reason size..........: " << min_reas_size << endl;
             }
-            os << "; SOD done.................: " << sod_done << endl;
-            os << "; SOD sent.................: " << sod_sent << endl;
-            if ( sod_sent > 0 )
-            {
-                os << "; Average reason size......: " << avg_reas_size / (float)sod_sent << endl;
-                os << "; Max reason size..........: " << max_reas_size << endl;
-                os << "; Min reason size..........: " << min_reas_size << endl;
-            }
         }
     }
 
@@ -116,12 +103,6 @@ class TSolverStats
     float avg_reas_size;
     int   max_reas_size;
     int   min_reas_size;
-    // Deductions statistics
-    int   sod_done;
-    int   sod_sent;
-    float avg_sod_size;
-    int   max_sod_size;
-    int   min_sod_size;
 };
 
 
@@ -146,6 +127,8 @@ protected:
     vec<size_t>                 deductions_lim;  // Keeps track of deductions done up to a certain point
     vec<size_t>                 deductions_last; // Keeps track of deductions done up to a certain point
     vec<PTRef>                  suggestions;     // List of suggestions for decisions
+
+    TSolverStats                generalTSolverStats;
 
     // Methods for querying and modifying infromation about known polarities
     void  setPolarity(PTRef tr, lbool p);
@@ -173,7 +156,7 @@ public:
     , config  (c)
     {}
 
-    virtual ~TSolver ( ) {}
+    virtual ~TSolver () = default;
 
     // Called after every check-sat.
     virtual void clearSolver();
@@ -201,6 +184,8 @@ public:
     virtual bool isValid(PTRef tr) = 0;
     bool         isKnown(PTRef tr);
     void         setKnown(PTRef tr);
+
+    virtual void printStatistics(std::ostream & os);
 
 protected:
     bool                        isInformed(PTRef tr) const { return informed_PTRefs.has(tr); }

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -225,7 +225,6 @@ public:
     Egraph(SMTConfig & c, Logic & l);
 
     virtual ~Egraph() {
-        backtrackToStackSize(0);
 #ifdef STATISTICS
         tsolver_stats.printStatistics(std::cerr);
 #endif // STATISTICS

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -45,7 +45,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <unordered_set>
 
-class UFSolverStats: public TSolverStats
+class UFSolverStats
 {
     public:
         opensmt::OSMTTimeVal egraph_asrt_timer;
@@ -53,12 +53,8 @@ class UFSolverStats: public TSolverStats
         opensmt::OSMTTimeVal egraph_explain_timer;
         int num_eq_classes;
         UFSolverStats() : num_eq_classes(0) {}
-        void printStatistics(ostream& os)
+        void printStatistics(std::ostream & os)
         {
-            os << "; -------------------------" << endl;
-            os << "; STATISTICS FOR EUF SOLVER" << endl;
-            os << "; -------------------------" << endl;
-            TSolverStats::printStatistics(os);
             os << "; egraph time..............: " << egraph_asrt_timer.getTime() << " s\n";
             os << "; backtrack time...........: " << egraph_backtrack_timer.getTime() << " s\n";
             os << "; explain time.............: " << egraph_explain_timer.getTime() << " s\n";
@@ -196,7 +192,7 @@ private:
 
     double fa_garbage_frac;
 
-    UFSolverStats tsolver_stats;
+    UFSolverStats egraphStats;
 
     class Values {
         Map<ERef, ERef, ERefHash> values;
@@ -226,7 +222,7 @@ public:
 
     virtual ~Egraph() {
 #ifdef STATISTICS
-        tsolver_stats.printStatistics(std::cerr);
+        printStatistics(std::cerr);
 #endif // STATISTICS
     }
 
@@ -282,8 +278,8 @@ public:
     void       fillTheoryFunctions     (ModelBuilder & modelBuilder) const override;
     void       clearModel              ();
     PTRef      getAbstractValueForERef (ERef er, SRef sr) const;
-    void       splitOnDemand           (vec<PTRef> &, int) {};       // Splitting on demand modulo equality
 
+    void       printStatistics         (std::ostream &) override;
 
 #if MORE_DEDUCTIONS
   bool                deduceMore              ( vector< ERef > & );
@@ -407,10 +403,6 @@ private:
     void processParentsAfterMerge(ERef mergedRoot);
     void processParentsBeforeUnMerge(ERef oldroot);
     void processParentsAfterUnMerge(ERef oldroot);
-
-#ifdef STATISTICS
-    void printStatistics ( ofstream & );
-#endif
 };
 
 #endif

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -276,7 +276,7 @@ public:
     void       popBacktrackPoint       () override;                 // Backtrack to last saved point
     PTRef      getSuggestion           ();                          // Return a suggested literal based on the current state
     lbool      getPolaritySuggestion   (PTRef);                     // Return a suggested polarity for a given literal
-    void       getConflict             (bool, vec<PtAsgn>&) override;// Get explanation
+    void       getConflict             (vec<PtAsgn> &) override;
     TRes       check                   (bool) override { return TRes::SAT; }// Check satisfiability
     void       computeModel            () override;
     void       fillTheoryFunctions     (ModelBuilder & modelBuilder) const override;

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -172,11 +172,10 @@ lbool Egraph::getPolaritySuggestion(PTRef p)
 //
 // Communicate conflict
 //
-void Egraph::getConflict( bool deduction, vec<PtAsgn>& cnfl )
+void Egraph::getConflict(vec<PtAsgn> & conflict)
 {
-    (void)deduction;
-    for (PtAsgn pta : explanation) {
-        cnfl.push(pta);
+    for (PtAsgn lit : explanation) {
+        conflict.push(lit);
     }
 #ifdef STATISTICS
     if (deduction) {

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -111,7 +111,7 @@ void Egraph::pushBacktrackPoint( )
 // Pops a backtrack point
 //
 void Egraph::popBacktrackPoint() {
-//    opensmt::StopWatch sw(tsolver_stats.egraph_backtrack_timer);
+//    opensmt::StopWatch sw(egraphStats.egraph_backtrack_timer);
     assert( backtrack_points.size( ) > 0 );
     size_t undo_stack_new_size = backtrack_points.last();
     backtrack_points.pop();
@@ -178,22 +178,12 @@ void Egraph::getConflict(vec<PtAsgn> & conflict)
         conflict.push(lit);
     }
 #ifdef STATISTICS
-    if (deduction) {
-        if (cnfl.size() > tsolver_stats.max_reas_size)
-            tsolver_stats.max_reas_size = cnfl.size();
-        if (cnfl.size() < tsolver_stats.min_reas_size)
-            tsolver_stats.min_reas_size = cnfl.size();
-        tsolver_stats.reasons_sent ++;
-        tsolver_stats.avg_reas_size += cnfl.size();
-    }
-    else {
-        if (cnfl.size() > tsolver_stats.max_conf_size)
-            tsolver_stats.max_conf_size = cnfl.size();
-        if (cnfl.size() < tsolver_stats.min_conf_size)
-            tsolver_stats.min_conf_size = cnfl.size();
-        tsolver_stats.conflicts_sent ++;
-        tsolver_stats.avg_conf_size += cnfl.size();
-    }
+    if (conflict.size() > generalTSolverStats.max_conf_size)
+        generalTSolverStats.max_conf_size = conflict.size();
+    if (conflict.size() < generalTSolverStats.min_conf_size)
+        generalTSolverStats.min_conf_size = conflict.size();
+    generalTSolverStats.conflicts_sent ++;
+    generalTSolverStats.avg_conf_size += conflict.size();
 #endif
 }
 
@@ -365,7 +355,7 @@ bool Egraph::addEquality(PtAsgn pa) {
 
 #ifdef STATISTICS
     if (res == false)
-        tsolver_stats.unsat_calls++;
+        generalTSolverStats.unsat_calls++;
     // The sat_calls is increased already in addTrue
 #endif
 
@@ -398,7 +388,7 @@ bool Egraph::addDisequality(PtAsgn pa) {
     }
 #ifdef STATISTICS
     if (!res)
-        tsolver_stats.unsat_calls++;
+        generalTSolverStats.unsat_calls++;
     // The sat_calls is increased already in addFalse
 #endif
 
@@ -414,9 +404,9 @@ bool Egraph::addTrue(PTRef term) {
     }
 #ifdef STATISTICS
     if (res == false)
-        tsolver_stats.unsat_calls++;
+        generalTSolverStats.unsat_calls++;
     else {
-        tsolver_stats.sat_calls++;
+        generalTSolverStats.sat_calls++;
     }
 #endif
     return res;
@@ -431,9 +421,9 @@ bool Egraph::addFalse(PTRef term) {
     }
 #ifdef STATISTICS
     if (res == false)
-        tsolver_stats.unsat_calls++;
+        generalTSolverStats.unsat_calls++;
     else {
-        tsolver_stats.sat_calls++;
+        generalTSolverStats.sat_calls++;
     }
 #endif
     return res;
@@ -921,7 +911,7 @@ void Egraph::deduce( ERef x, ERef y, PtAsgn reason ) {
                     ERef ded_eq = enode_store.termToERef[eq];
                     enode_store[ded_eq].setDeduced(l_False);
                     deductions.push(PtAsgn_reason(eq, l_False, reason.tr));
-                    tsolver_stats.deductions_done ++;
+                    egraphStats.deductions_done ++;
                 }
             }
             if (elr == next_elr) break;
@@ -942,7 +932,7 @@ void Egraph::deduce( ERef x, ERef y, PtAsgn reason ) {
             assert(v_tr == enode_store.getPTRef(v));
             storeDeduction(PtAsgn_reason(v_tr, deduced_polarity, reason.tr));
 #ifdef STATISTICS
-            tsolver_stats.deductions_done ++;
+            generalTSolverStats.deductions_done ++;
 #endif
         }
         v = getEnode(v).getEqNext();
@@ -1172,7 +1162,7 @@ bool Egraph::assertLit(PtAsgn pta)
         // MB: The deductions done by this TSolver are also marked using polarity.
         //     The invariant is that TSolver will not process the literal again (when asserted from the SAT solver)
         //     once it is marked for deduction, so the implementation must count with that.
-        tsolver_stats.sat_calls ++;
+        generalTSolverStats.sat_calls ++;
         return true;
     }
 
@@ -1203,7 +1193,7 @@ bool Egraph::assertLit(PtAsgn pta)
         assert(false);
     }
 
-    !res ? tsolver_stats.unsat_calls ++ : tsolver_stats.sat_calls ++;
+    !res ? generalTSolverStats.unsat_calls ++ : generalTSolverStats.sat_calls ++;
     return res;
 }
 
@@ -1639,4 +1629,9 @@ void Egraph::removeFromUseVectorsExcept(ERef parent, CgId cgid) {
             }
         }
     }
+}
+
+void Egraph::printStatistics(std::ostream & os) {
+    TSolver::printStatistics(os);
+    egraphStats.printStatistics(os);
 }

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -720,25 +720,10 @@ void LASolver::print( ostream & )
 }
 
 
-void LASolver::getConflict(bool, vec<PtAsgn>& e) {
-    for (int i = 0; i < explanation.size(); i++) {
-        e.push(explanation[i]);
-
+void LASolver::getConflict(vec<PtAsgn> & conflict) {
+    for (PtAsgn lit : explanation) {
+        conflict.push(lit);
     }
-//    printf(" => explanation: \n");
-//    for (int i = 0; i < e.size(); i++) {
-//        PtAsgn asgn = e[i];
-//        LABoundRefPair p = boundStore.getBoundRefPair(asgn.tr);
-//        LABoundRef bound_ref = asgn.sgn == l_False ? p.neg : p.pos;
-//        printf("(%s) ", boundStore.printBound(bound_ref));
-//    }
-//    printf("\n");
-//    vec<PTRef> check_me;
-//    for (int i = 0; i < e.size(); i++) {
-//        check_me.push(e[i].sgn == l_False ? logic.mkNot(e[i].tr) : e[i].tr);
-//    }
-////    printf("In PTRef this is %s\n", logic.pp(logic.mkAnd(check_me)));
-//    assert(logic.implies(logic.mkAnd(check_me), logic.getTerm_false()));
 }
 
 // We may assume that the term is of the following forms

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -20,24 +20,16 @@ class LAVarStore;
 class Delta;
 class PartitionManager;
 
-class LASolverStats: public TSolverStats
+class LASolverStats
 {
     public:
         int num_vars;
         opensmt::OSMTTimeVal timer;
 
-        LASolverStats()
-        : TSolverStats()
-        , num_vars(0)
-        {}
+        LASolverStats() : num_vars(0) {}
 
-        void printStatistics(ostream& os) override
-        {
-            os << "; -------------------------" << endl;
-            os << "; STATISTICS FOR LA SOLVER" << endl;
-            os << "; -------------------------" << endl;
-            TSolverStats::printStatistics(os);
-            os << "; Number of LA vars........: " << num_vars << endl;
+        void printStatistics(ostream& os) {
+            os << "; Number of LA vars........: " << num_vars << '\n';
             os << "; LA time..................: " << timer.getTime() << " s\n";
         }
 };
@@ -81,8 +73,8 @@ private:
         INIT, INCREMENT, SAT, UNSAT, NEWSPLIT, UNKNOWN, ERROR
     } LASolverStatus;
 
-    //opensmt::Real delta; // The size of one delta.  Set through computeModel()
-    LASolverStats tsolver_stats;
+    LASolverStats laSolverStats;
+
     void setBound(PTRef leq);
     bool assertBoundOnVar(LVRef it, LABoundRef itBound_ref);
 
@@ -96,6 +88,8 @@ public:
     LASolver(SolverDescr dls, SMTConfig & c, ArithLogic & l);
 
     virtual ~LASolver( );                                      // Destructor ;-)
+
+    virtual void printStatistics(std::ostream &) override;
 
     virtual void clearSolver() override; // Remove all problem specific data from the solver.  Should be called each time the solver is being used after a push or a pop in the incremental interface.
 

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -113,7 +113,7 @@ public:
     PTRef getIntegerInterpolant(std::map<PTRef, icolor_t> const &);
 
     // Return the conflicting bounds
-    void        getConflict(bool, vec<PtAsgn>& e) override;
+    void getConflict(vec<PtAsgn> &) override;
 
     ArithLogic& getLogic() override;
     bool        isValid(PTRef tr) override;

--- a/src/tsolvers/stpsolver/STPSolver.h
+++ b/src/tsolvers/stpsolver/STPSolver.h
@@ -64,7 +64,7 @@ public:
 
     void computeModel() override;
 
-    void getConflict(bool b, vec<PtAsgn> &vec) override;
+    void getConflict(vec<PtAsgn> &) override;
 
     void declareAtom(PTRef tr) override;
 

--- a/src/tsolvers/stpsolver/STPSolver_implementations.hpp
+++ b/src/tsolvers/stpsolver/STPSolver_implementations.hpp
@@ -213,17 +213,15 @@ void STPSolver<T>::computeModel() {
 }
 
 template<class T>
-void STPSolver<T>::getConflict(bool b, vec<PtAsgn> &vec) {
-    // In case of unsatisfiability, return the witnessing subset of constraints
-    // The bool parameter can be ignored, the second parameter is the output parameter
+void STPSolver<T>::getConflict(vec<PtAsgn> & conflict) {
     if (inv_asgn == PtAsgn_Undef) return;
-    vec.push(inv_asgn);
+    conflict.push(inv_asgn);
     EdgeRef e = mapper.getEdgeRef(inv_asgn.tr);
     if (inv_asgn.sgn == l_True) {
         e = store.getNegation(e);
     }
     assert(graphMgr.isTrue(e));
-    graphMgr.findExplanation(e, vec);
+    graphMgr.findExplanation(e, conflict);
 }
 
 template<class T>

--- a/test/unit/test_Egraph.cpp
+++ b/test/unit/test_Egraph.cpp
@@ -88,7 +88,7 @@ TEST_F(EgraphTest, test_booleans) {
     ASSERT_FALSE(egraph.assertLit({eq, l_True}));
 
     vec<PtAsgn> expl;
-    egraph.getConflict(false, expl);
+    egraph.getConflict(expl);
 
     ASSERT_EQ(expl.size(), 3);
     for (auto pta : expl) {


### PR DESCRIPTION
This PR contains two parts:
1. Introduce a separate method `getReason` in `TSolver`. This cleans up the method in `THandler` a bit and allows us to remove the boolean parameter from `TSolver::getConflict` (which was mostly ignored anyway).
2. Related to the first part, the collection and printing of statistics is cleaned up a bit as well. There are more things that could be done, but I hope this is a good start.