### PR TITLE
Arith: Substitute variable by a constant when possible

### DIFF
--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -225,6 +225,9 @@ lbool ArithLogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Subs
         PTRef var = sub.first;
         assert(var != PTRef_Undef and isNumVarLike(var) and sub.second != PTRef_Undef);
         if (substitutions.has(var)) {
+            if (logic.isConstant(sub.second)) {
+                substitutions[var] = sub.second;
+            }
             // Already has substitution for this var, let the main substitution code deal with this situation
             continue;
         } else {


### PR DESCRIPTION
When computing substitutions from top-level arithmetic equalities, it
can happen that multiple substitutions for the same variable are
possible.
Before we just used the first one we encountered.
With this change, if we later encounter a different possible substition
with a constant, we use that one.
This should simplify the formula more.

Another possibility is to compare the complexity of the current and
alternative substitution and pick the less complex one (an example
metric would be the number of terms in the polynomial).
That I leave for future investigation.