### PR TITLE
Enable warnings on unused parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
             environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Werror
+                FLAGS: -Wall -Wunused-parameter -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -57,7 +57,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
+                    FLAGS: -Wall -Wunused-parameter -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-7 gmp-devel libedit-devel
@@ -79,7 +79,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
               environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Werror
+                FLAGS: -Wall -Wunused-parameter -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -144,7 +144,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Release
-                    FLAGS: -Wall -Werror
+                    FLAGS: -Wall -Wunused-parameter -Werror
                     INSTALL: ~/osmt-install
 
 workflows:

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -137,7 +137,7 @@ MainSolver::insertFormula(PTRef root, char** msg)
     return s_Undef;
 }
 
-sstat MainSolver::simplifyFormulas(char** err_msg)
+sstat MainSolver::simplifyFormulas()
 {
     if (binary_init)
         return s_Undef;

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -129,8 +129,6 @@ class MainSolver
 
     FContainer root_instance; // Contains the root of the instance once simplifications are done
 
-    // Simplify frames (not yet simplified) until all are simplified or the instance is detected unsatisfiable.
-    sstat simplifyFormulas(char** msg);
     sstat solve           ();
 
     sstat giveToSolver(PTRef root, FrameId push_id) {
@@ -198,7 +196,8 @@ class MainSolver
     void      initialize() { ts.solver.initialize(); ts.initialize(); }
 
     sstat check();      // A wrapper for solve which simplifies the loaded formulas and initializes the solvers
-    sstat simplifyFormulas() { char* msg; sstat res = simplifyFormulas(&msg); if (res == s_Error) { printf("%s\n", msg); } return res; }
+    // Simplify frames (not yet simplified) until all are simplified or the instance is detected unsatisfiable.
+    sstat simplifyFormulas();
 
     void  printFramesAsQuery() const;
     sstat getStatus       () const { return status; }

--- a/src/api/Opensmt.cc
+++ b/src/api/Opensmt.cc
@@ -34,7 +34,7 @@ opensmt::Logic_t convert(opensmt_logic logic) {
 }
 }
 
-Opensmt::Opensmt(opensmt_logic _logic, const char* name, int bw)
+Opensmt::Opensmt(opensmt_logic _logic, const char* name)
 {
     config = std::unique_ptr<SMTConfig>(new SMTConfig());
     logic.reset(opensmt::LogicFactory::getInstance(convert(_logic)));

--- a/src/api/Opensmt.h
+++ b/src/api/Opensmt.h
@@ -26,7 +26,7 @@ typedef enum
 class Opensmt
 {
 public:
-    Opensmt(opensmt_logic _logic, const char* name, int bw = 32);
+    Opensmt(opensmt_logic _logic, const char* name);
 
     /**
      * Constructor for OpenSMT instance where user user can passed its open configuration.

--- a/src/itehandler/IteToSwitch.h
+++ b/src/itehandler/IteToSwitch.h
@@ -84,7 +84,7 @@ namespace ite {
         Node*       lea       (NodeRef r)       { return (Node*)RegionAllocator<uint32_t>::lea(r.x); }
         const Node *lea       (NodeRef r) const { return (Node*)RegionAllocator<uint32_t>::lea(r.x); }
         NodeRef     ael       (const Node *t)   { auto r = RegionAllocator<uint32_t>::ael((uint32_t*)t); return {r}; }
-        void        free      (NodeRef r)       {}
+        void        free      (NodeRef)         {}
     };
 
 

--- a/src/logics/CUFLogic.cc
+++ b/src/logics/CUFLogic.cc
@@ -110,7 +110,7 @@ CUFLogic::~CUFLogic()
 //}
 
 PTRef
-CUFLogic::mkCUFNeg(PTRef tr, char** msg)
+CUFLogic::mkCUFNeg(PTRef tr)
 {
     if (isCUFNeg(tr)) return getPterm(tr)[0];
     if (isCUFPlus(tr)) {
@@ -118,7 +118,7 @@ CUFLogic::mkCUFNeg(PTRef tr, char** msg)
         assert(getPterm(tr).size() == 2);
         PTRef arg1 = mkCUFNeg(getPterm(tr)[0]);
         PTRef arg2 = mkCUFNeg(getPterm(tr)[1]);
-        PTRef tr_n = mkCUFPlus(arg1, arg2, msg);
+        PTRef tr_n = mkCUFPlus(arg1, arg2);
         assert(tr_n != PTRef_Undef);
         return tr_n;
     }
@@ -134,25 +134,25 @@ CUFLogic::mkCUFNeg(PTRef tr, char** msg)
 }
 
 PTRef
-CUFLogic::mkCUFMinus(const vec<PTRef>& args_in, char** msg)
+CUFLogic::mkCUFMinus(const vec<PTRef>& args_in)
 {
     vec<PTRef> args;
     args_in.copyTo(args);
     if (args.size() == 1) {
-        PTRef ret = mkCUFNeg(args[0], msg);
+        PTRef ret = mkCUFNeg(args[0]);
         return ret;
     }
     else {
         assert(args.size() == 2);
         PTRef mo = mkCUFConst(-1);
-        PTRef fact = mkCUFTimes(mo, args[1], msg);
+        PTRef fact = mkCUFTimes(mo, args[1]);
         args[1] = fact;
         return mkCUFPlus(args[0], args[1]);
     }
 }
 
 PTRef
-CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
+CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2)
 {
     PTRef tr = mkFun(sym_CUF_PLUS, {arg1, arg2});
     PTRef tr_comm = mkFun(sym_CUF_PLUS, {arg2, arg1});
@@ -163,7 +163,7 @@ CUFLogic::mkCUFPlus(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2, char** msg)
+CUFLogic::mkCUFTimes(const PTRef arg1, const PTRef arg2)
 {
     PTRef tr = mkFun(sym_CUF_TIMES, {arg1, arg2});
     PTRef tr_comm = mkFun(sym_CUF_TIMES, {arg2, arg1});
@@ -181,13 +181,13 @@ CUFLogic::mkCUFDiv(const PTRef arg1, const PTRef arg2)
 }
 
 PTRef
-CUFLogic::mkCUFGeq(const PTRef arg1, const PTRef arg2, char** msg)
+CUFLogic::mkCUFGeq(const PTRef arg1, const PTRef arg2)
 {
-    return mkCUFLeq(arg2, arg1, msg);
+    return mkCUFLeq(arg2, arg1);
 }
 
 PTRef
-CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2, char** msg)
+CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg1) && isCUFNUMConst(arg2)) {
         int c1 = getCUFNUMConst(arg1);
@@ -202,7 +202,7 @@ CUFLogic::mkCUFLeq(const PTRef arg1, const PTRef arg2, char** msg)
 }
 
 PTRef
-CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2, char** msg)
+CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2)
 {
     if (isCUFNUMConst(arg1) && isCUFNUMConst(arg2)) {
         int c1 = getCUFNUMConst(arg1);
@@ -222,9 +222,9 @@ CUFLogic::mkCUFGt(const PTRef arg1, const PTRef arg2, char** msg)
     return tr;
 }
 
-PTRef CUFLogic::mkCUFLt(const PTRef arg1, const PTRef arg2, char** msg)
+PTRef CUFLogic::mkCUFLt(const PTRef arg1, const PTRef arg2)
 {
-    return mkCUFGt(arg2, arg1, msg);
+    return mkCUFGt(arg2, arg1);
 }
 
 PTRef CUFLogic::mkCUFLshift(const PTRef arg1, const PTRef arg2)

--- a/src/logics/CUFLogic.h
+++ b/src/logics/CUFLogic.h
@@ -201,36 +201,31 @@ class CUFLogic: public Logic
     PTRef getTerm_CUFOne()  { return term_CUF_ONE; }
 
     PTRef mkCUFNeg(const vec<PTRef>& args) { assert(args.size() == 1); return mkCUFNeg(args[0]); }
-    PTRef mkCUFNeg(PTRef, char**);
-    PTRef mkCUFNeg(PTRef tr) {char* msg; PTRef trn = mkCUFNeg(tr, &msg); assert(trn != PTRef_Undef); return trn; }
+    PTRef mkCUFNeg(PTRef);
 
-    //PTRef mkCUFMinus(const vec<PTRef>& args) { assert(args.size() == 2); return mkCUFMinus(args[0], args[1]); }
-    PTRef mkCUFMinus(const vec<PTRef>&, char**);
-    PTRef mkCUFMinus(const vec<PTRef>& args) { char *msg; PTRef tr = mkCUFMinus(args, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkCUFMinus(const vec<PTRef>&);
     PTRef mkCUFMinus(const PTRef a1, const PTRef a2) { return mkCUFMinus({a1, a2}); }
 
     PTRef mkCUFPlus(const vec<PTRef>& args) { assert(args.size() == 2); return mkCUFPlus(args[0], args[1]); }
-    PTRef mkCUFPlus(const PTRef arg1, const PTRef arg2, char**);
-    PTRef mkCUFPlus(const PTRef arg1, const PTRef arg2) { char *msg; PTRef tr = mkCUFPlus(arg1, arg2, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkCUFPlus(const PTRef arg1, const PTRef arg2);
 
     PTRef mkCUFTimes(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFTimes(args[0], args[1]);}
-    PTRef mkCUFTimes(const PTRef, const PTRef, char**);
-    PTRef mkCUFTimes(const PTRef arg1, const PTRef arg2) { char *msg; PTRef tr = mkCUFTimes(arg1, arg2, &msg); assert(tr != PTRef_Undef); return tr; }
+    PTRef mkCUFTimes(const PTRef, const PTRef);
 
     PTRef mkCUFDiv(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFDiv(args[0], args[1]);}
     PTRef mkCUFDiv(const PTRef nom, const PTRef den);
 
-    PTRef mkCUFLeq(const vec<PTRef>& args) {assert(args.size() == 2); char *msg; return mkCUFLeq(args[0], args[1], &msg);}
-    PTRef mkCUFLeq(const PTRef arg1, const PTRef arg2, char**);
+    PTRef mkCUFLeq(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFLeq(args[0], args[1]);}
+    PTRef mkCUFLeq(const PTRef arg1, const PTRef arg2);
 
-    PTRef mkCUFGeq(const vec<PTRef>& args) {assert(args.size() == 2); char *msg; return mkCUFGeq(args[0], args[1], &msg);}
-    PTRef mkCUFGeq(const PTRef arg1, const PTRef arg2, char**);
+    PTRef mkCUFGeq(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFGeq(args[0], args[1]);}
+    PTRef mkCUFGeq(const PTRef arg1, const PTRef arg2);
 
-    PTRef mkCUFLt(const vec<PTRef>& args) {assert(args.size() == 2); char *msg; return mkCUFLt(args[0], args[1], &msg);}
-    PTRef mkCUFLt(const PTRef arg1, const PTRef arg2, char** tmp);
+    PTRef mkCUFLt(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFLt(args[0], args[1]);}
+    PTRef mkCUFLt(const PTRef arg1, const PTRef arg2);
 
-    PTRef mkCUFGt(const vec<PTRef>& args) {assert(args.size() == 2); char *msg; return mkCUFGt(args[0], args[1], &msg);}
-    PTRef mkCUFGt(const PTRef arg1, const PTRef arg2, char** tmp);
+    PTRef mkCUFGt(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFGt(args[0], args[1]);}
+    PTRef mkCUFGt(const PTRef arg1, const PTRef arg2);
 
     PTRef mkCUFLshift(const vec<PTRef>& args) {assert(args.size() == 2); return mkCUFLshift(args[0], args[1]);}
     PTRef mkCUFLshift   (const PTRef, const PTRef);

--- a/src/logics/CUFTheory.cc
+++ b/src/logics/CUFTheory.cc
@@ -9,7 +9,7 @@ const int CUFTheory::i_default_bitwidth = 32;
 // This function adds the newly introduced partial interpretations to
 // the top frame.
 //
-bool CUFTheory::simplify(const vec<PFRef>& formulas, PartitionManager& pmanager, int curr)
+bool CUFTheory::simplify(const vec<PFRef>& formulas, PartitionManager&, int curr)
 {
     auto & currentFrame = pfstore[formulas[curr]];
     if (this->keepPartitions()) {

--- a/src/logics/SubstLoopBreaker.cc
+++ b/src/logics/SubstLoopBreaker.cc
@@ -52,13 +52,13 @@ SNRef SubstNodeAllocator::alloc(PTRef tr, PTRef target)
     SNRef sid = {v};
     TVLRef tvr;
     if (target == PTRef_Undef) {
-        new (lea(sid)) SubstNode(tr, PTRef_Undef, vec<PTRef>(), tla);
+        new (lea(sid)) SubstNode(tr, vec<PTRef>(), tla);
     }
     else if (TargetToTargetVarListRef.peek(target, tvr)) {
-        new (lea(sid)) SubstNode(tr, target, tvr, tla);
+        new (lea(sid)) SubstNode(tr, tvr, tla);
     }
     else {
-        new (lea(sid)) SubstNode(tr, target, getVars(target), tla);
+        new (lea(sid)) SubstNode(tr, getVars(target), tla);
     }
     SourceToSNRef.insert(tr, sid);
     SNRefs.push(sid);

--- a/src/logics/SubstLoopBreaker.h
+++ b/src/logics/SubstLoopBreaker.h
@@ -86,7 +86,7 @@ private:
     SNRef   parent;
     TVLRef  children;
 
-    SubstNode(PTRef tr, PTRef, TargetVarListAllocator& tvla)
+    SubstNode(PTRef tr, TargetVarListAllocator& tvla)
     : tvla(tvla)
     , procChild(0)
     , index(-1)
@@ -96,12 +96,12 @@ private:
     , parent(SNRef_Undef)
     {}
 
-    SubstNode(PTRef tr, PTRef target, vec<PTRef>&& children, TargetVarListAllocator& tvla)
-    : SubstNode(tr, target, tvla)
+    SubstNode(PTRef tr, vec<PTRef>&& children, TargetVarListAllocator& tvla)
+    : SubstNode(tr, tvla)
     { this->children = tvla.alloc(std::move(children)); }
 
-    SubstNode(PTRef tr, PTRef target, TVLRef children, TargetVarListAllocator& tvla)
-    : SubstNode(tr, target, tvla)
+    SubstNode(PTRef tr, TVLRef children, TargetVarListAllocator& tvla)
+    : SubstNode(tr, tvla)
     { this->children = children; }
 
 public:

--- a/src/logics/SubstLoopBreaker.h
+++ b/src/logics/SubstLoopBreaker.h
@@ -86,7 +86,7 @@ private:
     SNRef   parent;
     TVLRef  children;
 
-    SubstNode(PTRef tr, PTRef target, TargetVarListAllocator& tvla)
+    SubstNode(PTRef tr, PTRef, TargetVarListAllocator& tvla)
     : tvla(tvla)
     , procChild(0)
     , index(-1)

--- a/src/logics/UFLATheory.cc
+++ b/src/logics/UFLATheory.cc
@@ -4,7 +4,7 @@
 #include "Substitutor.h"
 #include "ArithmeticEqualityRewriter.h"
 
-bool UFLATheory::simplify(const vec<PFRef>& formulas, PartitionManager &pmanager, int curr)
+bool UFLATheory::simplify(const vec<PFRef>& formulas, PartitionManager &, int curr)
 {
     auto & currentFrame = pfstore[formulas[curr]];
     if (this->keepPartitions()) {

--- a/src/logics/UFTheory.cc
+++ b/src/logics/UFTheory.cc
@@ -6,7 +6,7 @@
 // present.  If partitions cannot mix, do no simplifications but just
 // update the root.
 //
-bool UFTheory::simplify(const vec<PFRef>& formulas, PartitionManager &pmanager, int curr)
+bool UFTheory::simplify(const vec<PFRef>& formulas, PartitionManager &, int curr)
 {
     auto & currentFrame = pfstore[formulas[curr]];
     if (this->keepPartitions()) {

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -413,7 +413,7 @@ public:
 
     PTRef           compInterpLabelingOriginal               (ProofNode * n, const ipartitions_t & A_mask);
     PTRef           compInterpLabelingInner                  (ProofNode *);
-    void            labelLeaf                                (ProofNode *, const ipartitions_t&, unsigned num_config = 0, std::map<Var, icolor_t>* PSFunc = nullptr);
+    void            labelLeaf                                (ProofNode *, unsigned num_config = 0, std::map<Var, icolor_t>* PSFunc = nullptr);
     void            setLeafRandomLabeling                    (ProofNode *);
     void            setLeafMcMillanLabeling                  (ProofNode *);
     void            setLeafPudlakLabeling                    (ProofNode *);

--- a/src/proof/PGInterpolator.cc
+++ b/src/proof/PGInterpolator.cc
@@ -494,7 +494,7 @@ void ProofGraph::produceSingleInterpolant ( vec<PTRef> &interpolants, const ipar
         {
             if (!isLeafClauseType(n->getType())) opensmt_error ( "; Leaf node with non-leaf clause type" );
 
-            labelLeaf (n, A_mask, 0, PSFunction);
+            labelLeaf (n, 0, PSFunction);
 
             if (n->getType() == clause_type::CLA_ORIG)
             {
@@ -1024,7 +1024,7 @@ void ProofGraph::checkInterAlgo()
 
 
 void
-ProofGraph::labelLeaf (ProofNode *n, const ipartitions_t &A_mask, unsigned num_config, map<Var, icolor_t> *PSFunction)
+ProofGraph::labelLeaf(ProofNode * n, unsigned num_config, std::map<Var, icolor_t> * PSFunction)
 {
     // Proof Sensitive
     if (usingPSInterpolation()) setLeafPSLabeling (n, PSFunction);

--- a/src/simplifiers/BoolRewriting.cc
+++ b/src/simplifiers/BoolRewriting.cc
@@ -70,7 +70,7 @@ PTRef rewriteMaxArityClassic(Logic & logic, PTRef root) {
 
 PTRef rewriteMaxArityAggresive(Logic & logic, PTRef root) {
     return rewriteMaxArity(logic, root,
-                    [](PTRef candidate) { return false;});
+                    [](PTRef) { return false;});
 }
 
 namespace {

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -2112,7 +2112,7 @@ bool CoreSMTSolver::scatterLevel()
 }
 
 
-bool CoreSMTSolver::createSplit_scatter(bool last)
+bool CoreSMTSolver::createSplit_scatter(bool)
 {
     assert(splits.size() == split_assumptions.size());
     splits.emplace_back(SplitData(config.smt_split_format_length() == spformat_brief));

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -1689,7 +1689,7 @@ lbool CoreSMTSolver::search(int nof_conflicts, int nof_learnts)
                 updateSplitState();
                 if (!split_start && split_on && scatterLevel())
                 {
-                    if (!createSplit_scatter(false))   // Rest is unsat
+                    if (!createSplit_scatter())   // Rest is unsat
                     {
                         opensmt::stop = true;
                         return l_Undef;
@@ -1751,7 +1751,7 @@ lbool CoreSMTSolver::search(int nof_conflicts, int nof_learnts)
         }
     }
     cancelUntil(0);
-    createSplit_scatter(true);
+    createSplit_scatter();
     opensmt::stop = true;
     return l_Undef;
 }
@@ -2112,7 +2112,7 @@ bool CoreSMTSolver::scatterLevel()
 }
 
 
-bool CoreSMTSolver::createSplit_scatter(bool)
+bool CoreSMTSolver::createSplit_scatter()
 {
     assert(splits.size() == split_assumptions.size());
     splits.emplace_back(SplitData(config.smt_split_format_length() == spformat_brief));

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -537,7 +537,7 @@ protected:
 
     void     updateSplitState();                                                       // Update the state of the splitting machine.
     bool     scatterLevel();                                                           // Are we currently on a scatter level.
-    bool     createSplit_scatter(bool last);                                           // Create a split formula and place it to the splits vector.
+    bool     createSplit_scatter();                                                    // Create a split formula and place it to the splits vector.
     bool     excludeAssumptions(vec<Lit>& neg_constrs);                                // Add a clause to the database and propagate
     void     insertVarOrder   (Var x);                                                 // Insert a variable in the decision order priority queue.
     virtual Lit  pickBranchLit ();                                                     // Return the next decision variable.

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -408,6 +408,7 @@ char* THandler::printAsrtClause(Clause* c) {
 }
 
 bool THandler::checkTrailConsistency(vec<Lit>& trail) {
+    (void)trail;
     assert(trail.size() >= stack.size()); // There might be extra stuff
                                           // because of conflicting assignments
     for (int i = 0; i < stack.size(); i++) {

--- a/src/tsolvers/UFLATHandler.cc
+++ b/src/tsolvers/UFLATHandler.cc
@@ -20,7 +20,7 @@ UFLATHandler::UFLATHandler(SMTConfig & c, ArithLogic & l)
 
 }
 
-PTRef UFLATHandler::getInterpolant(const ipartitions_t& mask, map<PTRef, icolor_t> *labels, PartitionManager &pmanager)
+PTRef UFLATHandler::getInterpolant(const ipartitions_t&, map<PTRef, icolor_t> *, PartitionManager &)
 {
     throw std::logic_error("Not implemented");
 }

--- a/src/tsolvers/lasolver/Matrix.h
+++ b/src/tsolvers/lasolver/Matrix.h
@@ -79,7 +79,7 @@ public:
     LAVec*       lea       (LAVecRef r)       { return (LAVec*)RegionAllocator<uint32_t>::lea(r.x); }
     const LAVec* lea       (LAVecRef r) const { return (LAVec*)RegionAllocator<uint32_t>::lea(r.x); }
     LAVecRef     ael       (const LAVec* t)   { RegionAllocator<uint32_t>::Ref r = RegionAllocator<uint32_t>::ael((uint32_t*)t); LAVecRef rf; rf.x = r; return rf; }
-    void         free      (LAVecRef r)       {}
+    void         free      (LAVecRef)         {}
     // Debug stuff
     char*        printVec (LAVecRef r)  const;
 };

--- a/src/tsolvers/stpsolver/STPSolver_implementations.hpp
+++ b/src/tsolvers/stpsolver/STPSolver_implementations.hpp
@@ -144,7 +144,7 @@ bool STPSolver<T>::assertLit(PtAsgn asgn) {
 }
 
 template<class T>
-TRes STPSolver<T>::check(bool b) {
+TRes STPSolver<T>::check(bool) {
     // The main method checking the consistency of the current set of constraints
     // Return SAT if the current set of constraints is satisfiable, UNSAT if unsatisfiable
 


### PR DESCRIPTION
This PR fixes a couple of places where compiler warns on unused parameter and enables the flag in CI runs.

There are a few places where it is not clear if the parameter should be removed completely or not.