### PR TITLE
Async Printer and Time Checker

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -19,11 +19,12 @@ target_sources(common
     "${CMAKE_CURRENT_LIST_DIR}/PartitionInfo.cc"
     "${CMAKE_CURRENT_LIST_DIR}/VerificationUtils.cc"
     "${CMAKE_CURRENT_LIST_DIR}/ReportUtils.h"
+    "${CMAKE_CURRENT_LIST_DIR}/Printer.h"
 )
 
 install(FILES
         Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h Timer.h osmtinttypes.h
-    TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h NumberUtils.h
+    TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h NumberUtils.h Printer.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/Printer.h
+++ b/src/common/Printer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2022, Seyedmasoud Asadzadeh <seyedmasoud.asadzadeh@usi.ch>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef PRINTER_H
+#define PRINTER_H
+
+#include "Timer.h"
+#include <iostream>
+
+namespace opensmt {
+
+    namespace Color {
+        enum Code {
+            FG_DEFAULT = 39,
+            FG_Black = 30,
+            BG_Black = 40,
+            FG_Red = 31,
+            BG_Red = 41,
+            FG_Green = 32,
+            BG_Green = 42,
+            FG_Yellow = 33,
+            BG_Yellow = 43,
+            FG_Blue = 34,
+            BG_Blue = 44,
+            FG_Magenta = 35,
+            BG_Magenta = 45,
+            FG_Cyan = 36,
+            BG_Cyan = 46,
+            FG_White = 37,
+            BG_White = 47,
+            FG_BrightBlack = 90,
+            BG_BrightBlack = 100,
+            FG_BrightRed = 91,
+            BG_BrightRed = 101,
+            FG_BrightGreen = 92,
+            BG_BrightGreen = 102,
+            FG_BrightYellow = 93,
+            BG_BrightYellow = 103,
+            FG_BrightBlue = 94,
+            BG_BrightBlue = 104,
+            FG_BrightMagenta = 95,
+            BG_BrightMagenta = 105,
+            FG_BrightCyan = 96,
+            BG_BrightCyan = 106,
+            FG_BrightWhite = 97,
+            BG_BrightWhite = 107
+        };
+    }
+}
+#endif

--- a/src/common/Printer.h
+++ b/src/common/Printer.h
@@ -75,5 +75,32 @@ namespace opensmt {
         mutable std::mutex stream_mutex = {};
         std::ostream & out_stream;
     };
+
+    class PrintStopWatch {
+    protected:
+        char * name;
+        StoppableWatch timer;
+        synced_stream & ss;
+        Color::Code colorCode;
+
+    public:
+        PrintStopWatch(const char * _name, synced_stream & _ss, Color::Code cc = Color::Code::FG_DEFAULT)
+                : ss(_ss), colorCode(cc) {
+            timer.start();
+            name = (char *) malloc(strlen(_name) + 1);
+            strcpy(name, _name);
+        }
+
+        PrintStopWatch(std::string_view _name, synced_stream & _ss, Color::Code cc = Color::Code::FG_DEFAULT)
+                : ss(_ss), colorCode(cc) {
+            timer.start();
+            name = _name
+        }
+
+        ~PrintStopWatch() {
+            ss.println(colorCode, ";", name, " ", timer.elapsed_time_milliseconds());
+            free(name);
+        }
+    };
 }
 #endif

--- a/src/common/Printer.h
+++ b/src/common/Printer.h
@@ -50,5 +50,30 @@ namespace opensmt {
             BG_BrightWhite = 107
         };
     }
+
+    class synced_stream {
+    public:
+        synced_stream(std::ostream & _out_stream = std::cout)
+                : out_stream(_out_stream) {};
+
+        template<typename... T>
+        void print(Color::Code colorCode, const T & ...items) {
+            const std::scoped_lock lock(stream_mutex);
+            if (colorCode != Color::FG_DEFAULT)
+                out_stream << "\033[" << colorCode << "m";
+            (out_stream << ... << items);
+            if (colorCode != Color::FG_DEFAULT)
+                out_stream << "\033[" << Color::FG_DEFAULT << "m";
+        }
+
+        template<typename... T>
+        void println(Color::Code colorCode, const T & ...items) {
+            print(colorCode, items..., '\n');
+        }
+
+    private:
+        mutable std::mutex stream_mutex = {};
+        std::ostream & out_stream;
+    };
 }
 #endif

--- a/src/common/Printer.h
+++ b/src/common/Printer.h
@@ -9,7 +9,6 @@
 #define PRINTER_H
 
 #include "Timer.h"
