### PR TITLE
UFInterpolator: Fix interpolation in the present of distincts

### DIFF
--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -136,6 +136,8 @@ private:
         return colorInfo->getColorFor(term);
     }
 
+    icolor_t determineDisequalityColor(PTRef t1, PTRef t2, std::map<PTRef, icolor_t> const & conflictColors) const;
+
     void colorCGraph();
     void colorNodes();
     icolor_t colorNode(CNode * c);


### PR DESCRIPTION
UF theory conflict is caused by a disequality and a chain of (possibly
derived) equalities.
Previously, the code was assuming that it will find positive version of
the disequality in the labels map (unless the conflict is between two
interpreted constants). This assumption is not true if the disequality
is actually derived from a distinct term.
The fix is to consider also the possibility of presence of distinct
terms.

Fixes #432 