### PR TITLE
CI: Update and cleanup the scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,12 @@ jobs:
                 name: Create the build directory
                 command: mkdir build
             - run:
+                name: Debug build gcc under devtoolset-8
+                command: |
+                    cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash
+                environment:
+                    CMAKE_BUILD_TYPE: Debug
+            - run:
                 name: Release build gcc under devtoolset-8
                 command: |
                     cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,32 +24,32 @@ jobs:
                 name: install model validation environment
                 command: ./regression_models/bin/setup-env.sh
             - run:
-                name: Release build gcc
-                command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Release
-            - run:
                 name: Debug build gcc
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
                     ENABLE_LINE_EDITING: ON
             - run:
+                name: Release build gcc
+                command: ./ci/run_travis_commands.sh
+                environment:
+                    CMAKE_BUILD_TYPE: Release
+            - run:
                 name: Install clang
                 command: |
                     sudo apt-get install clang
                     sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
-            - run:
-                name: Release build llvm
-                command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Release
             - run:
                 name: Debug build llvm
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
                     FLAGS: -Wall -Wextra -Werror -fsanitize=signed-integer-overflow,address,undefined
+            - run:
+                name: Release build llvm
+                command: ./ci/run_travis_commands.sh
+                environment:
+                    CMAKE_BUILD_TYPE: Release
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Wextra -Werror -Werror=sign-compare -Wunused-lambda-capture -fsanitize=signed-integer-overflow
+                    FLAGS: -Wall -Wextra -Werror
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-7 gmp-devel libedit-devel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
             environment:
                 CMAKE_BUILD_TYPE: Release
                 FLAGS: -Wall -Wextra -Werror
-                INSTALL: ~/osmt-install
+                OSMT_INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
         steps:
@@ -80,7 +80,7 @@ jobs:
               environment:
                 CMAKE_BUILD_TYPE: Release
                 FLAGS: -Wall -Wextra -Werror
-                INSTALL: ~/osmt-install
+                OSMT_INSTALL: ~/osmt-install
                 USE_READLINE: OFF
 
         steps:
@@ -145,7 +145,7 @@ jobs:
                 environment:
                     CMAKE_BUILD_TYPE: Release
                     FLAGS: -Wall -Wextra -Werror
-                    INSTALL: ~/osmt-install
+                    OSMT_INSTALL: ~/osmt-install
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
                 name: install model validation environment
                 command: ./regression_models/bin/setup-env.sh
             - run:
-                name: Create the build directory
-                command: mkdir build
-            - run:
                 name: Release build gcc
                 command: ./ci/run_travis_commands.sh
                 environment:
@@ -37,11 +34,6 @@ jobs:
                 environment:
                     CMAKE_BUILD_TYPE: Debug
                     ENABLE_LINE_EDITING: ON
-            - run:
-                name: Clean build directory
-                command: |
-                    rm -rf build
-                    mkdir build
             - run:
                 name: Install clang
                 command: |
@@ -109,9 +101,6 @@ jobs:
             - run:
                 name: Set up model validation environment
                 command: echo 'bash ./regression_models/bin/setup-env.sh' |scl enable devtoolset-8 bash
-            - run:
-                name: Create the build directory
-                command: mkdir build
             - run:
                 name: Debug build gcc under devtoolset-8
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,8 @@ jobs:
                     yum -y install gmp-devel
                     yum -y install libedit-devel
                     yum -y install bison
-                    yum -y install flex
                     yum -y install git
+                    yum -y install wget
                     yum -y install rh-python38
                     yum -y install python3-pip
                     yum -y install zlib-devel
@@ -110,6 +110,17 @@ jobs:
                 name: Compile cmake-3.12.3 under devtoolset-8
                 command: |
                     echo "cd ~/cmake-3.12.3; ./bootstrap --prefix=/usr/local; gmake -j4; make install" |scl enable devtoolset-8 bash
+            - run:
+                name: Set up newer version of flex
+                command: |
+                    cd ~
+                    wget --no-verbose "https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz"
+                    tar -xvzf flex-2.6.4.tar.gz
+                    cd flex-2.6.4
+                    echo "./configure --prefix=/usr/local; make -j4; make install" | scl enable devtoolset-8 bash
+                    cd ..
+                    rm -rf flex-*
+                    flex --version
             - checkout
             - run:
                 name: Set up model validation environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,15 +62,6 @@ jobs:
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel
     #  - scl enable devtoolset-8 bash