-#include <iostream>
 
 namespace opensmt {
 
@@ -94,7 +93,7 @@ namespace opensmt {
         PrintStopWatch(std::string_view _name, synced_stream & _ss, Color::Code cc = Color::Code::FG_DEFAULT)
                 : ss(_ss), colorCode(cc) {
             timer.start();
-            name = _name
+            strcpy (&name, _name.c_str());
         }
 
         ~PrintStopWatch() {

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -26,125 +26,187 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifndef TIMER_H
 #define TIMER_H
+
 #include <string.h>
 #include <ostream>
-#include <iostream>
-#include <assert.h>
 #include <sys/time.h>
+#include <chrono>
 #include <sys/resource.h>
 
 namespace opensmt {
-
 // A c++ wrapper for struct timeval
-class BTime {
-    time_t tv_sec;
-    suseconds_t tv_usec;
-public:
-    BTime() : tv_sec(0), tv_usec(0) {}
-    BTime(const struct timeval& tv) : tv_sec(tv.tv_sec), tv_usec(tv.tv_usec) {}
-    BTime(const BTime& from) : tv_sec(from.tv_sec), tv_usec(from.tv_usec) {}
-    void operator-= (const BTime& subst)
-    {
-        tv_sec  -= subst.tv_sec;
-        tv_usec -= subst.tv_usec;
-    }
-    BTime operator- (const BTime& subst)
-    {
-        BTime out;
-        out.tv_sec = tv_sec - subst.tv_sec;
-        out.tv_usec = tv_usec - subst.tv_usec;
-        return out;
-    }
-    void operator= (const BTime& from)
-    {
-        tv_sec = from.tv_sec;
-        tv_usec = from.tv_usec;
-    }
-    BTime& operator+= (const BTime& other)
-    {
-        tv_sec += other.tv_sec;
-        tv_usec += other.tv_usec;
-        return *this;
-    }
-    double getTime()
-    {
-        return tv_sec + tv_usec/(double)1000000;
-    }
-};
+    class BTime {
+        time_t tv_sec;
+        suseconds_t tv_usec;
+    public:
+        BTime() : tv_sec(0), tv_usec(0) {}
 
-class OSMTTimeVal {
-    BTime usrtime;
-    BTime systime;
-public:
-    OSMTTimeVal() {}
-    OSMTTimeVal(const BTime& usrtime, const BTime& systime) : usrtime(usrtime), systime(systime) {}
+        BTime(const struct timeval & tv) : tv_sec(tv.tv_sec), tv_usec(tv.tv_usec) {}
 
-    OSMTTimeVal(const struct rusage& res_usage) : usrtime(res_usage.ru_utime), systime(res_usage.ru_stime) {}
-    void operator-= (const OSMTTimeVal& subst) {
-        usrtime -= subst.usrtime;
-        systime -= subst.systime;
-    }
-    OSMTTimeVal operator- (const OSMTTimeVal& subst) {
-        OSMTTimeVal out;
-        out.usrtime = usrtime - subst.usrtime;
-        out.systime = systime - subst.systime;
-        return out;
-    }
+        BTime(const BTime & from) : tv_sec(from.tv_sec), tv_usec(from.tv_usec) {}
 
-    OSMTTimeVal& operator+= (const OSMTTimeVal& from) {
-        usrtime += from.usrtime;
-        systime += from.systime;
-        return *this;
-    }
-    double getTime()
-    {
-        return usrtime.getTime() + systime.getTime();
-    }
-};
+        void operator-=(const BTime & subst) {
+            tv_sec -= subst.tv_sec;
+            tv_usec -= subst.tv_usec;
+        }
 
-class StopWatch {
+        BTime operator-(const BTime & subst) {
+            BTime out;
+            out.tv_sec = tv_sec - subst.tv_sec;
+            out.tv_usec = tv_usec - subst.tv_usec;
+            return out;
+        }
+
+        void operator=(const BTime & from) {
+            tv_sec = from.tv_sec;
+            tv_usec = from.tv_usec;
+        }
+
+        BTime & operator+=(const BTime & other) {
+            tv_sec += other.tv_sec;
+            tv_usec += other.tv_usec;
+            return *this;
+        }
+
+        double getTime() {
+            return tv_sec + tv_usec / (double) 1000000;
+        }
+    };
+
+    class OSMTTimeVal {
+        BTime usrtime;
+        BTime systime;
+    public:
+        OSMTTimeVal() {}
+
+        OSMTTimeVal(const BTime & usrtime, const BTime & systime) : usrtime(usrtime), systime(systime) {}
+
+        OSMTTimeVal(const struct rusage & res_usage) : usrtime(res_usage.ru_utime), systime(res_usage.ru_stime) {}
+
+        void operator-=(const OSMTTimeVal & subst) {
+            usrtime -= subst.usrtime;
+            systime -= subst.systime;
+        }
+
+        OSMTTimeVal operator-(const OSMTTimeVal & subst) {
+            OSMTTimeVal out;
+            out.usrtime = usrtime - subst.usrtime;
+            out.systime = systime - subst.systime;
+            return out;
+        }
+
+        OSMTTimeVal & operator+=(const OSMTTimeVal & from) {
+            usrtime += from.usrtime;
+            systime += from.systime;
+            return *this;
+        }
+
+        double getTime() {
+            return usrtime.getTime() + systime.getTime();
+        }
+    };
+
+    class StopWatch {
     protected:
         struct rusage tmp_rusage;
         OSMTTimeVal time_start;
-        OSMTTimeVal &timer;
+        OSMTTimeVal & timer;
     public:
-    StopWatch(OSMTTimeVal& timer)
-        : timer(timer)
-    {
-        if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
-            time_start = OSMTTimeVal(tmp_rusage);
+        StopWatch(OSMTTimeVal & timer)
+                : timer(timer) {
+            if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
+                time_start = OSMTTimeVal(tmp_rusage);
+            } else
+                assert(false);
         }
-        else assert(false);
-    }
-    ~StopWatch()
-    {
-        if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
-            timer += OSMTTimeVal(tmp_rusage) - time_start;
-        }
-        else assert(false);
-    }
-};
 
-class PrintStopWatch {
-    protected:
-        char* name;
-        OSMTTimeVal timer;
-        std::ostream& os;
-        StopWatch* watch;
+        ~StopWatch() {
+            if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
+                timer += OSMTTimeVal(tmp_rusage) - time_start;
+            } else
+                assert(false);
+        }
+    };
+
+// A c++ wrapper for manual time checking
+    class StoppableWatch {
+
     public:
-        PrintStopWatch(const char* _name, std::ostream& os) : os(os), watch(new StopWatch(timer))
-        {
-            int size = strlen(_name);
-            name = (char*)malloc(size+1);
-            strcpy(name, _name);
-        }
-        ~PrintStopWatch()
-        {
-            delete watch;
-            os << "; " << name << " " << timer.getTime() << " s\n";
-            free(name);
-        }
-};
+        StoppableWatch(const StoppableWatch & other) = default;
 
+        StoppableWatch(StoppableWatch && other) = default;
+
+        virtual ~StoppableWatch() = default;
+
+        StoppableWatch & operator=(const StoppableWatch & other) = default;
+
+        StoppableWatch & operator=(StoppableWatch && other) = default;
+
+        inline StoppableWatch(bool start = false) :
+                started_(false), paused_(false),
+                reference_(std::chrono::steady_clock::now()),
+                accumulated_(std::chrono::duration<long double>(0)) {
+            if (start)
+                this->start();
+        }
+
+        inline void start() {
+            if (not started_) {
+                started_ = true;
+                paused_ = false;
+                accumulated_ = std::chrono::duration<long double>(0);
+                reference_ = std::chrono::steady_clock::now();
+            } else if (paused_) {
+                reference_ = std::chrono::steady_clock::now();
+                paused_ = false;
+            }
+        }
+
+        inline void stop() {
+            if (started_ && not paused_) {
+                std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+                accumulated_ = accumulated_ +
+                               std::chrono::duration_cast<std::chrono::duration<long double> >(now - reference_);
+                paused_ = true;
+            }
+        }
+
+        inline void reset() {
+            if (started_) {
+                started_ = false;
+                paused_ = false;
+                reference_ = std::chrono::steady_clock::now();
+                accumulated_ = std::chrono::duration<long double>(0);
+            }
+        }
+
+        inline std::uint_fast16_t elapsed_time_milliseconds() {
+            return count_elapsed<std::chrono::milliseconds>();
+        }
+
+        inline std::uint_fast8_t elapsed_time_second() {
+            return count_elapsed<std::chrono::seconds>();
+        }
+
+        template<class duration_t>
+        typename duration_t::rep count_elapsed() const {
+            if (started_) {
+                if (paused_) {
+                    return std::chrono::duration_cast<duration_t>(accumulated_).count();
+                } else {
+                    return std::chrono::duration_cast<duration_t>(
+                            accumulated_ + (std::chrono::steady_clock::now() - reference_)).count();
+                }
+            } else {
+                return duration_t(0).count();
+            }
+        }
+
+    private:
+        bool started_;
+        bool paused_;
+        std::chrono::steady_clock::time_point reference_;
+        std::chrono::duration<long double> accumulated_;
+    };
 }
 #endif

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -29,9 +29,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string.h>
 #include <ostream>
+#include <iostream>
 #include <sys/time.h>
 #include <chrono>
 #include <sys/resource.h>
+#include <cassert>
 
 namespace opensmt {
 // A c++ wrapper for struct timeval


### PR DESCRIPTION
This pull request consists of: 
1) An async printer to output coloured text which can be used in multi-threading context.
  use case: 
     A shared cross-thread object of opensmt::synced_stream, synced_stream, can be used as follow:
      synced_stream(std::clog);
      synced_stream.println(Color::FG_BrightCyan, "status:", status, ...);
    to have a thread-safe coloured stream.

2) A manual time checker which can start, stop, accumulate and reset the time
    use case:
        opensmt::StoppableWatch timer;
        timer.start();
        timer.elapsed_time_milliseconds()

3) An async time checker/printer which triggers on contructor/destructor, automatically measures the time
  use case:
     opensmt::PrintStopWatch timer("wait time ", synced_stream, Color::Code:: FG_BrightCyan );

      