### PR TITLE
Proof: Cleanup of proof building process

### DIFF
--- a/regression_itp/trivial-proof-A.smt2
+++ b/regression_itp/trivial-proof-A.smt2
@@ -1,0 +1,7 @@
+(set-option :produce-interpolants 1)
+(set-logic QF_UF)
+(declare-fun x () Bool)
+(assert (! false :named A))
+(assert (! x :named B))
+(check-sat)
+(get-interpolants A B)

--- a/regression_itp/trivial-proof-B.smt2
+++ b/regression_itp/trivial-proof-B.smt2
@@ -1,0 +1,7 @@
+(set-option :produce-interpolants 1)
+(set-logic QF_UF)
+(declare-fun x () Bool)
+(assert (! x :named A))
+(assert (! false :named B))
+(check-sat)
+(get-interpolants A B)

--- a/src/options/SMTConfig.cc
+++ b/src/options/SMTConfig.cc
@@ -475,7 +475,6 @@ const char* SMTConfig::o_certify_inter = ":certify-interpolants";
 const char* SMTConfig::o_simplify_inter = ":simplify-interpolants";
 const char* SMTConfig::o_interpolant_cnf = ":cnf-interpolants";
 const char* SMTConfig::o_proof_struct_hash       = ":proof-struct-hash";
-const char* SMTConfig::o_proof_struct_hash_build = ":proof-struct-hash-build";
 const char* SMTConfig::o_proof_check   = ":proof-check";
 const char* SMTConfig::o_proof_multiple_inter    = ":proof-interpolation-property";
 const char* SMTConfig::o_proof_alternative_inter = ":proof-alternative-inter";

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -266,7 +266,6 @@ public:
   static const char* o_proof_rec_piv;
   static const char* o_proof_push_units;
   static const char* o_proof_transf_trav;
-  static const char* o_proof_struct_hash_build;
   static const char* o_proof_check;
   static const char* o_proof_multiple_inter;
   static const char* o_proof_alternative_inter;
@@ -597,9 +596,6 @@ public:
   int proof_transf_trav() const
     { return optionTable.has(o_proof_transf_trav) ?
         optionTable[o_proof_transf_trav]->getValue().numval : 1; }
-  int proof_struct_hash_build() const
-    { return optionTable.has(o_proof_struct_hash_build) ?
-        optionTable[o_proof_struct_hash_build]->getValue().numval : 0; }
   int proof_check() const
     { return optionTable.has(o_proof_check) ?
         optionTable[o_proof_check]->getValue().numval : 0; }

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -339,7 +339,6 @@ public:
     bool			enabledPushDownUnits() { return (config.proof_push_units() >=1); }
     bool			enabledTransfTraversals() { return (config.proof_transf_trav() >= 1); }
     bool			enabledStructuralHashing() { return (config.proof_struct_hash() >= 1); }
-    bool			enabledStructuralHashingWhileBuilding() { return (config.proof_struct_hash_build() >= 1); }
     // Inverts the normal order Hashing + RecyclePivots
     bool			switchToRPHashing()			{ return (config.proof_switch_to_rp_hash >= 1);}
     inline bool    additionalRandomization       ( ) { return ( config.proof_random_context_analysis == 1 ); }

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -265,21 +265,18 @@ public:
 	ProofGraph ( SMTConfig &  c
 			, Theory &        th
 			, TermMapper &    termMapper
-			, Proof const &   t
+			, Proof const &   proof
 			, PartitionManager & pmanager
 			, int             n = -1 )
 : config   ( c )
-, proof	   ( t )
 , logic_ ( th.getLogic() )
 , pmanager (pmanager)
 , thandler {new THandler(th, termMapper)}
-, graph_   ( new std::vector<ProofNode*> )
-, graph    ( *graph_ )
-, vars_suggested_color_map ( NULL )
+, vars_suggested_color_map ( nullptr )
 {
 		mpz_init(visited_1);
 		mpz_init(visited_2);
-		buildProofGraph( n );
+		buildProofGraph(proof, n);
 		initTSolver();
 }
 
