### PR TITLE
Enable interpolant validation in regression tests

### DIFF
--- a/regression_itp/bug_mask_ite.smt2
+++ b/regression_itp/bug_mask_ite.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 
 (declare-fun x () Real)

--- a/regression_itp/bug_mask_ite_nested.smt2
+++ b/regression_itp/bug_mask_ite_nested.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (declare-fun |state::state.pc| () Real)
 (declare-fun |state::state.old| () Real)

--- a/regression_itp/dec-far1.smt2
+++ b/regression_itp/dec-far1.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants true)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (set-option :interpolation-lra-algorithm 4) ; decomposed Farkas
 (declare-fun x1 () Real)

--- a/regression_itp/dec-far2.smt2
+++ b/regression_itp/dec-far2.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants true)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (set-option :interpolation-lra-algorithm 4) ; decomposed Farkas
 (declare-fun x1 () Real)

--- a/regression_itp/distinct_unsat.smt2
+++ b/regression_itp/distinct_unsat.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (set-info :status unsat)
 (declare-fun a () Real)

--- a/regression_itp/itp_bug.smt2
+++ b/regression_itp/itp_bug.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (declare-fun |state_type::state.delta| () Real)
 (declare-fun |state_type::state.v!0| () Real)

--- a/regression_itp/itp_bug_small.smt2
+++ b/regression_itp/itp_bug_small.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (declare-fun x () Bool)
 

--- a/regression_itp/part_bug.smt2
+++ b/regression_itp/part_bug.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_LRA)
 (declare-fun |hifrog::fun_start!0#3| () Bool)
 (declare-fun |hifrog::fun_end!0#3| () Bool)

--- a/regression_itp/preint-options.smt2
+++ b/regression_itp/preint-options.smt2
@@ -1,3 +1,4 @@
 (set-logic QF_LRA)
 (set-option :produce-interpolants true)
+(set-option :certify-interpolants 1)
 (check-sat)

--- a/regression_itp/trivial-proof-A.smt2
+++ b/regression_itp/trivial-proof-A.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-fun x () Bool)
 (assert (! false :named A))

--- a/regression_itp/trivial-proof-B.smt2
+++ b/regression_itp/trivial-proof-B.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-fun x () Bool)
 (assert (! x :named A))

--- a/regression_itp/uf_bug.smt2
+++ b/regression_itp/uf_bug.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-sort U 0)
 (declare-fun e () U)

--- a/regression_itp/uf_duplicates.smt2
+++ b/regression_itp/uf_duplicates.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-sort Real 0)
 (declare-fun .uf-not () Bool)

--- a/regression_itp/uf_itp_problem.smt2
+++ b/regression_itp/uf_itp_problem.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants true)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-sort Real 0)
 (declare-fun g (Real Real ) Real)

--- a/regression_itp/uf_local_colors_insufficient.smt2
+++ b/regression_itp/uf_local_colors_insufficient.smt2
@@ -1,4 +1,5 @@
 (set-option :produce-interpolants 1)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-sort U 0)
 (declare-fun f (U U) U)

--- a/src/api/PartitionManager.cc
+++ b/src/api/PartitionManager.cc
@@ -1,6 +1,10 @@
-//
-// Created by prova on 05.08.20.
-//
+/*
+ *  Copyright (c) 2020 - 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #include "PartitionManager.h"
 #include "TreeOps.h"
@@ -60,7 +64,12 @@ PTRef PartitionManager::getPartition(const ipartitions_t& mask, PartitionManager
     vec<PTRef> args;
     for (auto part : parts)
     {
-        const auto & p_mask = getIPartitions(part);
+        int partitionIndex = getPartitionIndex(part);
+        if (partitionIndex < 0) {
+            throw OsmtInternalException("Internal error in partition bookkeeping");
+        }
+        ipartitions_t p_mask = 0;
+        opensmt::setbit(p_mask, static_cast<unsigned>(partitionIndex));
         if (isLocalToP(p_mask, mask)) {
             args.push(part);
         }
@@ -68,8 +77,8 @@ PTRef PartitionManager::getPartition(const ipartitions_t& mask, PartitionManager
             throw OsmtInternalException("Assertion is neither A or B");
         }
     }
-    PTRef A = logic.mkAnd(std::move(args));
-    return A;
+    PTRef requestedPartition = logic.mkAnd(std::move(args));
+    return requestedPartition;
 }
 
 void

--- a/src/api/PartitionManager.h
+++ b/src/api/PartitionManager.h
@@ -1,6 +1,10 @@
-//
-// Created by prova on 05.08.20.
-//
+/*
+ *  Copyright (c) 2020 - 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #ifndef OPENSMT_PARTITIONMANAGER_H
 #define OPENSMT_PARTITIONMANAGER_H

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -933,7 +933,7 @@ void InterpolationContext::transformProofForCNFInterpolants() {
 bool InterpolationContext::verifyInterpolant(PTRef itp, const ipartitions_t & A_mask) const {
     PTRef partA = pmanager.getPartition(A_mask, PartitionManager::part::A);
     PTRef partB = pmanager.getPartition(A_mask, PartitionManager::part::B);
-    bool sound = VerificationUtils(config, logic).verifyInterpolantExternal(partA, partB, itp);
+    bool sound = VerificationUtils(config, logic).verifyInterpolantInternal(partA, partB, itp);
     return sound;
 }
 


### PR DESCRIPTION
This PR suggests to switch from external to internal interpolant validation with the aim of enabling interpolant validations in our regression tests.
The successful interpolant validation is asserted, so any violation in our regression test suite will be caught in CI.

This already caught a problem in how we determine how the input formula is split into A and B part.
For now, the validation is enabled only on some benchmarks in our suite, as there are still problems with validation of path interpolants or interpolants in incremental mode. This I plan to address in other PRs.