### PR TITLE
TSolvers: Remove useless method

### DIFF
--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -178,7 +178,6 @@ public:
     // Called after every check-sat.
     virtual void clearSolver();
 
-    virtual void print(ostream& out) = 0;
     virtual bool                assertLit           (PtAsgn) = 0              ;  // Assert a theory literal
     virtual void                pushBacktrackPoint  ( )                       ;  // Push a backtrack point
     virtual void                popBacktrackPoint   ( )                       ;  // Backtrack to last saved point

--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -232,8 +232,6 @@ public:
 
     void clearSolver() override { clearModel(); } // Only clear the possible computed values
 
-    void print(ostream &) override { return; }
-
 protected:
     inline Enode & getEnode(ERef er) { return enode_store[er]; }
 

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -679,46 +679,6 @@ void LASolver::deduce(LABoundRef bound_prop) {
     }
 }
 
-//
-// Prints the current state of the solver (terms, bounds, tableau)
-//
-void LASolver::print( ostream & )
-{
-    throw "Not implemented yet!";
-    // print current non-basic variables
-//    out << "Var:" << endl;
-//    for ( unsigned i = 0; i < columns.size(); i++ )
-//        out << logic.pp(lva[columns[i]].getPTRef()) << "\t";
-//    out << endl;
-//
-//    // print the terms IDs
-//    out << "Tableau:" << endl;
-//    for ( unsigned i = 0; i < columns.size(); i++)
-//        out << lva[columns[i]].ID() << "\t";
-//    out << endl;
-//
-//    // print the Basic/Nonbasic status of terms
-//    for ( unsigned i = 0; i < columns.size(); i++)
-//        out << ( lva[columns[i]].isBasic() ? "B" : "N" ) << "\t";
-//    out << endl;
-//
-//    // print the tableau cells (zeros are skipped)
-//    // iterate over Tableau rows
-//    for ( unsigned i = 0; i < rows.size( ); i++ ) {
-//        auto const & row_poly = row_polynomials.at(rows[i]);
-//        for (unsigned j = 0; j < columns.size(); j++) {
-////            if (polyStore.has(lva[rows[i]].getPolyRef(), columns[j]))
-////                out << pta[polyStore.find(lva[rows[i]].getPolyRef(), columns[j])].coef;
-//            auto it = row_poly.find(columns[j]);
-//            if (it != row_poly.end()){
-//               out << it->second;
-//            }
-//            out << "\t";
-//        }
-//        out << endl;
-//    }
-}
-
 
 void LASolver::getConflict(bool, vec<PtAsgn>& e) {
     for (int i = 0; i < explanation.size(); i++) {

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -161,28 +161,12 @@ private:
     void computeConcreteModel(LVRef v, const opensmt::Real& d);
     void computeModel() override;
 
-    void print( ostream & out ) override;                            // Prints terms, current bounds and the tableau
-
-
     std::vector<opensmt::Real> concrete_model;              // Save here the concrete model for the vars indexed by Id
 
     opensmt::Real evaluateTerm(PTRef tr);
 
     LASolverStatus status;                  // Internal status of the solver (different from bool)
 
-
-    // Two reloaded output operators
-    inline friend ostream & operator <<( ostream & out, LASolver & solver )
-    {
-        solver.print( out );
-        return out;
-    }
-
-    inline friend ostream & operator <<( ostream & out, LASolver * solver )
-    {
-        solver->print( out );
-        return out;
-    }
     void fillTheoryFunctions(ModelBuilder & modelBuilder) const override;
 
     PTRef interpolateUsingEngine(FarkasInterpolator &) const;

--- a/src/tsolvers/stpsolver/STPSolver.h
+++ b/src/tsolvers/stpsolver/STPSolver.h
@@ -48,8 +48,6 @@ public:
 
     void clearSolver() override;
 
-    void print(ostream &out) override;
-
     bool assertLit(PtAsgn asgn) override;
 
     void pushBacktrackPoint() override;

--- a/src/tsolvers/stpsolver/STPSolver_implementations.hpp
+++ b/src/tsolvers/stpsolver/STPSolver_implementations.hpp
@@ -161,11 +161,6 @@ void STPSolver<T>::clearSolver() {
 }
 
 template<class T>
-void STPSolver<T>::print(ostream &out) {
-
-}
-
-template<class T>
 void STPSolver<T>::pushBacktrackPoint() {
     // Marks a checkpoint for the set of constraints in the solver
     // Important for backtracking


### PR DESCRIPTION
The method `TSolver::print` is not doing anything in any of the theory
solvers, I believe we should remove it.