@@ -289,7 +286,6 @@ public:
 		mpz_clear(visited_2);
 		for(size_t i=0;i<getGraphSize();i++)
 			if(getNode(i)!=NULL) removeNode(i);
-		delete graph_;
 	}
 
     bool verifyPartialInterpolant(ProofNode*, const ipartitions_t&);
@@ -351,7 +347,6 @@ public:
     //
     // Build et al.
     //
-    void           buildProofGraph               ( int );
     void		   emptyProofGraph				 ();					// Empties all clauses besides leaves
     void 		   fillProofGraph				 ();					// Explicitly compute all clauses
     int            cleanProofGraph               ( );                   // Removes proof leftovers
@@ -506,6 +501,8 @@ public:
     bool            allowSwapRuleForCNFinterpolant(RuleContext& ra);
 
 private:
+    void buildProofGraph(Proof const & proof, int varCount);
+    ProofNode * createProofNodeFor(CRef cref, clause_type _ctype, Proof const & proof); // Helper method for building the proof graph
 
     inline Lit PTRefToLit(PTRef ref) const {return thandler->getTMap().getLit(ref);}
     inline Var PTRefToVar(PTRef ref) const { return thandler->getTMap().getVar(ref); }
@@ -513,8 +510,8 @@ private:
 
     void initTSolver();
     void clearTSolver();
-    bool assertLiteralsToTSolver(vec<Lit> const&);
-    void addDefaultAssumedLiterals();
+    bool assertLiteralsToTSolver(vec<Lit> const &);
+    void addDefaultAssumedLiterals(std::vector<Lit> && assumedLiteralsFromDerivations);
     inline bool isAssumedLiteral(Lit l) const {
         return std::find(assumedLiterals.begin(), assumedLiterals.end(), l) != assumedLiterals.end();
     }
@@ -534,13 +531,10 @@ private:
     Var 				  pred_to_push;
 
     SMTConfig &                 config;
-    Proof const &               proof;
     Logic &                     logic_;
     PartitionManager &          pmanager;
     std::unique_ptr<THandler>   thandler;
-
-    std::vector< ProofNode * >*    graph_;                      // Graph
-    std::vector< ProofNode * >&    graph;
+    std::vector<ProofNode *>    graph {};
     double                         building_time;               // Time spent building graph
     clauseid_t                     root;                        // Proof root
     std::set<clauseid_t>		   leaves_ids;					// Proof leaves, for top-down visits
@@ -550,7 +544,7 @@ private:
     std::vector<Lit> assumedLiterals;
     // NOTE class A has value -1, class B value -2, undetermined value -3, class AB has index bit from 0 onwards
     std::vector<int>               AB_vars_mapping;             // Variables of class AB mapping to mpz integer bit index
-    vec< std::map<PTRef, icolor_t>* > *    vars_suggested_color_map;	 // To suggest color for shared vars
+    vec<std::map<PTRef, icolor_t>*> * vars_suggested_color_map { nullptr };	 // To suggest color for shared vars
     int                            num_vars_limit;               // Number of variables in the problem (not nec in the proof)
 
     // Info on graph dimension

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -173,9 +173,6 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
 
     // Map to associate node to its antecedents
     std::map< std::pair<int,int>, int > ants_map;
