### PR TITLE
CoreSMTSolver: Remove forced_split field

### DIFF
--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -100,7 +100,6 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     , learnts_size(0) , all_learnts(0)
     , learnt_theory_conflicts(0)
     , top_level_lits        (0)
-    , forced_split          (lit_Undef)
 
     , ok                    (true)
     , conflict_frame        (0)
@@ -558,13 +557,6 @@ Lit CoreSMTSolver::pickBranchLit()
 #ifdef STATISTICS
     opensmt::StopWatch s(branchTimer);
 #endif
-    if (forced_split != lit_Undef) {
-        assert(value(var(forced_split)) == l_Undef);
-        Lit fs = forced_split;
-        forced_split = lit_Undef;
-        return fs;
-    }
-
     Var next = var_Undef;
 
     // Random decision:

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -375,7 +375,6 @@ public:
     std::vector<vec<Lit>> split_assumptions;
 
 protected:
-    Lit forced_split; // If theory solver tells that we must split the instance, a literal with unknown value is inserted here for the splitting heuristic
     int processed_in_frozen; // The index in Theory's frozen vec until which frozennes has been processed
     // Helper structures:
     //

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -162,11 +162,6 @@ GhostSMTSolver::pickBranchLit() {
 #ifdef STATISTICS
     opensmt::StopWatch s(branchTimer);
 #endif
-    if (forced_split != lit_Undef) {
-        Lit fs = forced_split;
-        forced_split = lit_Undef;
-        return fs;
-    }
 
     if ((drand(random_seed) < random_var_freq) && !order_heap.empty()) {
         Var v = pickRandomBranchVar();

--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -173,7 +173,6 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
         } else {
             processNewClause(splitClause);
             if (satisfied == 0) {
-                forced_split = ~splitClause[0];
                 if (res != TPropRes::Propagate) {
                     res = TPropRes::Decide;
                 }
@@ -182,7 +181,6 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
     }
     assert(res != TPropRes::Undef);
     if (res == TPropRes::Propagate) {
-        forced_split = lit_Undef;
         for (auto [litToPropogate, reason] : propData) {
             uncheckedEnqueue(litToPropogate, reason);
         }


### PR DESCRIPTION
The `forced_split` literal does not seem to be necessary anymore.
Experiments on QF_LIA suggest this is even positive change for the LIA solver.