### PR TITLE
ArithLogic: Use direct simplification for sum of constants

### DIFF
--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -19,13 +19,13 @@ namespace{
 class SimplifyConst {
 protected:
     ArithLogic& l;
-    PTRef simplifyConstOp(const vec<PTRef> & const_terms);
     virtual void Op(opensmt::Number& s, const opensmt::Number& v) const = 0;
     virtual opensmt::Number getIdOp() const = 0;
     virtual void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const = 0;
 public:
     SimplifyConst(ArithLogic& log) : l(log) {}
     void simplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new);
+    PTRef simplifyConstOp(const vec<PTRef> & const_terms);
 };
 
 class SimplifyConstSum : public SimplifyConst {
@@ -429,7 +429,7 @@ PTRef ArithLogic::mkPlus(vec<PTRef> && args)
     flattened_args.clear();
     for (PTRef key : keys) {
         const vec<PTRef>& consts = s2t[key];
-        PTRef consts_summed = consts.size() == 1 ? consts[0] : mkPlus(consts);
+        PTRef consts_summed = consts.size() == 1 ? consts[0] : SimplifyConstSum(*this).simplifyConstOp(consts);
         if (isZero(consts_summed)) { continue; }
         if (key == PTRef_Undef) {
             flattened_args.push(consts_summed);

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -15,6 +15,44 @@ const std::string ArithLogic::e_nonlinear_term = "Logic does not support nonline
  * Class defining simplifications
  ***********************************************************/
 
+namespace{
+class SimplifyConst {
+protected:
+    ArithLogic& l;
+    PTRef simplifyConstOp(const vec<PTRef> & const_terms);
+    virtual void Op(opensmt::Number& s, const opensmt::Number& v) const = 0;
+    virtual opensmt::Number getIdOp() const = 0;
+    virtual void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const = 0;
+public:
+    SimplifyConst(ArithLogic& log) : l(log) {}
+    void simplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new);
+};
+
+class SimplifyConstSum : public SimplifyConst {
+    void Op(opensmt::Number& s, const opensmt::Number& v) const { s += v; }
+    opensmt::Number getIdOp() const { return 0; }
+    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
+public:
+    SimplifyConstSum(ArithLogic& log) : SimplifyConst(log) {}
+};
+
+class SimplifyConstTimes : public SimplifyConst {
+    void Op(opensmt::Number& s, const opensmt::Number& v) const { s *= v; }
+    opensmt::Number getIdOp() const { return 1; }
+    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
+public:
+    SimplifyConstTimes(ArithLogic& log) : SimplifyConst(log) {}
+};
+
+class SimplifyConstDiv : public SimplifyConst {
+    void Op(opensmt::Number& s, const opensmt::Number& v) const { if (v == 0) { printf("explicit div by zero\n"); } s /= v; }
+    opensmt::Number getIdOp() const { return 1; }
+    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
+public:
+    SimplifyConstDiv(ArithLogic& log) : SimplifyConst(log) {}
+};
+}
+
 const std::string ArithLogic::tk_int_zero  = "0";
 const std::string ArithLogic::tk_int_one   = "1";
 const std::string ArithLogic::tk_int_neg   = "-";

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -417,40 +417,4 @@ public:
     bool operator ()  (PTRef x_, PTRef y_) const;
 
 };
-
-class SimplifyConst {
-protected:
-    ArithLogic& l;
-    PTRef simplifyConstOp(const vec<PTRef> & const_terms);
-    virtual void Op(opensmt::Number& s, const opensmt::Number& v) const = 0;
-    virtual opensmt::Number getIdOp() const = 0;
-    virtual void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const = 0;
-public:
-    SimplifyConst(ArithLogic& log) : l(log) {}
-    void simplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new);
-};
-
-class SimplifyConstSum : public SimplifyConst {
-    void Op(opensmt::Number& s, const opensmt::Number& v) const { s += v; }
-    opensmt::Number getIdOp() const { return 0; }
-    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
-public:
-    SimplifyConstSum(ArithLogic& log) : SimplifyConst(log) {}
-};
-
-class SimplifyConstTimes : public SimplifyConst {
-    void Op(opensmt::Number& s, const opensmt::Number& v) const { s *= v; }
-    opensmt::Number getIdOp() const { return 1; }
-    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
-public:
-    SimplifyConstTimes(ArithLogic& log) : SimplifyConst(log) {}
-};
-
-class SimplifyConstDiv : public SimplifyConst {
-    void Op(opensmt::Number& s, const opensmt::Number& v) const { if (v == 0) { printf("explicit div by zero\n"); } s /= v; }
-    opensmt::Number getIdOp() const { return 1; }
-    void constSimplify(SymRef s, vec<PTRef> const & terms, SymRef & s_new, vec<PTRef> & terms_new) const;
-public:
-    SimplifyConstDiv(ArithLogic& log) : SimplifyConst(log) {}
-};
 #endif


### PR DESCRIPTION
In ArithLogic::mkPlus, when combining linear terms with the same variable, we collect the constants from all such terms. Then we need to sum these constants together. Instead of calling mkPlus again, we can directly call the constant simplification procedure, as we know that all the terms we are trying to sum must be numeric constants.
This saves some unnecessary vector copying.

I also suggest to move the simplification helpers into the `.cc` file, so we don't expose them unnecessarily.