### PR TITLE
Change printing methods to return string instead of char*

### DIFF
--- a/examples/test-bv.cc
+++ b/examples/test-bv.cc
@@ -106,11 +106,10 @@ int main(int argc, char** argv)
         printf("sat\n");
         bbb.computeModel();
         PTRef v = bbb.getValue(d);
-        char * val = logic.pp(v);
+        auto val = logic.pp(v);
         char* bin;
-        opensmt::wordToBinary(atoi(val), bin, bw);
-        printf("%s (%s)\n", val, bin);
-        free(val);
+        opensmt::wordToBinary(atoi(val.c_str()), bin, bw);
+        printf("%s (%s)\n", val.c_str(), bin);
         free(bin);
     }
     else if (r == s_False)

--- a/examples/test-cuf.cc
+++ b/examples/test-cuf.cc
@@ -54,12 +54,7 @@ int main(int argc, char** argv)
     if (r == s_True) {
         printf("sat\n");
         bbb.computeModel();
-        char * val = logic.pp(bbb.getValue(a_bv));
-        printf("%s\n", val);
-        free(val);
-        val = logic.pp(bbb.getValue(a));
-        printf("%s\n", val);
-        free(val);
+        std::cout << logic.pp(bbb.getValue(a_bv)) << '\n' << logic.pp(bbb.getValue(a)) << std::endl;
     }
     else if (r == s_False)
         printf("unsat\n");

--- a/examples/test17_ex2CADE_CUF.cc
+++ b/examples/test17_ex2CADE_CUF.cc
@@ -122,29 +122,17 @@ int main()
 
     auto m = mainSolver.getModel();
 
-    char * v_a = logic.pp(m->evaluate(a));
-    std::cout << v_a << "\n";
-    free(v_a);
+    std::cout << logic.pp(m->evaluate(a)) << "\n";
 
-    char * v_b = logic.pp(m->evaluate(b));
-    std::cout << v_b << "\n";
-    free(v_b);
+    std::cout << logic.pp(m->evaluate(b)) << "\n";
 
-    char * v_c1 = logic.pp(m->evaluate(c1));
-    std::cout << v_c1 << "\n";
-    free(v_c1);
+    std::cout << logic.pp(m->evaluate(c1)) << "\n";
 
-    char * v_c2 = logic.pp(m->evaluate(c2));
-	std::cout << v_c2 << "\n";
-    free(v_c2);
+	std::cout << logic.pp(m->evaluate(c2)) << "\n";
 
-	char * v_d = logic.pp(m->evaluate(d));
-	std::cout << v_d << "\n";
-	free(v_d);
+	std::cout << logic.pp(m->evaluate(d)) << "\n";
 
-	char * v_dp = logic.pp(m->evaluate(d_p));
-	std::cout << v_dp << "\n";
-	free(v_dp);
+	std::cout << logic.pp(m->evaluate(d_p)) << "\n";
 
     if (r == s_True)
         printf("sat\n");

--- a/examples/test18_ex2CADE_glue_BV-CUF.cc
+++ b/examples/test18_ex2CADE_glue_BV-CUF.cc
@@ -19,11 +19,9 @@ assert(d == d_p);                           //assert ((d != d_p ) = 1)
 
 void printValue(PTRef tr, std::unique_ptr<Model> & m, const Logic & l)
 {
-    char* name = l.pp(tr);
-    char* value = l.pp(m->evaluate(tr));
+    auto name = l.pp(tr);
+    auto value = l.pp(m->evaluate(tr));
     std::cout << name << " "  << value << "\n";
-    free(name);
-    free(value);
 }
 
 int main()

--- a/examples/test2.cc
+++ b/examples/test2.cc
@@ -31,17 +31,13 @@ int main()
     if (r == s_True) {
         printf("sat\n");
         auto m = mainSolver.getModel();
-        char * v1_p = logic.pp(m->evaluate(v1));
-        char * v2_p = logic.pp(m->evaluate(v2));
-        char* var_a_s = logic.pp(v1);
-        char* var_b_s = logic.pp(v2);
+        auto v1_p = logic.pp(m->evaluate(v1));
+        auto v2_p = logic.pp(m->evaluate(v2));
+        auto var_a_s = logic.pp(v1);
+        auto var_b_s = logic.pp(v2);
 
-        printf("var %s has value %s\n", var_a_s, v1_p);
-        printf("var %s has value %s\n", var_b_s, v2_p);
-        free(var_a_s);
-        free(var_b_s);
-        free(v1_p);
-        free(v2_p);
+        printf("var %s has value %s\n", var_a_s.c_str(), v1_p.c_str());
+        printf("var %s has value %s\n", var_b_s.c_str(), v2_p.c_str());
     }
     else if (r == s_False)
         printf("unsat\n");