-    #  - curl https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz > cmake-3.12.3.tar.gz
-    #  - tar zxf cmake-3.12.3.tar.gz
-    #  - cd cmake-3.12.3
-    #  - ./bootstrap --prefix=/usr/local
-    #  - gmake -j4
-    #  - make install
-    #  - yum install gmp-devel
-    #  - yum install libedit-devel
-    #  - make -j4
     build-starexec:
         docker:
             - image: centos:7
@@ -101,15 +92,8 @@ jobs:
                     echo "pip3 install pyinstaller" |scl enable devtoolset-8 bash
                     yum -y install Cython
             - run:
-                name: Fetch cmake-3.12.3
-                command: |
-                    cd
-                    curl https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz > cmake-3.12.3.tar.gz
-                    tar zxf cmake-3.12.3.tar.gz
-            - run:
-                name: Compile cmake-3.12.3 under devtoolset-8
-                command: |
-                    echo "cd ~/cmake-3.12.3; ./bootstrap --prefix=/usr/local; gmake -j4; make install" |scl enable devtoolset-8 bash
+                name: Set up newer version of cmake
+                command: pip3 install cmake
             - run:
                 name: Set up newer version of flex
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                 command: ./ci/run_travis_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Wextra -Werror
+                    FLAGS: -Wall -Wextra -Werror -fsanitize=signed-integer-overflow,address,undefined
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
                     FLAGS: -Wall -Wextra -Werror
 
     # To set up the centos-7 environment:
-    #  - yum install centos-release-scl devtoolset-7 gmp-devel libedit-devel
-    #  - scl enable devtoolset-7 bash
+    #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel
+    #  - scl enable devtoolset-8 bash
     #  - curl https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz > cmake-3.12.3.tar.gz
     #  - tar zxf cmake-3.12.3.tar.gz
     #  - cd cmake-3.12.3
@@ -88,7 +88,7 @@ jobs:
                 name: Install the environment
                 command: |
                     yum -y install centos-release-scl
-                    yum -y install devtoolset-7
+                    yum -y install devtoolset-8
                     yum -y install gmp-devel
                     yum -y install libedit-devel
                     yum -y install bison
@@ -98,7 +98,7 @@ jobs:
                     yum -y install python3-pip
                     yum -y install zlib-devel
                     pip3 install wheel
-                    echo "pip3 install pyinstaller" |scl enable devtoolset-7 bash
+                    echo "pip3 install pyinstaller" |scl enable devtoolset-8 bash
                     yum -y install Cython
             - run:
                 name: Fetch cmake-3.12.3
@@ -107,20 +107,20 @@ jobs:
                     curl https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz > cmake-3.12.3.tar.gz
                     tar zxf cmake-3.12.3.tar.gz
             - run:
-                name: Compile cmake-3.12.3 under devtoolset-7
+                name: Compile cmake-3.12.3 under devtoolset-8
                 command: |
-                    echo "cd ~/cmake-3.12.3; ./bootstrap --prefix=/usr/local; gmake -j4; make install" |scl enable devtoolset-7 bash
+                    echo "cd ~/cmake-3.12.3; ./bootstrap --prefix=/usr/local; gmake -j4; make install" |scl enable devtoolset-8 bash
             - checkout
             - run:
                 name: Set up model validation environment
-                command: echo 'bash ./regression_models/bin/setup-env.sh' |scl enable devtoolset-7 bash
+                command: echo 'bash ./regression_models/bin/setup-env.sh' |scl enable devtoolset-8 bash
             - run:
                 name: Create the build directory
                 command: mkdir build
             - run:
-                name: Release build gcc under devtoolset-7
+                name: Release build gcc under devtoolset-8
                 command: |
-                    cat ./ci/run_travis_commands.sh |scl enable devtoolset-7 bash
+                    cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash
                 environment:
                     CMAKE_BUILD_TYPE: Release
 

