### PR TITLE
LASolver: Prepare for adding new atoms on-the-fly

### DIFF
--- a/src/tsolvers/lasolver/LABounds.cc
+++ b/src/tsolvers/lasolver/LABounds.cc
@@ -85,6 +85,12 @@ void LABoundStore::clear() {
     this->bounds.clear();
 }
 
+void LABoundStore::ensureReadyFor(LVRef v) {
+    while (bounds.size() <= getVarId(v)) {
+        bounds.emplace_back();
+    }
+}
+
 void LABoundStore::updateBound(BoundInfo bi) {
     auto & varBounds = getBounds(bi.v);
     for (LABoundRef bound : {bi.ub, bi.lb}) {
@@ -136,17 +142,7 @@ void LABoundStore::buildBounds()
             ba[refs[j]].setIdx(LABound::BLIdx{j});
         }
 
-        while (bounds.size() <= getVarId(v)) {
-            bounds.emplace_back();
-        }
+        assert(getVarId(v) < bounds.size());
         refs.moveTo(bounds.at(getVarId(v)));
-    }
-
-    // make sure all variables are recorded in the bound lists, even if they have no bounds
-    for (LVRef ref : lvstore) {
-        auto id = getVarId(ref);
-        while (bounds.size() <= id) {
-            bounds.emplace_back();
-        }
     }
 }

--- a/src/tsolvers/lasolver/LABounds.h
+++ b/src/tsolvers/lasolver/LABounds.h
@@ -98,6 +98,7 @@ public:
     vec<LABoundRef> & getBounds(LVRef v) { return bounds.at(getVarId(v)); }
     LABoundRef getBoundByIdx(LVRef v, int it) const;
     bool isUnbounded(LVRef v) const;
+    void ensureReadyFor(LVRef v);
 
     // Debug
     char* printBound(LABoundRef br) const; // Print the bound br
@@ -106,6 +107,7 @@ public:
 
     // Allocates lower and upper bound for LA var with the given values
     BoundInfo allocBoundPair(LVRef v, BoundValuePair boundPair) {
+        ensureReadyFor(v);
         LABoundRef ub = ba.alloc(bound_u, v, std::move(boundPair.upper));
         LABoundRef lb = ba.alloc(bound_l, v, std::move(boundPair.lower));
         in_bounds.push(BoundInfo{v, ub, lb});

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -337,19 +337,15 @@ void LASolver::declareAtom(PTRef leq_tr)
         // Treat the PTRef as it is pushed on-the-fly
         //    status = INCREMENT;
         assert( status == SAT );
+        PTRef term = logic.getPterm(leq_tr)[1];
+        LVRef v = exprToLVar(term);
+        laVarMapper.addLeqVar(leq_tr, v);
+        updateBound(leq_tr);
     }
     // DEBUG check
     isProperLeq(leq_tr);
 
     setKnown(leq_tr);
-}
-
-void LASolver::informNewSplit(PTRef tr)
-{
-    PTRef term = logic.getPterm(tr)[1];
-    LVRef v = exprToLVar(term);
-    laVarMapper.addLeqVar(tr, v);
-    updateBound(tr);
 }
 
 TRes LASolver::checkIntegersAndSplit() {

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -64,8 +64,11 @@ private:
     vec<PtAsgn>          LABoundRefToLeqAsgn;
     PtAsgn getAsgnByBound(LABoundRef br) const;
     vec<LABoundRefPair>  LeqToLABoundRefPair;
-    LABoundRefPair getBoundRefPair(const PTRef leq) const
-        { return LeqToLABoundRefPair[Idx(logic.getPterm(leq).getId())]; }
+    LABoundRefPair getBoundRefPair(const PTRef leq) const {
+        auto index = Idx(logic.getPterm(leq).getId());
+        assert(index < LeqToLABoundRefPair.size_());
+        return LeqToLABoundRefPair[index];
+    }
 
     // Possible internal states of the solver
     typedef enum
@@ -95,7 +98,6 @@ public:
 
     void getNewSplits(vec<PTRef>& splits) override;
     void  declareAtom        (PTRef tr) override;                // Inform the theory solver about the existence of an atom
-    void  informNewSplit     (PTRef tr) override;                // Update bounds for the split variable
     TRes  check              (bool) override;                    // Checks the satisfiability of current constraints
     bool  check_simplex      (bool);
     bool  assertLit          ( PtAsgn ) override;                // Push the constraint into Solver

--- a/src/tsolvers/lasolver/Simplex.h
+++ b/src/tsolvers/lasolver/Simplex.h
@@ -122,6 +122,8 @@ private:
         while (getVarId(v) >= boundsActivated.size()) {
             boundsActivated.push_back(0);
         }
+        model->addVar(v);
+        boundStore.ensureReadyFor(v);
     }
 
     void processBufferOfActivatedBounds();

