### PR TITLE
Egraph: Introduce mechanism for dealing with dynamicly added terms

### DIFF
--- a/src/tsolvers/egraph/Egraph.h
+++ b/src/tsolvers/egraph/Egraph.h
@@ -168,7 +168,7 @@ private:
     std::vector<UseVector> parents;
 
     void addToUseVectors(ERef);
-    void updateUseVectors(PTRef);
+    void ensureUseVectorFor(ERef);
 
     void removeFromUseVectorsExcept(ERef parent, CgId cgid);
     void removeFromUseVectors(ERef parent);
@@ -293,7 +293,7 @@ private:
     , DISEQ           // A negated equality is asserted
     , DIST            // A distinction is asserted
     , EXPL            // Explanation added
-    , SET_DYNAMIC     // Dynamic info was set
+    , REANALYZE       // A term added after init need to be reanalyzed
     , SET_POLARITY    // A polarity of a PTRef was set
     , UNDEF_OP        // A dummy value for default constructor
     #if MORE_DEDUCTIONS
@@ -360,6 +360,8 @@ private:
 
     vec<opensmt::pair<ERef,ERef>> pending;                          // Pending merges
     vec<Undo>                 undo_stack_main;                  // Keeps track of terms involved in operations
+
+    void reanalyze(ERef);
 
     void doExplain(ERef, ERef, PtAsgn);                            // Explain why the Enodes are equivalent when PtAsgn says it should be different
     void explainConstants(ERef, ERef);

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -75,11 +75,7 @@ ERef EnodeStore::addTerm(PTRef term) {
         args.push(termToERef[arg]);
     }
     ERef newEnode = ea.alloc(symref, opensmt::span(args.begin(), args.size_()) , term);
-    // Term's signature must not exist.  Otherwise the term would have two different signatures.
-    assert(not containsSig(newEnode));
-    if (args.size() > 0) { // MB: No need to insert signatures of terms who cannot be parents
-        insertSig(newEnode);
-    }
+
     termToERef.insert(term, newEnode);
     assert(not ERefToTerm.has(newEnode));
     ERefToTerm.insert(newEnode, term);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -33,7 +33,7 @@ gtest_add_tests(TARGET TheorySimplificationsTest)
 
 add_executable(EGraphTest)
 target_sources(EGraphTest
-    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Egraph.cpp"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Egraph.cc"
     )
 
 target_link_libraries(EGraphTest OpenSMT gtest gtest_main)


### PR DESCRIPTION
Egraph is sensitive to backtracking and needs to undo the made changes
exactly. The important thing is to maintain the invariants of signatures
and use-vectors. Adding new terms to Egraph after initialization causes
problems for maintaining the invariants when backtracking happens.

The solution is inspired by the approach of Yices. For these newly added
terms, we remember on the backtracking stack that we need to re-analyze
them on backtracking to maintain the invariants.

Re-analysis means that we remove these terms from the signature and
use-vectors data structures if they are the representative. After the
solver has backtracked, these terms are re-introduced to these
data-structures, if they are still the representative of their class.

One problem is that it is still not entirely clear to me at which point
we can stop re-analyzing these terms.