### PR TITLE
fix: bump minimum required flex to 2.6

### DIFF
--- a/src/parsers/smt2new/CMakeLists.txt
+++ b/src/parsers/smt2new/CMakeLists.txt
@@ -9,7 +9,7 @@
 add_library(parsers OBJECT "")
 
 find_package(BISON 3.0 REQUIRED)
-find_package(FLEX REQUIRED)
+find_package(FLEX 2.6 REQUIRED)
 
 BISON_TARGET(smt2newParser smt2newparser.yy ${CMAKE_CURRENT_BINARY_DIR}/smt2newparser.cc)
 FLEX_TARGET(smt2newScanner smt2newlexer.ll ${CMAKE_CURRENT_BINARY_DIR}/smt2newlexer.cc)


### PR DESCRIPTION
flex versions < 2.6 are not compatible with c++17