--- a/examples/test_lra_value.cc
+++ b/examples/test_lra_value.cc
@@ -70,29 +70,21 @@ int main()
         printf("sat\n");
         auto m = mainSolver.getModel();
         PTRef v1 = m->evaluate(x1);
-        char* name = logic.pp(x1);
-        char* value = logic.pp(v1);
-        printf("%s: %s\n", name, value);
-        free(name);
-        free(value);
+        auto name = logic.pp(x1);
+        auto value = logic.pp(v1);
+        std::cout << name << ": " << value << '\n';
         PTRef v2 = m->evaluate(x2);
         name = logic.pp(x2);
         value = logic.pp(v2);
-        printf("%s: %s\n", name, value);
-        free(name);
-        free(value);
+        std::cout << name << ": " << value << '\n';
         PTRef v3 = m->evaluate(x3);
         name = logic.pp(x3);
         value = logic.pp(v3);
-        printf("%s: %s\n", name, value);
-        free(name);
-        free(value);
+        std::cout << name << ": " << value << '\n';
         PTRef v4 = m->evaluate(x4);
         name = logic.printTerm(x4);
         value = logic.printTerm(v4);
-        printf("%s: %s\n", name, value);
-        free(name);
-        free(value);
+        std::cout << name << ": " << value << '\n';
     }
     else if (r == s_False)
     {

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -796,15 +796,11 @@ std::string Interpret::printDefinitionSmtlib(const TemplateFunction & templateFu
     ss << "  (define-fun " << templateFun.getName() << " (";
     const vec<PTRef>& args = templateFun.getArgs();
     for (int i = 0; i < args.size(); i++) {
-        char* tmp = logic->pp(args[i]);
         auto sortString = logic->printSort(logic->getSortRef(args[i]));
-        ss << "(" << tmp << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");
-        free(tmp);
+        ss << "(" << logic->pp(args[i]) << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");
     }
     ss << ")" << " " << logic->printSort(templateFun.getRetSort()) << "\n";
-    char* tmp = logic->pp(templateFun.getBody());
-    ss << "    " << tmp << ")\n";
-    free(tmp);
+    ss << "    " << logic->pp(templateFun.getBody()) << ")\n";
     return ss.str();
 }
 
@@ -1292,10 +1288,9 @@ void Interpret::getInterpolants(const ASTNode& n)
     }
 
     for (int j = 0; j < itps.size(); j++) {
-        char * itp = logic->pp(itps[j]);
+        auto itp = logic->pp(itps[j]);
         notify_formatted(false, "%s%s%s",
-                         (j == 0 ? "(" : " "), itp, (j == itps.size() - 1 ? ")" : ""));
-        free(itp);
+                         (j == 0 ? "(" : " "), itp.c_str(), (j == itps.size() - 1 ? ")" : ""));
     }
 }
 

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -782,7 +782,7 @@ void Interpret::getModel() {
  */
 std::string Interpret::printDefinitionSmtlib(PTRef tr, PTRef val) {
     std::stringstream ss;
-    const char *s = logic->protectName(logic->getSymName(tr));
+    auto s = logic->protectName(logic->getSymName(tr));
     SRef sortRef = logic->getSym(tr).rsort();
     ss << "  (define-fun " << s << " () " << logic->printSort(sortRef) << '\n';
     char* val_string = logic->printTerm(val);

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -443,7 +443,8 @@ PTRef ArithLogic::mkTimes(vec<PTRef> && args)
     if (isNumTerm(tr) || isPlus(tr) || isUF(tr) || isIte(tr))
         return tr;
     else {
-        throw LANonLinearException(printTerm(tr));
+        auto termStr = pp(tr);
+        throw LANonLinearException(termStr.c_str());
     }
 }
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -114,7 +114,7 @@ bool Logic::isBuiltinFunction(const SymRef sr) const
 // Escape the symbol name if it contains a prohibited character from the
 // list defined by the quotable[] table below
 //
-bool Logic::hasQuotableChars(const char* name) const
+bool Logic::hasQuotableChars(std::string const & name) const
 {
     // Entry is 1 if the corresponding ascii character requires quoting
     const bool quotable[256] =
@@ -165,7 +165,7 @@ bool Logic::hasQuotableChars(const char* name) const
 //
 // Quote the name if it contains illegal characters
 //
-std::string Logic::protectName(const char* name) const
+std::string Logic::protectName(std::string const & name) const
 {
     if (hasQuotableChars(name)) {
         std::stringstream ss;

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -145,21 +145,14 @@ bool Logic::hasQuotableChars(std::string const & name) const
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     };
-    bool quoted = false;
-    bool escape = false;
-    char first = name[0];
-    char last;
-    for (int i = 0; name[i] != '\0'; i++)
-    {
-        if (quotable[(int)name[i]])
-            escape = true;
-        last = name[i];
+
+    if (name.front() == '|' and name.back() == '|') return false; // Already quoted
+
+    for (auto c : name) {
+        if (quotable[(int)c])
+            return true;
     }
-    quoted = (first == '|') && (last == '|');
-    if (!quoted && escape)
-        return true;
-    else
-        return false;
+    return false;
 }
 
 //

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -181,14 +181,13 @@ Logic::printSym(SymRef sr) const
     return protectName(sym_store.getName(sr));
 }
 
-char*
-Logic::pp(PTRef tr) const
-{
-    char* out;
 
+std::string Logic::pp(PTRef tr) const {
     const Pterm& t = getPterm(tr);
     SymRef sr = t.symb();
-    std::string name_escaped = printSym(sr);
+    char * tmp = printSym(sr);
+    std::string name_escaped = tmp;
+    free(tmp);
 
     if (t.size() == 0) {
         std::stringstream ss;
@@ -200,8 +199,7 @@ Logic::pp(PTRef tr) const
 #ifdef PARTITION_PRETTYPRINT
         ss << " [" << getIPartitions(tr) << ' ]';
 #endif
-        out = strdup(ss.str().c_str());
-        return out;
+        return ss.str();
     }
 
     // Here we know that t.size() > 0
@@ -219,8 +217,7 @@ Logic::pp(PTRef tr) const
 #ifdef PARTITION_PRETTYPRINT
     ss << " [" << getIPartitions(tr) << ']';
 #endif
-    out = strdup(ss.str().c_str());
-    return out;
+    return ss.str();
 }
 
 char*

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -396,15 +396,15 @@ public:
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 
 
-    bool       hasQuotableChars(const char* name) const;
-    char*      protectName(const char* name) const;
-    char*      protectName(const std::string& name) const { return protectName(name.c_str()); };
+    bool          hasQuotableChars(const char* name) const;
+    std::string   protectName(const char* name) const;
+    std::string   protectName(const std::string& name) const { return protectName(name.c_str()); };
     virtual char* printTerm_       (PTRef tr, bool l, bool s) const;
     virtual char* printTerm        (PTRef tr)                 const;// { return printTerm_(tr, false, false); }
     virtual char* printTerm        (PTRef tr, bool l, bool s) const ;//{ return printTerm_(tr, l, s); }
     std::string pp(PTRef tr) const; // A pretty printer
 
-    char*       printSym           (SymRef sr) const;
+    std::string   printSym          (SymRef sr) const;
     virtual void termSort(vec<PTRef>& v) const;// { sort(v, LessThan_PTRef()); }
 
     void  purify           (PTRef r, PTRef& p, lbool& sgn) const;//{p = r; sgn = l_True; while (isNot(p)) { sgn = sgn^1; p = getPterm(p)[0]; }}

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -396,9 +396,8 @@ public:
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 
 
-    bool          hasQuotableChars(const char* name) const;
-    std::string   protectName(const char* name) const;
-    std::string   protectName(const std::string& name) const { return protectName(name.c_str()); };
+    bool          hasQuotableChars(std::string const & name) const;
+    std::string   protectName(const std::string& name) const;
     virtual char* printTerm_       (PTRef tr, bool l, bool s) const;
     virtual char* printTerm        (PTRef tr)                 const;// { return printTerm_(tr, false, false); }
     virtual char* printTerm        (PTRef tr, bool l, bool s) const ;//{ return printTerm_(tr, l, s); }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -402,7 +402,8 @@ public:
     virtual char* printTerm_       (PTRef tr, bool l, bool s) const;
     virtual char* printTerm        (PTRef tr)                 const;// { return printTerm_(tr, false, false); }
     virtual char* printTerm        (PTRef tr, bool l, bool s) const ;//{ return printTerm_(tr, l, s); }
-    virtual char* pp(PTRef tr) const; // A pretty printer
+    std::string pp(PTRef tr) const; // A pretty printer
+
     char*       printSym           (SymRef sr) const;
     virtual void termSort(vec<PTRef>& v) const;// { sort(v, LessThan_PTRef()); }
 

--- a/src/logics/SubstLoopBreaker.cc
+++ b/src/logics/SubstLoopBreaker.cc
@@ -283,9 +283,7 @@ std::string SubstLoopBreaker::printGraphAndLoops(const vec<SNRef> &startNodes, c
 
     ss << "digraph foo {\n";
     for (int i = 0; i < startNodes.size(); i++) {
-        char *n = logic.pp(sna[startNodes[i]].getTr());
-        ss << "  " << n << " [shape=box]\n";
-        free(n);
+        ss << "  " << logic.pp(sna[startNodes[i]].getTr()) << " [shape=box]\n";
     }
 
     Map<PTRef,bool,PTRefHash> seen;
@@ -304,11 +302,7 @@ std::string SubstLoopBreaker::printGraphAndLoops(const vec<SNRef> &startNodes, c
             for (int j = 0; j < sna[n].nChildren(); j++) {
                 SNRef sn = sna[n][j];
                 if (sn != SNRef_Undef) {
-                    char *in = logic.pp(sna[n].getTr());
-                    char *out = logic.pp(sna[sn].getTr());
-                    ss << "  " << in << " -> " << out << ";\n";
-                    free(in);
-                    free(out);
+                    ss << "  " << logic.pp(sna[n].getTr()) << " -> " << logic.pp(sna[sn].getTr()) << ";\n";
                     queue.push(sn);
                 }
             }
@@ -316,20 +310,14 @@ std::string SubstLoopBreaker::printGraphAndLoops(const vec<SNRef> &startNodes, c
     }
     for (const auto & loop : loops) {
         for (int j = 0; j < loop.size()-1; j++) {
-            char *in = logic.pp(sna[loop[j]].getTr());
-            char *out = logic.pp(sna[loop[(j + 1)]].getTr());
-            ss << "  " << in << " -> " << out << " [style=dotted];\n";
-            free(in);
-            free(out);
+            ss << "  " << logic.pp(sna[loop[j]].getTr()) << " -> " << logic.pp(sna[loop[(j + 1)]].getTr()) << " [style=dotted];\n";
         }
         SNRef last = loop[loop.size()-1];
-        char* in = logic.pp(sna[last].getTr());
+        auto in = logic.pp(sna[last].getTr());
         for (int j = 0; j < sna[last].nChildren(); j++) {
-            char* out = logic.pp(sna[sna[last][j]].getTr());
+            auto out = logic.pp(sna[sna[last][j]].getTr());
             ss << "  " << in << " -> " << out << " [style=dashed];\n";
-            free(out);
         }
-        free(in);
     }
     ss << "}";
     return ss.str();

--- a/src/tsolvers/lasolver/Matrix.cc
+++ b/src/tsolvers/lasolver/Matrix.cc
@@ -1026,8 +1026,7 @@ LAMatrixStore::discretize(const LAVecRef v)
     return v_r;
 }
 
-char*
-LAMatrixStore::print(MId A)
+std::string LAMatrixStore::print(MId A)
 {
     int nRows = operator[](A).nRows();
     int nCols = operator[](A).nCols();
@@ -1053,5 +1052,7 @@ LAMatrixStore::print(MId A)
     int res = asprintf(&buf_new, "[%s]", buf);
     assert(res >= 0); (void)res;
     free(buf);
-    return buf_new;
+    std::string ret = buf_new;
+    free(buf_new);
+    return ret;
 }

--- a/src/tsolvers/lasolver/Matrix.h
+++ b/src/tsolvers/lasolver/Matrix.h
@@ -194,7 +194,7 @@ public:
     MId mul_matrix        (MId A, MId B);
     LAVecRef discretize   (LAVecRef v); // compute [v], i.e., round up or down to closest integer
 
-    char* print(MId A);
+    std::string print(MId A);
 };
 
 

--- a/test/unit/test_HNF.cc
+++ b/test/unit/test_HNF.cc
@@ -44,7 +44,7 @@ TEST_F(HNF_test, test_hnf1)
     MId V1 = MId_Undef;
 
     ms.compute_hnf_v1(U, H, dim, U1, V1);
-    printf("The hnf matrix:\n%s\n", ms.print(H));
+    printf("The hnf matrix:\n%s\n", ms.print(H).c_str());
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)

--- a/test/unit/test_LIAInterpolation.cc
+++ b/test/unit/test_LIAInterpolation.cc
@@ -43,13 +43,13 @@ TEST_F(LIAInterpolationTest, test_InterpolationLRASat){
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_B}};
     LIAInterpolator interpolator(logic, LAExplanations::getLIAExplanation(logic, conflict, {1,1}, labels));
     PTRef farkasItp = interpolator.getFarkasInterpolant();
-    std::cout << logic.printTerm(farkasItp) << std::endl;
+    std::cout << logic.pp(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(leq1, leq2, farkasItp));
     PTRef dualFarkasItp = interpolator.getDualFarkasInterpolant();
-    std::cout << logic.printTerm(dualFarkasItp) << std::endl;
+    std::cout << logic.pp(dualFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(leq1, leq2, dualFarkasItp));
     PTRef halfFarkasItp = interpolator.getFlexibleInterpolant(FastRational(1,2));
-    std::cout << logic.printTerm(halfFarkasItp) << std::endl;
+    std::cout << logic.pp(halfFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(leq1, leq2, halfFarkasItp));
 }
 
