### PR TITLE
Tableau: Simplify normalization of rows

### DIFF
--- a/src/tsolvers/lasolver/Tableau.cc
+++ b/src/tsolvers/lasolver/Tableau.cc
@@ -255,23 +255,19 @@ bool Tableau::checkConsistency() const {
 void Tableau::normalizeRow(LVRef v) {
     assert(isQuasiBasic(v)); // Do not call this for non quasi rows
     Polynomial & row = getRowPoly(v);
-    std::vector<Polynomial::Term const*> toEliminate;
+    std::vector<LVRef> toEliminate;
     for (auto const & term : row) {
         if (isQuasiBasic(term.var)) {
             normalizeRow(term.var);
-            toEliminate.push_back(&term);
+            toEliminate.push_back(term.var);
         }
         if (isBasic(term.var)) {
-            toEliminate.push_back(&term);
+            toEliminate.push_back(term.var);
         }
     }
-    if (!toEliminate.empty()) {
-        Polynomial p;
-        for (auto const* term : toEliminate) {
-            p.merge(getRowPoly(term->var), term->coeff, [](LVRef) {}, [](LVRef) {}, tmp_storage);
-            p.addTerm(term->var, -term->coeff);
-        }
-        row.merge(p, 1, [](LVRef) {}, [](LVRef) {}, tmp_storage);
+    for (LVRef var : toEliminate) {
+        auto const coeff = row.removeVar(var);
+        row.merge(getRowPoly(var), coeff, [](LVRef) {}, [](LVRef) {}, tmp_storage);
     }
 }
 


### PR DESCRIPTION
Instead of remembering pointers to problematic variables, can can
remember the variables themselves. Then, instead of building a separate
polynomial and updating the row in one go, we can update the row for
each variable the same way we do in pivoting.

The new way avoids the need for a temporary polynomial which caused
unnecessary memory allocotations as we were gradually building it.
On the other hand, we are now updating the same row multiple times.
It is not immediatelly clear which approach is better, but the
experiments suggest this is a good idea.