### PR TITLE
ModelBuilder: Avoid name clash

### DIFF
--- a/regression_models/instances/name_clash.smt2
+++ b/regression_models/instances/name_clash.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_UFLRA)
+(declare-fun x0 () Real)
+(declare-fun f (Real Real) Real)
+(assert (distinct 0.0 (f 1.0 0.0)))
+(check-sat)

--- a/src/models/ModelBuilder.cc
+++ b/src/models/ModelBuilder.cc
@@ -40,9 +40,11 @@ void ModelBuilder::addToTheoryFunction(SymRef sr, const vec<PTRef> & vals, PTRef
         std::string formalArgPrefix(Model::getFormalArgBaseNameForSymbol(logic, sr, formalArgDefaultPrefix));
 
         for (PTRef v : vals) {
-            std::stringstream ss;
-            ss << formalArgPrefix << uniqueNum++;
-            formalArgs.push(logic.mkVar(logic.getSortRef(v), ss.str().c_str()));
+            std::string name;
+            do {
+                name = formalArgPrefix + std::to_string(uniqueNum++);
+            } while (logic.hasSym(name.c_str()));
+            formalArgs.push(logic.mkVar(logic.getSortRef(v), name.c_str()));
         }
         FunctionSignature templateSig(logic.protectName(logic.getSymName(sr)), std::move(formalArgs), logic.getSortRef(sr));
         definitions.insert({sr,opensmt::pair<FunctionSignature,ValuationNode*>{std::move(templateSig), nullptr}});


### PR DESCRIPTION
Model validator does not seem to like the case when function argument
has the same name as a normal variable defined in the same model.
With this change, names of the parameters are picked so the symbol with
the same name does not yet exist in the logic.