@@ -81,11 +81,11 @@ TEST_F(LIAInterpolationTest, test_DecompositionInLIA){
     LIAInterpolator interpolator(logic, LAExplanations::getLIAExplanation(logic, std::move(conflict), {2,1,1,1,1,2}, labels));
     PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), decomposedFarkasItp));
-    std::cout << logic.printTerm(decomposedFarkasItp) << std::endl;
+    std::cout << logic.pp(decomposedFarkasItp) << std::endl;
     ASSERT_TRUE(logic.isAnd(decomposedFarkasItp));
     PTRef dualDecomposedFarkasItp = interpolator.getDualDecomposedInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), dualDecomposedFarkasItp));
-//    std::cout << logic.printTerm(dualDecomposedFarkasItp) << std::endl;
+//    std::cout << logic.pp(dualDecomposedFarkasItp) << std::endl;
 }
 
 TEST_F(LIAInterpolationTest, test_Split_ALocal){
@@ -118,7 +118,7 @@ TEST_F(LIAInterpolationTest, test_Split_ALocal){
     ipartitions_t mask;
     setbit(mask, 0);
     itpCtx->getSingleInterpolant(interpolants, mask);
-    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+    std::cout << logic.pp(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(partA, partB, interpolants[0]));
 }
 
@@ -152,7 +152,7 @@ TEST_F(LIAInterpolationTest, test_Split_BLocal){
     ipartitions_t mask;
     setbit(mask, 0);
     itpCtx->getSingleInterpolant(interpolants, mask);
-    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+    std::cout << logic.pp(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(partA, partB, interpolants[0]));
 }
 
@@ -186,17 +186,17 @@ TEST_F(LIAInterpolationTest, test_Split_ABShared) {
     ipartitions_t mask;
     setbit(mask, 0);
     itpCtx->getSingleInterpolant(interpolants, mask);
-    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+    std::cout << logic.pp(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(partA, partB, interpolants[0]));
     interpolants.clear();
     config.setBooleanInterpolationAlgorithm(itp_alg_pudlak);
     itpCtx->getSingleInterpolant(interpolants, mask);
-    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+    std::cout << logic.pp(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(partA, partB, interpolants[0]));
     interpolants.clear();
     config.setBooleanInterpolationAlgorithm(itp_alg_mcmillanp);
     itpCtx->getSingleInterpolant(interpolants, mask);
-    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+    std::cout << logic.pp(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(partA, partB, interpolants[0]));
     interpolants.clear();
 }

--- a/test/unit/test_LRAInterpolation.cc
+++ b/test/unit/test_LRAInterpolation.cc
@@ -45,13 +45,13 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothNonstrict){
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
-//    std::cout << logic.printTerm(farkasItp) << std::endl;
+//    std::cout << logic.pp(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
     PTRef dualFarkasItp = interpolator.getDualFarkasInterpolant();
-//    std::cout << logic.printTerm(dualFarkasItp) << std::endl;
+//    std::cout << logic.pp(dualFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), dualFarkasItp));
     PTRef halfFarkasItp = interpolator.getFlexibleInterpolant(FastRational(1,2));
-//    std::cout << logic.printTerm(halfFarkasItp) << std::endl;
+//    std::cout << logic.pp(halfFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), halfFarkasItp));
 }
 
