### PR TITLE
Enable more compiler warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
             environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Wunused-parameter -Werror
+                FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -57,7 +57,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Wunused-parameter -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
+                    FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-7 gmp-devel libedit-devel
@@ -79,7 +79,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
               environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Wunused-parameter -Werror
+                FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -144,7 +144,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Release
-                    FLAGS: -Wall -Wunused-parameter -Werror
+                    FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
                     INSTALL: ~/osmt-install
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
             environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
+                FLAGS: -Wall -Wextra -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -57,7 +57,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
+                    FLAGS: -Wall -Wextra -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-7 gmp-devel libedit-devel
@@ -79,7 +79,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
               environment:
                 CMAKE_BUILD_TYPE: Release
-                FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
+                FLAGS: -Wall -Wextra -Werror
                 INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
@@ -144,7 +144,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Release
-                    FLAGS: -Wall -Wextra -Wno-ignored-qualifiers -Werror
+                    FLAGS: -Wall -Wextra -Werror
                     INSTALL: ~/osmt-install
 
 workflows:

--- a/benchmark/performance/perf_RationalEfficiency.cc
+++ b/benchmark/performance/perf_RationalEfficiency.cc
@@ -23,10 +23,10 @@ protected:
     Real bigmax = rmax*rmax*rmax;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
     }
 };
 

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -90,10 +90,7 @@ public:
         out.systime = systime - subst.systime;
         return out;
     }
-    void operator= (const OSMTTimeVal& from) {
-        usrtime = from.usrtime;
-        systime = from.systime;
-    }
+
     OSMTTimeVal& operator+= (const OSMTTimeVal& from) {
         usrtime += from.usrtime;
         systime += from.systime;

--- a/src/logics/BVLogic.cc
+++ b/src/logics/BVLogic.cc
@@ -391,7 +391,7 @@ PTRef BVLogic::mkBVNeq(const PTRef a1, const PTRef a2)
     return mkBVNot(mkBVEq(args));
 }
 
-const int BVLogic::getBVNUMConst(PTRef tr) const
+int BVLogic::getBVNUMConst(PTRef tr) const
 {
     return atoi(getSymName(tr));
 }

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -118,7 +118,7 @@ class BVLogic: public CUFLogic
 
     SRef declareSort_BVNUM(char** msg);
     SRef getSort_BVNUM() const { return sort_BVNUM; }
-    const int getBVNUMConst(PTRef tr) const;
+    int getBVNUMConst(PTRef tr) const;
 
 
     bool isBVPlus(SymRef sr)   const { return sr == sym_BV_PLUS; }

--- a/src/logics/CUFLogic.cc
+++ b/src/logics/CUFLogic.cc
@@ -357,7 +357,7 @@ PTRef CUFLogic::mkCUFNeq(const PTRef a1, const PTRef a2)
     return Logic::mkNot(Logic::mkEq(a1, a2));
 }
 
-const int CUFLogic::getCUFNUMConst(PTRef tr) const
+int CUFLogic::getCUFNUMConst(PTRef tr) const
 {
     return atoi(getSymName(tr));
 }

--- a/src/logics/CUFLogic.h
+++ b/src/logics/CUFLogic.h
@@ -127,7 +127,7 @@ class CUFLogic: public Logic
 
     SRef declareSort_CUFNUM(char** msg);
     SRef getSort_CUFNUM() const { return sort_CUFNUM; }
-    const int getCUFNUMConst(PTRef tr) const;
+    int getCUFNUMConst(PTRef tr) const;
 
 
     bool isCUFPlus(SymRef sr)   const { return sr == sym_CUF_PLUS; }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -156,7 +156,7 @@ class Logic {
     virtual PTRef conjoinExtras(PTRef root);
 
     virtual std::string const getName() const { return opensmt::QFLogicToProperties.at(logicType).name; }
-    const opensmt::Logic_t getLogic() const { return logicType; }
+    opensmt::Logic_t getLogic() const { return logicType; }
 
     bool hasUFs() const { return opensmt::QFLogicToProperties.at(logicType).ufProperty.hasUF; }
     bool hasIntegers() const { return opensmt::QFLogicToProperties.at(logicType).arithProperty.hasInts; }

--- a/src/logics/LogicFactory.h
+++ b/src/logics/LogicFactory.h
@@ -126,7 +126,7 @@ inline const std::unordered_map<Logic_t, LogicProperty> QFLogicToProperties  {
                         no_bv}},
     {Logic_t::QF_AX, {"QF_AX",
                       no_arith,
-                      UFProperty{true, false},
+                      UFProperty{true, false, false},
                       no_bv}},
     {Logic_t::QF_AXDIFF, {"QF_AXDIFF",
                       no_arith,

--- a/src/tsolvers/bvsolver/Bvector.h
+++ b/src/tsolvers/bvsolver/Bvector.h
@@ -87,7 +87,7 @@ class Bvector {
         header.size      = 0;
     }
 
-    Bvector    operator=   (Bvector)         { assert(false); return *this; }
+    Bvector&    operator=   (Bvector const &) = delete;
 
     int      size        ()          const   { return header.size; }
     PTRef    getActVar   ()          const   { return actVar; }


### PR DESCRIPTION
`Wextra` subsumes `Wunused-parameter`.
I exclude `Wignored-qualifiers` for now, as we have quite a few of those.
We should discuss if we enable also that one (I vote "yes").