### PR TITLE
Logic: fix quoting of variable names which start with numbers

### DIFF
--- a/src/api/smt2tokens.h
+++ b/src/api/smt2tokens.h
@@ -29,6 +29,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+
 namespace osmttokens {
 //
 // The names for the tokens in the API for smtlib
@@ -72,7 +74,45 @@ namespace osmttokens {
         t_let,
         t_echo
     };
-
+    inline const std::unordered_set<std::string> tokenNames = {
+        "none",
+        "as",
+        "decimal",
+        "numeral",
+        "par",
+        "string",
+        "exists",
+        "forall",
+        "assert",
+        "check-sat",
+        "declare-sort",
+        "define-sort",
+        "declare-fun",
+        "declare-const",
+        "define-fun",
+        "exit",
+        "get-assertions",
+        "get-assignment",
+        "get-info",
+        "set-info",
+        "get-option",
+        "set-option",
+        "get-proof",
+        "get-unsat-core",
+        "get-value",
+        "get-model",
+        "pop",
+        "push",
+        "set-logic",
+        "get-interpolants",
+        "theory",
+        "write-state",
+        "read-state",
+        "simplify",
+        "write-funs",
+        "let",
+        "echo"
+    };
     inline const std::unordered_map<token, std::string> tokenToName = {
         {t_none, "none"},
         {t_as, "as"},

--- a/src/bin/Interpret.cc
+++ b/src/bin/Interpret.cc
@@ -702,7 +702,7 @@ public:
                     newArgs.push(var);
                     substMap.insert(oldArg, var);
                 }
-                FunctionSignature templateSig(logic.protectName(logic.getSymName(symRef)), std::move(newArgs), logic.getSortRef(symRef));
+                FunctionSignature templateSig(logic.protectName(symRef), std::move(newArgs), logic.getSortRef(symRef));
                 PTRef newBody = Substitutor(logic, substMap).rewrite(modelTemplate.getBody());
                 res.emplace_back(std::move(templateSig), newBody);
 
@@ -778,7 +778,7 @@ void Interpret::getModel() {
  */
 std::string Interpret::printDefinitionSmtlib(PTRef tr, PTRef val) {
     std::stringstream ss;
-    auto s = logic->protectName(logic->getSymName(tr));
+    auto s = logic->protectName(logic->getSymRef(tr));
     SRef sortRef = logic->getSym(tr).rsort();
     ss << "  (define-fun " << s << " () " << logic->printSort(sortRef) << '\n';
     ss << "    " << logic->printTerm(val) << ")\n";

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -269,6 +269,20 @@ void ArithLogic::termSort(vec<PTRef>& v) const
     sort(v, LessThan_deepPTRef(*this));
 }
 
+std::string ArithLogic::protectName(std::string const & name, SRef retSort, bool isNullary) const {
+    assert(not name.empty());
+    // TODO: We cannot use isNumConst here since it takes a SymRef.  We cannot take a SymRef because this
+    // function needs to be callable from TemplateFunction, which does not have a SymRef.
+    if (isSortNum(retSort) and isNullary and std::all_of(name.begin(), name.end(), [](unsigned char c) { return std::isdigit(c); })) {
+        return name; // Is a number, no escaping
+    } else if (hasQuotableChars(name) or std::isdigit(name[0])) {
+        std::stringstream ss;
+        ss << '|' << name << '|';
+        return ss.str();
+    }
+    return name;
+}
+
 bool ArithLogic::isBuiltinFunction(const SymRef sr) const
 {
     if (sym_store[sr].isInterpreted()) return true;

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -275,7 +275,7 @@ std::string ArithLogic::protectName(std::string const & name, SRef retSort, bool
     // function needs to be callable from TemplateFunction, which does not have a SymRef.
     if (isSortNum(retSort) and isNullary and std::all_of(name.begin(), name.end(), [](unsigned char c) { return std::isdigit(c); })) {
         return name; // Is a number, no escaping
-    } else if (hasQuotableChars(name) or std::isdigit(name[0])) {
+    } else if (hasQuotableChars(name) or std::isdigit(name[0]) or isReservedWord(name)) {
         std::stringstream ss;
         ss << '|' << name << '|';
         return ss.str();

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -109,6 +109,8 @@ protected:
 public:
     ArithLogic(opensmt::Logic_t type);
     ~ArithLogic() { for (auto number : numbers) { delete number; } }
+
+    std::string      protectName(std::string const & name, SRef retSort, bool isNullary) const override;
     bool             isBuiltinFunction(SymRef sr) const override;
     PTRef            insertTerm       (SymRef sym, vec<PTRef> && terms) override;
     SRef             getSort_real     () const { return sort_REAL; }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -32,6 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "OsmtApiException.h"
 #include "OsmtInternalException.h"
 #include "Substitutor.h"
+#include "smt2tokens.h"
 
 #include <iostream>
 #include <map>
@@ -112,6 +113,10 @@ bool Logic::isBuiltinFunction(const SymRef sr) const
     return false;
 }
 
+bool Logic::isReservedWord(std::string const & name) const {
+    return osmttokens::tokenNames.find(name) != osmttokens::tokenNames.end();
+}
+
 //
 // Escape the symbol name if it contains a prohibited character from the
 // list defined by the quotable[] table below
@@ -164,7 +169,7 @@ std::string Logic::protectName(std::string const & name, SRef retSort, bool isNu
     assert(not name.empty());
     (void)retSort;
     (void)isNullary;
-    if (hasQuotableChars(name) or std::isdigit(name[0])) {
+    if (hasQuotableChars(name) or std::isdigit(name[0]) or isReservedWord(name)) {
         std::stringstream ss;
         ss << '|' << name << '|';
         return ss.str();

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -165,10 +165,8 @@ bool Logic::hasQuotableChars(std::string const & name) const
 //
 // Quote the name if it contains illegal characters
 //
-std::string Logic::protectName(std::string const & name, SRef retSort, bool isNullary) const {
+std::string Logic::protectName(std::string const & name, SRef, bool) const {
     assert(not name.empty());
-    (void)retSort;
-    (void)isNullary;
     if (hasQuotableChars(name) or std::isdigit(name[0]) or isReservedWord(name)) {
         std::stringstream ss;
         ss << '|' << name << '|';

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -160,9 +160,11 @@ bool Logic::hasQuotableChars(std::string const & name) const
 //
 // Quote the name if it contains illegal characters
 //
-std::string Logic::protectName(std::string const & name) const
-{
-    if (hasQuotableChars(name)) {
+std::string Logic::protectName(std::string const & name, SRef retSort, bool isNullary) const {
+    assert(not name.empty());
+    (void)retSort;
+    (void)isNullary;
+    if (hasQuotableChars(name) or std::isdigit(name[0])) {
         std::stringstream ss;
         ss << '|' << name << '|';
         return ss.str();
@@ -170,9 +172,8 @@ std::string Logic::protectName(std::string const & name) const
     return name;
 }
 
-std::string Logic::printSym(SymRef sr) const
-{
-    return protectName(sym_store.getName(sr));
+std::string Logic::printSym(SymRef sr) const {
+    return protectName(sr);
 }
 
 
@@ -1390,7 +1391,7 @@ void
 Logic::dumpFunction(ostream& dump_out, const TemplateFunction& tpl_fun)
 {
     const std::string& name = tpl_fun.getName();
-    auto quoted_name = protectName(name);
+    auto quoted_name = protectName(name, tpl_fun.getRetSort(), tpl_fun.getArgs().size() == 0);
 
     dump_out << "(define-fun " << quoted_name << " ( ";
     const vec<PTRef>& args = tpl_fun.getArgs();

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -397,7 +397,8 @@ public:
 
 
     bool          hasQuotableChars(std::string const & name) const;
-    std::string   protectName(const std::string& name) const;
+    virtual std::string protectName(std::string const & name, SRef retSort, bool isNullary) const;
+    std::string   protectName(SymRef sr) const { return protectName(getSymName(sr), getSortRef(sr), getSym(sr).nargs() == 0); };
     virtual std::string printTerm_ (PTRef tr, bool l, bool s) const;
     std::string printTerm          (PTRef tr)                 const { return printTerm_(tr, false, false); }
     std::string printTerm          (PTRef tr, bool l, bool s) const { return printTerm_(tr, l, s); }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -396,7 +396,8 @@ public:
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 
 
-    bool          hasQuotableChars(std::string const & name) const;
+    bool hasQuotableChars(std::string const & name) const;
+    bool isReservedWord(std::string const & name) const;
     virtual std::string protectName(std::string const & name, SRef retSort, bool isNullary) const;
     std::string   protectName(SymRef sr) const { return protectName(getSymName(sr), getSortRef(sr), getSym(sr).nargs() == 0); };
     virtual std::string printTerm_ (PTRef tr, bool l, bool s) const;

--- a/src/models/ModelBuilder.cc
+++ b/src/models/ModelBuilder.cc
@@ -44,7 +44,7 @@ void ModelBuilder::addToTheoryFunction(SymRef sr, const vec<PTRef> & vals, PTRef
             ss << formalArgPrefix << uniqueNum++;
             formalArgs.push(logic.mkVar(logic.getSortRef(v), ss.str().c_str()));
         }
-        FunctionSignature templateSig(logic.protectName(logic.getSymName(sr)), std::move(formalArgs), logic.getSortRef(sr));
+        FunctionSignature templateSig(logic.protectName(sr), std::move(formalArgs), logic.getSortRef(sr));
         definitions.insert({sr,opensmt::pair<FunctionSignature,ValuationNode*>{std::move(templateSig), nullptr}});
     }
     auto & signatureAndValuation = definitions.at(sr);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -227,3 +227,11 @@ target_sources(LASolverIncrementalityTest
 
 target_link_libraries(LASolverIncrementalityTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET LASolverIncrementalityTest)
+
+add_executable(NameProtectionTest)
+target_sources(NameProtectionTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_NameProtection.cc"
+        )
+
+target_link_libraries(NameProtectionTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET NameProtectionTest)

--- a/test/unit/test_NameProtection.cc
+++ b/test/unit/test_NameProtection.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2021, Seyedmasoud Asadzadeh <seyedmasoud.asadzadeh@usi.ch>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <gtest/gtest.h>
+#include <lasolver/LASolver.h>
+
+class NameProtectionTest : public ::testing::Test {
+public:
+    NameProtectionTest() : arithLogic(opensmt::Logic_t::QF_LIA), ufLogic(opensmt::Logic_t::QF_UF), ufliaLogic(opensmt::Logic_t::QF_UFLIA) {}
+    ArithLogic arithLogic;
+    Logic ufLogic;
+    ArithLogic ufliaLogic;
+};
+
+TEST_F(NameProtectionTest, test_NumberEscape) {
+    PTRef numberOne = arithLogic.mkIntVar("1");
+    ASSERT_EQ(arithLogic.pp(numberOne), "1");
+
+    PTRef numberTen = arithLogic.mkIntVar("10");
+    ASSERT_EQ(arithLogic.pp(numberTen), "10");
+
+    PTRef numericVar = arithLogic.mkIntVar("10abc");
+    ASSERT_EQ(arithLogic.pp(numericVar), "|10abc|");
+}
+
+TEST_F(NameProtectionTest, test_SymbolEscape) {
+    PTRef symbolOne = ufLogic.mkVar(ufLogic.getSort_bool(), "1");
+    ASSERT_EQ(ufLogic.pp(symbolOne), "|1|");
+
+    PTRef symbolTen = ufLogic.mkVar(ufLogic.getSort_bool(), "10");
+    ASSERT_EQ(ufLogic.pp(symbolTen), "|10|");
+
+    PTRef symbolNumericStart = ufLogic.mkVar(ufLogic.getSort_bool(), "10ab");
+    ASSERT_EQ(ufLogic.pp(symbolNumericStart), "|10ab|");
+}
+
+TEST_F(NameProtectionTest, test_SymbolExcapeMixed) {
+    PTRef symbolOne = ufliaLogic.mkVar(ufliaLogic.getSort_bool(), "1");
+    PTRef numberOne = ufliaLogic.mkIntVar("1");
+    ASSERT_EQ(ufliaLogic.pp(symbolOne), "|1|");
+    ASSERT_EQ(ufliaLogic.pp(numberOne), "1");
+
+    SymRef functionOne = ufliaLogic.declareFun("1", ufliaLogic.getSort_int(), {ufliaLogic.getSort_int()});
+    PTRef funSymbolOne = ufliaLogic.mkUninterpFun(functionOne, {ufliaLogic.mkIntVar("1")});
+    ASSERT_EQ(ufliaLogic.pp(funSymbolOne), "(|1| 1)");
+}

--- a/test/unit/test_NameProtection.cc
+++ b/test/unit/test_NameProtection.cc
@@ -52,4 +52,8 @@ TEST_F(NameProtectionTest, test_SymbolExcapeMixed) {
 TEST_F(NameProtectionTest, test_ReservedWord) {
     PTRef symbolLet = ufLogic.mkVar(ufLogic.getSort_bool(), "let");
     ASSERT_EQ(ufLogic.pp(symbolLet), "|let|");
+    PTRef symbolLet2 = arithLogic.mkVar(arithLogic.getSort_bool(), "let");
+    ASSERT_EQ(arithLogic.pp(symbolLet2), "|let|");
+    PTRef symbolLet3 = ufliaLogic.mkVar(ufliaLogic.getSort_bool(), "let");
+    ASSERT_EQ(ufliaLogic.pp(symbolLet3), "|let|");
 }

--- a/test/unit/test_NameProtection.cc
+++ b/test/unit/test_NameProtection.cc
@@ -48,3 +48,8 @@ TEST_F(NameProtectionTest, test_SymbolExcapeMixed) {
     PTRef funSymbolOne = ufliaLogic.mkUninterpFun(functionOne, {ufliaLogic.mkIntVar("1")});
     ASSERT_EQ(ufliaLogic.pp(funSymbolOne), "(|1| 1)");
 }
+
+TEST_F(NameProtectionTest, test_ReservedWord) {
+    PTRef symbolLet = ufLogic.mkVar(ufLogic.getSort_bool(), "let");
+    ASSERT_EQ(ufLogic.pp(symbolLet), "|let|");
+}

--- a/test/unit/test_NameProtection.cc
+++ b/test/unit/test_NameProtection.cc
@@ -17,10 +17,10 @@ public:
 };
 
 TEST_F(NameProtectionTest, test_NumberEscape) {
-    PTRef numberOne = arithLogic.mkIntVar("1");
+    PTRef numberOne = arithLogic.mkIntConst(1);
     ASSERT_EQ(arithLogic.pp(numberOne), "1");
 
-    PTRef numberTen = arithLogic.mkIntVar("10");
+    PTRef numberTen = arithLogic.mkIntConst(10);
     ASSERT_EQ(arithLogic.pp(numberTen), "10");
 
     PTRef numericVar = arithLogic.mkIntVar("10abc");
@@ -40,12 +40,12 @@ TEST_F(NameProtectionTest, test_SymbolEscape) {
 
 TEST_F(NameProtectionTest, test_SymbolExcapeMixed) {
     PTRef symbolOne = ufliaLogic.mkVar(ufliaLogic.getSort_bool(), "1");
-    PTRef numberOne = ufliaLogic.mkIntVar("1");
+    PTRef numberOne = ufliaLogic.mkIntConst(1);
     ASSERT_EQ(ufliaLogic.pp(symbolOne), "|1|");
     ASSERT_EQ(ufliaLogic.pp(numberOne), "1");
 
     SymRef functionOne = ufliaLogic.declareFun("1", ufliaLogic.getSort_int(), {ufliaLogic.getSort_int()});
-    PTRef funSymbolOne = ufliaLogic.mkUninterpFun(functionOne, {ufliaLogic.mkIntVar("1")});
+    PTRef funSymbolOne = ufliaLogic.mkUninterpFun(functionOne, {ufliaLogic.mkIntConst(1)});
     ASSERT_EQ(ufliaLogic.pp(funSymbolOne), "(|1| 1)");
 }
 


### PR DESCRIPTION
If, e.g., a boolean variable in smt-lib has a name consisting entirely of digits, the term printing system incorrectly leaves the variable unquoted.  This PR suggests a fix for the problem.