--- a/ci/run_travis_commands.sh
+++ b/ci/run_travis_commands.sh
@@ -29,18 +29,10 @@ if [[ ${CMAKE_BUILD_TYPE} == Debug ]]; then
 fi
 
 cd ../examples && rm -rf build && mkdir -p build && cd build
-if [[ ${CMAKE_BUILD_TYPE} == Debug ]]; then
-    cmake \
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-        -DOpenSMT_DIR=${OSMT_INSTALL} \
-        -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address,undefined \
-        ..
-else
-    cmake \
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-        -DOpenSMT_DIR=${OSMT_INSTALL} \
-        ..
-fi
+cmake \
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DOpenSMT_DIR=${OSMT_INSTALL} \
+    ..
 
 make -j4
 

--- a/ci/run_travis_commands.sh
+++ b/ci/run_travis_commands.sh
@@ -12,7 +12,7 @@ cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DCMAKE_CXX_FLAGS="$FLAGS" \
       -DUSE_READLINE:BOOL=${USE_READLINE} \
       -DENABLE_LINE_EDITING:BOOL=${ENABLE_LINE_EDITING} \
-      -DCMAKE_INSTALL_PREFIX=${INSTALL} \
+      -DCMAKE_INSTALL_PREFIX=${OSMT_INSTALL} \
       -DPACKAGE_BENCHMARKS=${PACKAGE_BENCHMARKS} \
       ${COMPILER_OPTION} \
       ..
@@ -32,13 +32,13 @@ cd ../examples && rm -rf build && mkdir -p build && cd build
 if [[ ${CMAKE_BUILD_TYPE} == Debug ]]; then
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-        -DOpenSMT_DIR=${INSTALL} \
+        -DOpenSMT_DIR=${OSMT_INSTALL} \
         -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address,undefined \
         ..
 else
     cmake \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-        -DOpenSMT_DIR=${INSTALL} \
+        -DOpenSMT_DIR=${OSMT_INSTALL} \
         ..
 fi
 

--- a/ci/run_travis_commands.sh
+++ b/ci/run_travis_commands.sh
@@ -10,7 +10,7 @@ if [ ! -z ${CMAKE_CXX_COMPILER} ]; then
 fi
 
 cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-      -DCMAKE_CXX_FLAGS="$FLAGS" \
+      -DCMAKE_CXX_FLAGS="${FLAGS}" \
       -DUSE_READLINE:BOOL=${USE_READLINE} \
       -DENABLE_LINE_EDITING:BOOL=${ENABLE_LINE_EDITING} \
       -DCMAKE_INSTALL_PREFIX=${OSMT_INSTALL} \
@@ -32,6 +32,7 @@ fi
 cd ../examples && rm -rf build && mkdir -p build && cd build
 cmake \
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DCMAKE_CXX_FLAGS="${FLAGS}" \
     -DOpenSMT_DIR=${OSMT_INSTALL} \
     ..
 

--- a/ci/run_travis_commands.sh
+++ b/ci/run_travis_commands.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -ev
+if [ -d build ]; then rm -rf build; fi
 mkdir -p build
 cd build
 

--- a/regression_models/bin/run-and-validate.sh
+++ b/regression_models/bin/run-and-validate.sh
@@ -94,7 +94,6 @@ ${scrambler} -seed "0" -gen-model-val true < $1 2>&1 > ${tmpin} \
 
 sh -c "\
     ulimit -St 10;
-    ulimit -Sv 4000000
     ${binary} ${tmpin}" \
         > ${tmpout} 2>/dev/null
 
@@ -110,7 +109,7 @@ if [[ $(grep '^sat' ${tmpout}) ]]; then
         exit 1
     fi
 else
-    echo "Not satisfiable: $1"
+    echo "Not shown satisfiable: $1"
     exit 1
 fi
 


### PR DESCRIPTION
This include the following changes:

CentOS specific:
- Use gcc-8 instead of gcc-7 on CentOS
- Add DEBUG build on CentOS
- Build newer version of `flex` manually
- Install newer version of `cmake` instead of compiling it from source

Others:
- Rename environmental variable used `INSTALL` -> `OSMT_INSTALL` (to prevent name clash in `flex` build)
- Use more sanitizers in Clang Debug build
- Create and delete `build` directory in the common script instead of having individual CI steps
