### PR TITLE
CMake: Add an option to prefer static GMP libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,18 @@ option(PRINT_UNITS "Print units" OFF)
 option(DEBUG_GC "Debug garbage collection" OFF)
 option(LADEBUG "Debug lookahead" OFF)
 option(PRINT_DECOMPOSED_STATS "Print statistics about decomposed interpolants" OFF)
+option(EXPLICIT_CONGRUENCE_EXPLANATIONS "Construct explicit congruence explanations" OFF)
+option(MATRIX_DEBUG "Trace matrix operations (noisy output)" OFF)
 option(STATISTICS "Compute and print solver's statistics" OFF)
+
 option(ENABLE_LINE_EDITING "Enable line editing with readline or libedit" OFF)
 option(USE_READLINE "Use readline over libedit" OFF)
+
 option(BUILD_STATIC_LIBS "Build static library" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(BUILD_EXECUTABLES "Build executables" ON)
-option(EXPLICIT_CONGRUENCE_EXPLANATIONS "Construct explicit congruence explanations" OFF)
-option(MATRIX_DEBUG "Trace matrix operations (noisy output)" OFF)
+
+option(PREFER_STATIC_GMP "Link to static version of GMP if possible" OFF)
 
 find_package(GMP REQUIRED)
 

--- a/cmake_modules/FindGMP.cmake
+++ b/cmake_modules/FindGMP.cmake
@@ -3,9 +3,15 @@
 # GMP_INCLUDE_DIR - the GMP include directory
 # GMP_LIBRARIES - Libraries needed to use GMP
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h )
-find_library(GMP_LIBRARY NAMES gmp libgmp )
-find_library(GMPXX_LIBRARY NAMES gmpxx libgmpxx )
+if(PREFER_STATIC_GMP)
+    #message("Trying to find static version of GMP")
+    find_library(GMP_LIBRARY NAMES libgmp.a)
+    find_library(GMPXX_LIBRARY NAMES libgmpxx.a)
+endif(PREFER_STATIC_GMP)
+
+find_library(GMP_LIBRARY NAMES gmp)
+find_library(GMPXX_LIBRARY NAMES gmpxx)
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY GMPXX_LIBRARY)
 MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARY} " " ${GMPXX_LIBRARY} )
 MESSAGE(STATUS "GMP include: " ${GMP_INCLUDE_DIR})


### PR DESCRIPTION
Here is my take on how to force CMake to prefer static over shared GMP library, if we want to.
This is useful for creating statically linked executables.