@@ -73,13 +73,13 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Astrict){
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
-//    std::cout << logic.printTerm(farkasItp) << std::endl;
+//    std::cout << logic.pp(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
     PTRef dualFarkasItp = interpolator.getDualFarkasInterpolant();
-//    std::cout << logic.printTerm(dualFarkasItp) << std::endl;
+//    std::cout << logic.pp(dualFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), dualFarkasItp));
     PTRef halfFarkasItp = interpolator.getFlexibleInterpolant(FastRational(1,2));
-//    std::cout << logic.printTerm(halfFarkasItp) << std::endl;
+//    std::cout << logic.pp(halfFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), halfFarkasItp));
 }
 
@@ -101,13 +101,13 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Bstrict){
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
-//    std::cout << logic.printTerm(farkasItp) << std::endl;
+//    std::cout << logic.pp(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
     PTRef dualFarkasItp = interpolator.getDualFarkasInterpolant();
-//    std::cout << logic.printTerm(dualFarkasItp) << std::endl;
+//    std::cout << logic.pp(dualFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), dualFarkasItp));
     PTRef halfFarkasItp = interpolator.getFlexibleInterpolant(FastRational(1,2));
-//    std::cout << logic.printTerm(halfFarkasItp) << std::endl;
+//    std::cout << logic.pp(halfFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), halfFarkasItp));
 }
 
