### PR TITLE
CoreSMTSolver: Fix possible access to index out of bounds

### DIFF
--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -126,7 +126,7 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
         return cr;
     };
 
-    auto sortedIndices = sortByLastAssignedLevel(splitClauses, [this](Var v) { return vardata[v].level; });
+    auto sortedIndices = sortByLastAssignedLevel(splitClauses, [this](Var v) { return v < nVars() ? vardata[v].level : 0; });
 
     for (int index : sortedIndices) {
         auto & splitClause = splitClauses[index];


### PR DESCRIPTION
Split clauses can contain new literals not known to the SAT solver.
When sorting split clauses, these literals are not yet introduced to the SAT solver, so we need to guard the query to the decision level.