### PR TITLE
Enable validation of path interpolants

### DIFF
--- a/regression_itp/proof_duplicate_literals.smt2
+++ b/regression_itp/proof_duplicate_literals.smt2
@@ -2,6 +2,7 @@
 (set-option :proof-reduce 1)
 ;(set-option :proof-check 1)
 ;(set-option :verbosity 2)
+(set-option :certify-interpolants 1)
 (set-logic QF_UF)
 (declare-fun a () Bool)
 (declare-fun b () Bool)

--- a/src/api/PartitionManager.cc
+++ b/src/api/PartitionManager.cc
@@ -81,6 +81,18 @@ PTRef PartitionManager::getPartition(const ipartitions_t& mask, PartitionManager
     return requestedPartition;
 }
 
+vec<PTRef> PartitionManager::getPartitions(ipartitions_t const & mask) const {
+    vec<PTRef> res;
+    for (PTRef topLevelPartition : getPartitions()) {
+        int index = getPartitionIndex(topLevelPartition);
+        assert(index >= 0);
+        if (opensmt::tstbit(mask, static_cast<unsigned>(index))) {
+            res.push(topLevelPartition);
+        }
+    }
+    return res;
+}
+
 void
 PartitionManager::addClauseClassMask(CRef c, const ipartitions_t& toadd)
 {

--- a/src/api/PartitionManager.h
+++ b/src/api/PartitionManager.h
@@ -52,14 +52,11 @@ public:
 
     void invalidatePartitions(const ipartitions_t & toinvalidate);
 
-    inline std::vector<PTRef> getPartitions() { return partitionInfo.getTopLevelFormulas(); }
+    inline std::vector<PTRef> getPartitions() const { return partitionInfo.getTopLevelFormulas(); }
 
+    vec<PTRef> getPartitions(ipartitions_t const &) const;
 
-    std::vector<PTRef> getPartitions(ipartitions_t const &) {
-        throw std::logic_error{"Not supported at the moment!"};
-    }
-
-    unsigned getNofPartitions() { return partitionInfo.getNoOfPartitions(); }
+    unsigned getNofPartitions() const { return partitionInfo.getNoOfPartitions(); }
 
     void transferPartitionMembership(PTRef old, PTRef new_ptref) {
         this->addIPartitions(new_ptref, getIPartitions(old));

--- a/src/common/VerificationUtils.cc
+++ b/src/common/VerificationUtils.cc
@@ -109,5 +109,13 @@ bool VerificationUtils::checkSubsetCondition(PTRef p1, PTRef p2) {
     return true;
 }
 
+bool VerificationUtils::impliesInternal(PTRef antecedent, PTRef consequent) {
+    SMTConfig validationConfig;
+    MainSolver validationSolver(logic, validationConfig, "validator");
+    validationSolver.insertFormula(logic.mkNot(logic.mkImpl(antecedent, consequent)));
+    auto res = validationSolver.check();
+    bool valid = res == s_False;
+    return valid;
+}
 
 

--- a/src/common/VerificationUtils.cc
+++ b/src/common/VerificationUtils.cc
@@ -10,7 +10,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-bool VerificationUtils::impliesExternal(PTRef implicant, PTRef implicated) {
+bool VerificationUtils::impliesExternal(PTRef implicant, PTRef implicated) const {
     const char * implies = "implies.smt2";
     std::ofstream dump_out( implies );
     logic.dumpHeaderToFile(dump_out);
@@ -59,7 +59,7 @@ bool VerificationUtils::impliesExternal(PTRef implicant, PTRef implicated) {
     return !tool_res;
 }
 
-bool VerificationUtils::verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp) {
+bool VerificationUtils::verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp) const {
     bool verbose = config.verbosity() > 0;
     if(verbose) {
         std::cout << "; Verifying final interpolant" << std::endl;
@@ -96,7 +96,7 @@ bool VerificationUtils::verifyInterpolantInternal(PTRef Apartition, PTRef Bparti
     return checkSubsetCondition(itp, Apartition) and checkSubsetCondition(itp, Bpartition);
 }
 
-bool VerificationUtils::checkSubsetCondition(PTRef p1, PTRef p2) {
+bool VerificationUtils::checkSubsetCondition(PTRef p1, PTRef p2) const {
     MapWithKeys<PTRef, bool, PTRefHash> vars_p1;
     getVars(p1, logic, vars_p1);
     MapWithKeys<PTRef, bool, PTRefHash> vars_p2;

--- a/src/common/VerificationUtils.h
+++ b/src/common/VerificationUtils.h
@@ -14,16 +14,16 @@ class VerificationUtils {
 public:
     VerificationUtils(SMTConfig const & config, Logic & logic) : config(config), logic(logic) {}
 
-    bool impliesExternal(PTRef, PTRef); // Check the result with an external solver
+    bool impliesExternal(PTRef, PTRef) const; // Check the result with an external solver
 
-    bool verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp); // Verify interpolant using an external solver
+    bool verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp) const; // Verify interpolant using an external solver
 
     bool verifyInterpolantInternal(PTRef partA, PTRef partB, PTRef itp); // Verify interpolant internally, using OpenSMT's MainSolver
 
     bool impliesInternal(PTRef antecedent, PTRef consequent); // Verify validity of implication `antecedent -> consequent`, using OpenSMT's MainSolver
 
 private:
-    bool checkSubsetCondition(PTRef p1, PTRef p2);
+    bool checkSubsetCondition(PTRef p1, PTRef p2) const;
 };
 
 

--- a/src/common/VerificationUtils.h
+++ b/src/common/VerificationUtils.h
@@ -20,6 +20,8 @@ public:
 
     bool verifyInterpolantInternal(PTRef partA, PTRef partB, PTRef itp); // Verify interpolant internally, using OpenSMT's MainSolver
 
+    bool impliesInternal(PTRef antecedent, PTRef consequent); // Verify validity of implication `antecedent -> consequent`, using OpenSMT's MainSolver
+
 private:
     bool checkSubsetCondition(PTRef p1, PTRef p2);
 };

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -901,7 +901,7 @@ bool InterpolationContext::getPathInterpolants(vec<PTRef> & interpolants, const 
             PTRef previous_itp = interpolants[interpolants.size() - 2];
             PTRef next_itp = interpolants[interpolants.size() - 1];
             PTRef movedPartitions = logic.mkAnd(pmanager.getPartitions(A_masks[i] ^ A_masks[i - 1]));
-            propertySatisfied &= VerificationUtils(config, logic).impliesExternal(logic.mkAnd(previous_itp, movedPartitions), next_itp);
+            propertySatisfied &= VerificationUtils(config, logic).impliesInternal(logic.mkAnd(previous_itp, movedPartitions), next_itp);
             if (not propertySatisfied) {
                 std::cerr << "; Path interpolation does not hold for:\n"
                           << "First interpolant: " << logic.printTerm(previous_itp) << '\n'


### PR DESCRIPTION
This PR continues the work of #441 and enables internal validation of path interpolation property.
It also implements missing functionality in `PartitionManager` to return any subset of top-level asserted formulas, which is needed to validate path interpolants.