@@ -129,13 +129,13 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothStrict){
     std::map<PTRef, icolor_t> labels {{conflict[0].tr, I_A}, {conflict[1].tr, I_A}, {conflict[2].tr, I_B}, {conflict[3].tr, I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
-    std::cout << logic.printTerm(farkasItp) << std::endl;
+    std::cout << logic.pp(farkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), farkasItp));
     PTRef dualFarkasItp = interpolator.getDualFarkasInterpolant();
-    std::cout << logic.printTerm(dualFarkasItp) << std::endl;
+    std::cout << logic.pp(dualFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), dualFarkasItp));
     PTRef halfFarkasItp = interpolator.getFlexibleInterpolant(FastRational(1,2));
-    std::cout << logic.printTerm(halfFarkasItp) << std::endl;
+    std::cout << logic.pp(halfFarkasItp) << std::endl;
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd(leq1, leq2), logic.mkAnd(leq3, leq4), halfFarkasItp));
 }
 
@@ -267,5 +267,5 @@ TEST_F(LRAInterpolationTest, test_Decomposition_Strict){
     EXPECT_EQ(decomposedFarkasItp, logic.mkAnd(logic.mkLt(zero, x2), logic.mkLeq(zero, logic.mkNeg(x3))));
     PTRef dualDecomposedFarkasItp = interpolator.getDualDecomposedInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3}), logic.mkAnd({leq4, leq5, leq6}), dualDecomposedFarkasItp));
