### PR TITLE
Cuts-from-proofs: Use uint32_t for matrix indexes

### DIFF
--- a/src/tsolvers/lasolver/CutCreator.cc
+++ b/src/tsolvers/lasolver/CutCreator.cc
@@ -196,7 +196,7 @@ Representation initFromConstraints(std::vector<CutCreator::DefiningConstaint> co
         }
     };
     std::unordered_map<PTRef, unsigned, PTRefHash> varIndices;
-    std::size_t columns = 0;
+    uint32_t columns = 0;
     // First pass to assign indices and find out number of columns
     for (auto defConstraint : constraints) {
         PTRef poly = defConstraint.lhs;
@@ -210,7 +210,7 @@ Representation initFromConstraints(std::vector<CutCreator::DefiningConstaint> co
         }
     }
 
-    auto rows = constraints.size();
+    auto rows = static_cast<uint32_t>(constraints.size());
     ColMatrix matrixA(RowCount{rows}, ColumnCount{columns});
     std::vector<FastRational> rhs(rows);
     std::vector<Polynomial> columnPolynomials(columns);
@@ -226,7 +226,7 @@ Representation initFromConstraints(std::vector<CutCreator::DefiningConstaint> co
             columnPolynomials[col].addTerm(LVRef{row}, logic.getNumConst(constant));
         }
     }
-    for (std::size_t i = 0; i < columnPolynomials.size(); ++i) {
+    for (uint32_t i = 0; i < columnPolynomials.size(); ++i) {
         matrixA.setColumn(ColIndex{i}, std::move(columnPolynomials[i]));
     }
     // compute the inverse map from column indices to variables

--- a/src/tsolvers/lasolver/CutCreator.cc
+++ b/src/tsolvers/lasolver/CutCreator.cc
@@ -210,7 +210,7 @@ Representation initFromConstraints(std::vector<CutCreator::DefiningConstaint> co
         }
     }
 
-    auto rows = static_cast<uint32_t>(constraints.size());
+    uint32_t rows = constraints.size();
     ColMatrix matrixA(RowCount{rows}, ColumnCount{columns});
     std::vector<FastRational> rhs(rows);
     std::vector<Polynomial> columnPolynomials(columns);

--- a/src/tsolvers/lasolver/CutCreator.h
+++ b/src/tsolvers/lasolver/CutCreator.h
@@ -13,15 +13,15 @@
 #include "Polynomial.h"
 
 struct ColumnCount {
-    std::size_t count;
-    operator std::size_t() const { return count; }
+    uint32_t count;
+    operator uint32_t () const { return count; }
 };
 
 using ColIndex = ColumnCount;
 
 struct RowCount {
-    std::size_t count;
-    operator std::size_t() const { return count; }
+    uint32_t count;
+    operator uint32_t () const { return count; }
 };
 
 using RowIndex = RowCount;
@@ -39,7 +39,7 @@ public:
             this->poly = std::move(_poly);
         }
 
-        std::size_t size() const { return poly.size(); }
+        uint32_t size() const { return poly.size(); }
 
         void negate();
         void add(Col const & other, FastRational const & multiple);
@@ -57,7 +57,7 @@ private:
     RowCount _rowCount;
     ColumnCount _colCount;
     std::vector<Col> cols;
-    std::vector<std::size_t> colPermutation;
+    std::vector<uint32_t> colPermutation;
 
 public:
     explicit ColMatrix(RowCount rowCount, ColumnCount colCount) : _rowCount(rowCount), _colCount{colCount} {
@@ -69,13 +69,13 @@ public:
     ColMatrix(ColMatrix const &) = delete;
     ColMatrix(ColMatrix &&) = default;
 
-    Col &       operator[](std::size_t index)       { return cols[colPermutation[index]]; }
-    Col const & operator[](std::size_t index) const { return cols[colPermutation[index]]; }
+    Col &       operator[](uint32_t index)       { return cols[colPermutation[index]]; }
+    Col const & operator[](uint32_t index) const { return cols[colPermutation[index]]; }
 
-    void swapCols(std::size_t first, std::size_t second) { std::swap(colPermutation[first], colPermutation[second]); }
+    void swapCols(uint32_t first, uint32_t second) { std::swap(colPermutation[first], colPermutation[second]); }
 
-    std::size_t colCount() const { return _colCount; }
-    std::size_t rowCount() const { return _rowCount; }
+    uint32_t colCount() const { return _colCount; }
+    uint32_t rowCount() const { return _rowCount; }
 
     void setColumn(ColIndex colIndex, Polynomial && poly) {
         assert(colIndex < _colCount);


### PR DESCRIPTION
This is what the cuts-from-proofs (after the minor comments) would look like if we used `uint32_t`.