### PR TITLE
UFInterpolator: Fix memory leak and cleanup

### DIFF
--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -75,6 +75,7 @@ CGraph::removeCEdge(CEdge * e) {
     if (e == nullptr) return;
     for (std::size_t i = 0; i < cedges.size(); ++i) {
         if (cedges[i] == e) {
+            delete e;
             cedges.erase(cedges.begin() + i);
             break;
         }

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -311,7 +311,7 @@ PTRef
 UFInterpolator::getInterpolant(const ipartitions_t & mask, std::map<PTRef, icolor_t> * labels, PartitionManager & pmanager) {
     assert(labels);
     if (labels) {
-        colorInfo.reset(new GlobalTermColorInfo(pmanager, mask));
+        colorInfo = std::make_unique<GlobalTermColorInfo>(pmanager, mask);
         litColors = *labels;
     } else {
         throw OsmtInternalException("Error in UFInterpolator::getInterpolant! No labels passed");

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -124,7 +124,7 @@ bool UFInterpolator::colorEdges(CNode * c1, CNode * c2) {
     std::set<path_t> cache_nodes;
     std::set<CEdge *> cache_edges;
     std::vector<path_t> unprocessed_nodes;
-    unprocessed_nodes.emplace_back(path_t{c1, c2});
+    unprocessed_nodes.emplace_back(c1, c2);
     bool no_mixed = true;
     while (!unprocessed_nodes.empty() && no_mixed) {
         auto node_pair = unprocessed_nodes.back();
@@ -160,7 +160,7 @@ bool UFInterpolator::colorEdges(CNode * c1, CNode * c2) {
                         // Push only unprocessed paths
                         path_t next_pair {arg_n1, arg_n2};
                         if (cache_nodes.find(next_pair) == cache_nodes.end()) {
-                            unprocessed_nodes.emplace_back(next_pair);
+                            unprocessed_nodes.push_back(next_pair);
                             unprocessed_children = true;
                         }
                     }

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -352,7 +352,7 @@ UFInterpolator::getInterpolant(const ipartitions_t & mask, std::map<PTRef, icolo
     assert (conf_color == I_A || conf_color == I_B);
 
     PTRef result = PTRef_Undef;
-    path_t pi = path(c1, c2);
+    const path_t pi = path(c1, c2);
 
     //
     // Compute interpolant as described in Fuchs et al. paper
@@ -1177,7 +1177,7 @@ void UFInterpolator::printAsDotty(ostream & os) {
     os << "}" << endl;
 }
 
-bool UFInterpolator::checkColors() {
+bool UFInterpolator::checkColors() const {
     for (CEdge * edge : cgraph.getEdges()) {
         // Edge that is not involved
         if (edge->color == I_UNDEF)

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -86,8 +86,8 @@ class CGraph {
     void clear();
 
 public:
-    std::vector<CNode *> const & getNodes() { return cnodes; }
-    std::vector<CEdge *> const & getEdges() { return cedges; }
+    std::vector<CNode *> const & getNodes() const { return cnodes; }
+    std::vector<CEdge *> const & getEdges() const { return cedges; }
     bool hasNode(PTRef term) const { return cnodes_store.find(term) != cnodes_store.end(); }
     CNode * getNode(PTRef term) const { return cnodes_store.at(term); }
 
@@ -121,7 +121,7 @@ public:
 
     inline int verbose() const { return config.verbosity(); }
 
-    PTRef getInterpolant(const ipartitions_t &, std::map<PTRef, icolor_t> *, PartitionManager &);
+    PTRef getInterpolant(const ipartitions_t &, std::map<PTRef, icolor_t> *, PartitionManager &) override;
 
     void printAsDotty(ostream &);
 
@@ -177,7 +177,7 @@ private:
 
     inline path_t path(CNode * c1, CNode * c2) { return make_pair(c1, c2); }
 
-    bool checkColors();
+    bool checkColors() const;
 
     SMTConfig & config;
     Logic & logic;

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -58,7 +58,6 @@ struct CNode {
     PTRef e;
     icolor_t color;
     CEdge * next;
-    std::set<CEdge *> prev;
 };
 
 typedef std::pair<CNode *, CNode *> path_t;
@@ -99,14 +98,14 @@ public:
     void removeCEdge(CEdge *);
 
     CNode* getConflictStart() const { assert(conf1 != PTRef_Undef); return cnodes_store.at(conf1); }
-    CNode* getConflictEnd()   const { assert(conf1 != PTRef_Undef); return cnodes_store.at(conf2); }
+    CNode* getConflictEnd()   const { assert(conf2 != PTRef_Undef); return cnodes_store.at(conf2); }
 
-    inline void setConf( PTRef c1, PTRef c2) {
+    inline void setConf(PTRef c1, PTRef c2) {
 //      cout << "SetConf: " << logic.printTerm(c1) << " = " << logic.printTerm(c2) << endl;
-        assert( conf1 == PTRef_Undef );
-        assert( conf2 == PTRef_Undef );
-        assert( c1 != PTRef_Undef);
-        assert( c2 != PTRef_Undef);
+        assert(conf1 == PTRef_Undef);
+        assert(conf2 == PTRef_Undef);
+        assert(c1 != PTRef_Undef);
+        assert(c2 != PTRef_Undef);
         conf1 = c1;
         conf2 = c2;
     }

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -131,7 +131,7 @@ private:
         return litColors.at(term);
     }
 
-    icolor_t getTermColor (PTRef term) const {
+    icolor_t getTermColor(PTRef term) const {
         assert(colorInfo);
         return colorInfo->getColorFor(term);
     }


### PR DESCRIPTION
`CGraph::edges` is a vector of raw pointers, but it owns the objects.
The objects were correctly deleted when all edges are removed, but not
when a single edge is to be removed.

Later we can come up with a better design, but for now we simply delete the edge
before we remove it from our vector.

I was originally worried that `UFInterpolator` accesses the removed edge after `splitEdge`, but that's not the case, since `splitEdge` correctly sets the new edge for the source node and this new edge is then used. So deleting the edge is fine.

While browsing the code, I noticed a couple of small problems with the code (mostly style), so I am including also a small cleanup here.