-//    std::cout << logic.printTerm(dualDecomposedFarkasItp) << std::endl;
+//    std::cout << logic.pp(dualDecomposedFarkasItp) << std::endl;
 }

--- a/test/unit/test_Matrix.cc
+++ b/test/unit/test_Matrix.cc
@@ -192,7 +192,7 @@ TEST(Matrix_test, smith_matrix1) {
     int dim;
 
     ms.compute_snf(U, S, dim, L, Li, R, Ri);
-    printf("The snf matrix:\n%s\n", ms.print(S));
+    printf("The snf matrix:\n%s\n", ms.print(S).c_str());
     int diag[] = {2, 6, 12};
      for (int i = 1; i <= 3; i++) {
          for (int j = 1; j <= 3; j++) {
@@ -246,7 +246,7 @@ TEST(Matrix_test, smith_matrix111) {
     int dim;
 
     ms.compute_snf(U, S, dim, L, Li, R, Ri);
-    printf("The snf matrix:\n%s\n", ms.print(S));
+    printf("The snf matrix:\n%s\n", ms.print(S).c_str());
     int diag[] = {1, 3, 21, 0};
      for (int i = 1; i <= 4; i++) {
          for (int j = 1; j <= 4; j++) {
@@ -315,7 +315,7 @@ TEST(Matrix_test, smith_matrix2) {
     MId R2i = ms.getNewMatrix(2, 2);
     int dim;
     ms.compute_snf(T, S2, dim, L2, L2i, R2, R2i);
-    printf("snf matrix:\n%s\n", ms.print(S2));
+    printf("snf matrix:\n%s\n", ms.print(S2).c_str());
 }
 
 TEST(Matrix_test, smith_matrix3) {
@@ -353,7 +353,7 @@ TEST(Matrix_test, smith_matrix3) {
     MId R3i = ms.getNewMatrix(1, 1);
     int dim;
     ms.compute_snf(T3, S3, dim, L3, L3i, R3, R3i);
-    printf("snf matrix:\n%s\n", ms.print(S3));
+    printf("snf matrix:\n%s\n", ms.print(S3).c_str());
 }
 
 TEST(Matrix_test, smith_matrix4) {
@@ -375,7 +375,7 @@ TEST(Matrix_test, smith_matrix4) {
     MId R3i = ms.getNewMatrix(1, 1);
     int dim;
     ms.compute_snf(T3, S3, dim, L3, L3i, R3, R3i);
-    printf("snf matrix:\n%s\n", ms.print(S3));
+    printf("snf matrix:\n%s\n", ms.print(S3).c_str());
 }
 
 TEST(Matrix_test, matrix_mult) {
@@ -410,9 +410,7 @@ TEST(Matrix_test, matrix_mult) {
     ms.MM(C, 2, 2) = 5;
     ms.MM(C, 3, 2) = 6;
     MId R2 = ms.mul_matrix(B, C);
-    char* R2_str = ms.print(R2);
-    printf("The matrix:\n%s\n", R2_str);
-    free(R2_str);
+    printf("The matrix:\n%s\n", ms.print(R2).c_str());
     ASSERT_EQ(ms.MM(R2, 1, 1), 22);
     ASSERT_EQ(ms.MM(R2, 2, 1), 28);
     ASSERT_EQ(ms.MM(R2, 1, 2), 49);
@@ -472,9 +470,7 @@ TEST(Matrix_test, non_square)
     ms.MM(U, 2, 2) = 22;
     ms.MM(U, 1, 3) = 13;
     ms.MM(U, 2, 3) = 23;
-    char* m_str = ms.print(U);
-    printf("The matrix:\n%s\n", m_str);
-    free(m_str);
+    printf("The matrix:\n%s\n", ms.print(U).c_str());
 }
 
 TEST(gcd_test, gcd)

--- a/test/unit/test_Model.cc
+++ b/test/unit/test_Model.cc
@@ -182,9 +182,8 @@ protected:
 
 TEST_F(UFConstModelTest, test_constModel) {
     PTRef a_model = getModelFor(a);
-    char * a_model_name = logic.pp(a_model);
-    ASSERT_EQ(strcmp(a_model_name, "a"), 0);
-    free(a_model_name);
+    auto a_model_name = logic.pp(a_model);
+    ASSERT_EQ(strcmp(a_model_name.c_str(), "a"), 0);
     PTRef f_a_model = getModelFor(f_a);
     PTRef x_model = getModelFor(x);
     ASSERT_EQ(f_a_model, x_model);

--- a/test/unit/test_SubstitutionBreaker.cpp
+++ b/test/unit/test_SubstitutionBreaker.cpp
@@ -28,9 +28,7 @@ TEST_F(SubstitutionBreaker, test_getVars) {
     SubstNodeAllocator sna(tvl, logic, 1024);
     SNRef snr = sna.alloc(a, f1);
     for (int i = 0; i < sna[snr].nChildren(); i++) {
-        char *n = logic.pp(sna[snr].getChildTerm(i));
-        std::cerr << n << " \n";
-        free(n);
+        std::cerr << logic.pp(sna[snr].getChildTerm(i)) << " \n";
     }
     ASSERT_EQ(sna[snr].nChildren(), 3);
 }


### PR DESCRIPTION
This prevents memory leaks when the caller does not free the received char*. 
It also makes the methods easier to use.