-    if (verbose() and enabledStructuralHashingWhileBuilding()) {
-        std::cerr << "; " << "Performing structural hashing while building the proof" << '\n';
-    }
     //Start from empty clause
     {
         auto it = clause_to_proof_der.find(CRef_Undef);
@@ -254,36 +251,6 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
                     if (i < chaincla.size()-1) {
                         currId = (int)graph.size();
 
-                        ///////////////////////////////////////////////////////////////////////////////////////
-                        // NOTE structural hashing: check whether there already
-                        // exists a node with the current pair of antecedents
-                        // if so, stop creating the proof chain
-                        if( enabledStructuralHashingWhileBuilding() )
-                        {
-                            int id__i=clauseToIDMap[ clause_i ];
-                            int c1, c2;
-                            if(id__i <= last_seen_id)
-                            { c1 = id__i; c2 =last_seen_id; }
-                            else
-                            { c2 = last_seen_id; c1 = id__i; }
-                            // Look for pair <ant1,ant2>
-                            std::pair<int, int> ant_pair (c1,c2);
-                            auto it = ants_map.find( ant_pair );
-                            bool found = ( it != ants_map.end() );
-                            // If pairs not found, add id of the next node to the map
-                            if( !found ) ants_map[ ant_pair ] = currId ;
-                            // else replace node with existing one
-                            else
-                            {
-                                assert( getNode( it->second ) );
-                                last_seen_id = it->second;
-                                // Skip the new node construction and move to the next clause in the chain
-                                continue;
-                            }
-                        }
-                        //
-                        //////////////////////////////////////////////////////////////////////////////////////////
-
                         n=new ProofNode(logic_);
                         n->initIData();
                         //Add node to graph vector
@@ -299,39 +266,6 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
                         if(clauseToIDMap.find(currClause)==clauseToIDMap.end())
                         {
                             currId=(int)graph.size();
-
-                            ///////////////////////////////////////////////////////////////////////////////////////
-                            // NOTE structural hashing: check whether there already
-                            // exists a node with the current pair of antecedents
-                            // if so, stop creating the proof chain
-                            // Make sure ant1 has the pivot positive (and ant2 negated)
-
-                            // NOTE: the technique does not seem to have effect here
-                            if( enabledStructuralHashingWhileBuilding() )
-                            {
-                                int id__i=clauseToIDMap[ clause_i ];
-                                int c1, c2;
-                                if(id__i <= last_seen_id)
-                                { c1 = id__i; c2 =last_seen_id; }
-                                else
-                                { c2 = last_seen_id; c1 = id__i; }
-                                // Look for pair <ant1,ant2>
-                                std::pair<int, int> ant_pair (c1,c2);
-                                auto it = ants_map.find(ant_pair);
-                                bool found = ( it != ants_map.end() );
-                                // If pairs not found, add id of the next node to the map
-                                if( !found ) ants_map[ ant_pair ] = currId ;
-                                // else replace node with existing one
-                                else
-                                {
-                                    assert( getNode( it->second ) );
-                                    last_seen_id = it->second;
-                                    // Skip the new node construction and move to the next clause in the chain
-                                    continue;
-                                }
-                            }
-                            //
-                            //////////////////////////////////////////////////////////////////////////////////////////
 
                             n = new ProofNode(logic_);
                             counters.recordNewClause(clause_type::CLA_LEARNT);

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -214,7 +214,7 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
         clause_type ctype = proofder.type;
 
         if (isLeafClauseType(ctype)) {
-            assert(chaincla.size() == 0);
+            assert(chaincla.empty());
             // MB: Proof built from the root towards the leaves.
             //     A leaf node is constructed when its first children is constructred. Here it must already exist.
             auto it = clauseToIDMap.find(currClause);
@@ -306,8 +306,7 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
         }
         visitedSet.insert(currClause);
         num_clause++;
-    }
-    while(!q.empty());
+    } while(!q.empty());
 
     setRoot(clauseToIDMap.at(CRef_Undef));
 

--- a/src/smtsolvers/Proof.h
+++ b/src/smtsolvers/Proof.h
@@ -166,7 +166,7 @@ public:
         return res;
     }
 
-    std::unordered_map< CRef, ProofDer> const & getProof() const { return clause_to_proof_der; }
+    std::unordered_map<CRef, ProofDer> const & getProof() const { return clause_to_proof_der; }
 
 private:
     // Helper methods


### PR DESCRIPTION
This PR begins a series of changes to interpolation-related code that aims to separate interpolation algorithm from the proof data structure in order to support proof-preserving interpolation needed for theory combination and LIA cuts-from-proofs.

Here the focus is on refactoring the initial resolution proof construction process: `ProofGraph::buildProofGraph`.

One point is important: We remove the code related to structural hashing during the proof construction.
The rationale is that this code has not been exercised for years and it is difficult to understand and complicates the reasoning about the proof construction code.
The interpolation has been working well without it.