### PR TITLE
LIA: Use most-infeasible branching heuristic

### DIFF
--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -346,7 +346,7 @@ void LASolver::declareAtom(PTRef leq_tr)
 
 LVRef LASolver::splitOnMostInfeasible(vec<LVRef> const & varsToFix) const {
     opensmt::Real maxDistance = 0;
-    LVRef chosen;
+    LVRef chosen = LVRef_Undef;
     for (LVRef x : varsToFix) {
         Delta val = simplex.getValuation(x);
         assert(not val.hasDelta());

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -124,7 +124,6 @@ void LASolver::clearSolver()
     LABoundRefToLeqAsgn.clear();
     LeqToLABoundRefPair.clear();
 
-    cuts.clear();
     int_vars.clear();
     int_vars_map.clear();
     // TODO: clear statistics
@@ -223,9 +222,6 @@ void LASolver::markVarAsInt(LVRef v) {
     if (!int_vars_map.has(v)) {
         int_vars_map.insert(v, true);
         int_vars.push(v);
-    }
-    while (static_cast<unsigned>(cuts.size()) <= getVarId(v)) {
-        cuts.emplace_back(0);
     }
 }
 
@@ -372,12 +368,6 @@ TRes LASolver::checkIntegersAndSplit() {
                     c = x_val.R();
                 }
             }
-
-            // We might have this blocked already, and then the solver should essentially return "I don't know, please go ahead".
-            if (cuts[getVarId(x)].find(c) != cuts[getVarId(x)].end()) {
-                continue;
-            }
-            cuts[getVarId(x)][c] = true;
 
             // Check if integer splitting is possible for the current variable
             if (simplex.hasLBound(x) && simplex.hasUBound(x) && c < simplex.Lb(x) && c + 1 > simplex.Ub(x)) { //then splitting not possible, and we create explanation

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -119,7 +119,6 @@ private:
 
     Map<LVRef, bool, LVRefHash> int_vars_map; // stores problem variables for duplicate check
     vec<LVRef> int_vars;                      // stores the list of problem variables without duplicates
-    std::vector<std::unordered_map<opensmt::Real, bool, FastRationalHash> > cuts;
 
     LABoundStore::BoundInfo addBound(PTRef leq_tr);
     void updateBound(PTRef leq_tr);

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -143,6 +143,8 @@ private:
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
     void notifyVar(LVRef);                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
 
+    // Most-infeasible branching heuristic
+    LVRef splitOnMostInfeasible(vec<LVRef> const &) const;
     TRes checkIntegersAndSplit();
     bool isModelInteger (LVRef v) const;
 


### PR DESCRIPTION
When Simplex model needs fixing because of integer domain, let's be a bit more clever than just branching on the first variable we find.

There are a couple of heuristics that could be used, most-infeasible branching seems like a good one.
It considers all integer variables that needs fixing and chooses the one with largest distance from an integer point (i.e., minimum from the two distances to the two closest points: floor and ceiling).