### PR TITLE
Interpret: Add model post-processing to avoid name clashes

### DIFF
--- a/regression_models/instances/name_clash.smt2
+++ b/regression_models/instances/name_clash.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_UFLRA)
+(declare-fun x0 () Real)
+(declare-fun f (Real Real) Real)
+(assert (distinct 0.0 (f 1.0 0.0)))
+(check-sat)

--- a/regression_models/instances/name_clash2.smt2
+++ b/regression_models/instances/name_clash2.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_UFLRA)
+(declare-fun r0 () Real)
+(declare-fun x!0 (Real Real) Real)
+(assert (distinct 0.0 (x!0 1.0 0.0)))
+(check-sat)

--- a/regression_models/instances/name_clash3.smt2
+++ b/regression_models/instances/name_clash3.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_UFLRA)
+(declare-fun r0 () Real)
+(declare-fun y!0 () Real)
+(declare-fun x!0 (Real Real) Real)
+(assert (distinct 0.0 (x!0 1.0 0.0)))
+(check-sat)

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -700,7 +700,7 @@ public:
                     std::string name;
                     PTRef var = PTRef_Undef;
                     do {
-                        name = "x!" + std::to_string(num++);
+                        name = getSafePrefix(symRef) + std::to_string(num++);
                         var = logic.mkVar(logic.getSortRef(oldArg), name.c_str());
                     } while (forbiddenVars.find(var) != forbiddenVars.end());
                     newArgs.push(var);
@@ -728,6 +728,9 @@ private:
         });
     }
 
+    std::string getSafePrefix(SymRef symref) {
+        return logic.getSymName(symref)[0] == 'x' ? "y!" : "x!";
+    }
 };
 }
 

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -689,12 +689,12 @@ public:
 
     std::vector<TemplateFunction> getSafeTemplates(Model const & model) {
         std::vector<TemplateFunction> res;
+        unsigned num = 0;
         for (SymRef symRef : functionsToCheck) {
             auto const & modelTemplate = model.getDefinition(symRef);
             if (hasClash(modelTemplate)) {
                 auto const & oldArgs = modelTemplate.getArgs();
                 vec<PTRef> newArgs; newArgs.capacity(oldArgs.size());
-                unsigned num = 0;
                 Logic::SubstMap substMap;
                 for (PTRef oldArg : oldArgs) {
                     std::string name;

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -737,8 +737,7 @@ void Interpret::getModel() {
     NameClashResolver resolver(*logic);
     std::stringstream ss;
     ss << "(\n";
-    for (int i = 0; i < user_declarations.size(); ++i) {
-        SymRef symref = user_declarations[i];
+    for (SymRef symref : user_declarations) {
         const Symbol & sym = logic->getSym(symref);
         if (sym.size() == 1) {
             // variable, just get its value
@@ -752,7 +751,7 @@ void Interpret::getModel() {
         else {
             // function
             resolver.addFunction(symref);
-        };
+        }
     }
     for (auto const & safeTempl : resolver.getSafeTemplates(*model)) {
         ss << printDefinitionSmtlib(safeTempl);


### PR DESCRIPTION
Model validator does not like when a formal argument of function
definition has the same name as a variable already defined in the model.
To work around this limitation, this patch adds a small post-processing
that checks for such name clashes in the model and renames the formal
parameters in problematic function definitions.

This is an alternative proposal to #381.