--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -20,8 +20,7 @@ namespace {
 }
 
 void Tableau::nonbasicVar(LVRef v) {
-    if(isNonBasic(v)) {return;}
-    assert(!isProcessed(v));
+    if (isProcessed(v)) { return; }
     newNonbasicVar(v);
 }
 
@@ -38,6 +37,7 @@ void Tableau::newRow(LVRef v, std::unique_ptr<Polynomial> poly) {
     ensureTableauReadyFor(v);
     addRow(v, std::move(poly));
     varTypes[getVarId(v)] = VarType::QUASIBASIC;
+    normalizeRow(v);
 
 }
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -219,3 +219,11 @@ target_sources(SortsTest
 
 target_link_libraries(SortsTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET SortsTest)
+
+add_executable(LASolverIncrementalityTest)
+target_sources(LASolverIncrementalityTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LASolverIncrementality.cc"
+        )
+
+target_link_libraries(LASolverIncrementalityTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET LASolverIncrementalityTest)

--- a/test/unit/test_LASolverIncrementality.cc
+++ b/test/unit/test_LASolverIncrementality.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2021, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <gtest/gtest.h>
+#include <lasolver/LASolver.h>
+
+class LASolverIncrementalityTest : public ::testing::Test {
+public:
+    LASolverIncrementalityTest() : logic(opensmt::Logic_t::QF_LRA), solver(c, logic) {}
+    SMTConfig c;
+    ArithLogic logic;
+    LASolver solver;
+};
+
+TEST_F(LASolverIncrementalityTest, test_Incrementality) {
+
+    // x >= 1
+    PTRef c1 = logic.getTerm_RealOne();
+    PTRef x = logic.mkRealVar("x");
+    PTRef constr1 = logic.mkGeq(x, c1);
+    solver.declareAtom(constr1);
+    solver.assertLit({constr1, l_True});
+    auto res = solver.check(true);
+    ASSERT_EQ(res, TRes::SAT);
+
+    // 0 <= -y - x
+    PTRef y = logic.mkRealVar("y");
+    PTRef p1 = logic.mkMinus(logic.mkNeg(y), x);
+    PTRef constr3 = logic.mkLeq(logic.getTerm_RealZero(), p1);
+    solver.declareAtom(constr3);
+    solver.assertLit({constr3, l_True});
+    res = solver.check(true);
+    ASSERT_EQ(res, TRes::SAT);
+
+    // y >= 1
+    PTRef constr2 = logic.mkGeq(y, c1);
+    solver.declareAtom(constr2);
+    solver.assertLit({constr2, l_True});
+    res = solver.check(true);
+    ASSERT_EQ(res, TRes::UNSAT);
+}


### PR DESCRIPTION
We aleady have a mechanism for adding new atoms that deals with LIA
splits. However, those atoms are special in the way that there are new
bounds on an existing variable.
This mechanism is generalized to allow bounds on arbitrary expressions
to be added dynamically.
The main issue is that new row being added to a tableaux must be
normalized, since he variables in the new expression might not be
nonbasic variables at the moment of addition.

Apart from that, we need to ensure that LASolver's data structure are
ready for dynamically added bounds of a new variable not seen at the
init stage.

The rest seems to be working nicely thanks for the mechanism of
QUASI_BASIC variables.