### PR TITLE
Substitutor: Optimize substitution application to variables

### DIFF
--- a/src/rewriters/Rewriter.h
+++ b/src/rewriters/Rewriter.h
@@ -16,6 +16,11 @@ public:
     Rewriter(Logic & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
 
     virtual PTRef rewrite(PTRef root) {
+        // MB: If term has no children then single call to config is enough; this can save memory allocations if successful
+        if (logic.isVar(root)) {
+            return cfg.previsit(root) ? cfg.rewrite(root) : root;
+        }
+
         struct DFSEntry {
             DFSEntry(PTRef term) : term(term) {}
             PTRef term;

--- a/src/rewriters/Rewriter.h
+++ b/src/rewriters/Rewriter.h
@@ -9,6 +9,7 @@
 
 template<typename TConfig>
 class Rewriter {
+protected:
     Logic & logic;
     TConfig & cfg;
 public:

--- a/src/rewriters/Substitutor.h
+++ b/src/rewriters/Substitutor.h
@@ -31,11 +31,4 @@ public:
     Substitutor(Logic & logic, SubstitutionConfig::SubMap const & substs) :
             Rewriter<SubstitutionConfig>(logic, config),
             config(substs) {}
-
-    PTRef rewrite(PTRef term) override {
-        if (logic.isVar(term)) {
-            return config.rewrite(term);
-        }
-        return Rewriter<SubstitutionConfig>::rewrite(term);
-    }
 };

--- a/src/rewriters/Substitutor.h
+++ b/src/rewriters/Substitutor.h
@@ -17,7 +17,7 @@ private:
 
 public:
 
-    SubstitutionConfig(Logic &, SubMap const & subMap): subMap(subMap) {}
+    SubstitutionConfig(SubMap const & subMap): subMap(subMap) {}
     PTRef rewrite(PTRef term) override {
         PTRef result;
         return subMap.peek(term, result) ? result : term;
@@ -28,7 +28,14 @@ class Substitutor : public Rewriter<SubstitutionConfig> {
     SubstitutionConfig config;
 
 public:
-    Substitutor(Logic &logic, SubstitutionConfig::SubMap const &substs) :
+    Substitutor(Logic & logic, SubstitutionConfig::SubMap const & substs) :
             Rewriter<SubstitutionConfig>(logic, config),
-            config(logic, substs) {}
+            config(substs) {}
+
+    PTRef rewrite(PTRef term) override {
+        if (logic.isVar(term)) {
+            return config.rewrite(term);
+        }
+        return Rewriter<SubstitutionConfig>::rewrite(term);
+    }
 };


### PR DESCRIPTION
The machinery of Rewriter is general, but also not optimal for simple
rewritings. Most importantly, it allocates a boolean mask (represented with
vector) to keep track of processed terms. This allocation is often
wasteful a should probably be re-thought.

Here we optimize Substitutor (a sub-class of Rewriter) to avoid the
general machinery when the term to process is a variable.
In this case, the general algorithm can be replaced by a simple lookup
in the substitutions map.