### PR TITLE
Generalize split clauses

### DIFF
--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -754,6 +754,9 @@ public:
 protected:
     virtual inline void clausesPublish() {};
     virtual inline void clausesUpdate() {};
+
+    using SplitClauses = std::vector<vec<Lit>>;
+    TPropRes handleNewSplitClauses(SplitClauses & clauses);
 };
 
 //=================================================================================================

--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -79,7 +79,7 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
     vec<LitLev> deds;
     deduceTheory(deds); // To remove possible theory deductions
     TPropRes res = TPropRes::Undef;
-    Lit toPropagate;
+    Lit toPropagate = lit_Undef;
     CRef propagationReason = CRef_Undef;
     for (auto & splitClause : splitClauses) {
         unsigned satisfied = 0;
@@ -106,7 +106,8 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
             if (!this->logsProofForInterpolation()) {
                 if (decisionLevel() == 0) {
                     // MB: do not allocate, we can directly enqueue the implied literal
-                    toPropagate = splitClause[impliedIndex];
+                    uncheckedEnqueue(splitClause[impliedIndex], CRef_Undef);
+                    toPropagate = lit_Undef;
                     propagationReason = CRef_Undef;
                     res = TPropRes::Propagate;
                     continue;
@@ -148,8 +149,10 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
     }
     assert(res != TPropRes::Undef);
     if (res == TPropRes::Propagate) {
-        uncheckedEnqueue(toPropagate, propagationReason);
         forced_split = lit_Undef;
+        if (toPropagate != lit_Undef) {
+            uncheckedEnqueue(toPropagate, propagationReason);
+        }
     }
     return res;
 }

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -1,28 +1,10 @@
-/*********************************************************************
-Author: Antti Hyvarinen <antti.hyvarinen@gmail.com>
-
-OpenSMT2 -- Copyright (C) 2012 - 2016 Antti Hyvarinen
-                         2008 - 2012 Roberto Bruttomesso
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*********************************************************************/
+/*
+ *  Copyright (c) 2008-2012 Roberto Bruttomesso
+ *  Copyright (c) 2012-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ */
 
 #include "THandler.h"
 #include "TSolver.h"
@@ -106,7 +88,7 @@ std::vector<vec<Lit>> THandler::getNewSplits() {
     }
     for (PTRef clause : newSplits) {
         splitClauses.emplace_back();
-        Logic & logic = getLogic();
+        Logic const & logic = getLogic();
         assert(logic.isOr(clause));
         for (int i = 0; i < logic.getPterm(clause).size(); i++) {
             PTRef litTerm = logic.getPterm(clause)[i];

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -63,7 +63,7 @@ public:
     TermMapper&           getTMap()      ;//          { return tmap; }
 
     void    getConflict          ( vec<Lit>&, vec<VarData>&, int & ); // Returns theory conflict in terms of literals
-    void    getNewSplits         ( vec<Lit>& ); // Return the new splits as a vector of literals that needs to be interpreted as a clause.
+    std::vector<vec<Lit>> getNewSplits(); // Return the new splits as a vector of literals that needs to be interpreted as a clause.
 
     PTRef   getInterpolant       (const ipartitions_t&, map<PTRef, icolor_t>*, PartitionManager &pmanager);
     Lit     getDeduction         ();                      // Returns a literal that is implied by the current state and the reason literal

--- a/src/tsolvers/TSolverHandler.cc
+++ b/src/tsolvers/TSolverHandler.cc
@@ -86,6 +86,17 @@ TRes TSolverHandler::check(bool complete)
     return res_final;
 }
 
+vec<PTRef> TSolverHandler::getSplitClauses() {
+    vec<PTRef> split_terms;
+    for (int i = 0; i < tsolvers.size(); i++) {
+        if (tsolvers[i] != nullptr && tsolvers[i]->hasNewSplits()) {
+            tsolvers[i]->getNewSplits(split_terms);
+            break;
+        }
+    }
+    return split_terms;
+}
+
 // MB: This is currently needed to replace a common array of deduced elements with solver ID
 TSolver* TSolverHandler::getReasoningSolverFor(PTRef ptref) const {
     assert(getLogic().isTheoryTerm(ptref));

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -74,6 +74,7 @@ public:
 //    virtual SolverId getId() const { return my_id; }
     virtual lbool getPolaritySuggestion(PTRef) const { return l_Undef; }
     TRes    check(bool);
+    virtual vec<PTRef> getSplitClauses();
 private:
     // Helper method for computing reasons
     TSolver* getReasoningSolverFor(PTRef ptref) const;


### PR DESCRIPTION
In order to implement model-based theory combination, we need to generalize our current mechanism of split clauses used currently only for LIA splits.

Instead of a single binary clause, we need to allow solvers to communicate any clause (not just binary) and any number of them. In our proposed implementation we need 3 clauses of which 2 are binary and 1 is ternary.

However, we still need to properly maintain invariants of the SAT solver.
For example, if the new split clause should actually propagate one of its literals, we need to backtrack to the point where it would have been propagated if the clause had already existed.