### PR TITLE
Rewriter: Optimize memory (re-)usage

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -23,7 +23,8 @@ target_sources(common
 
 install(FILES
         Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h Timer.h osmtinttypes.h
-    TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h NumberUtils.h
+        TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h 
+        NumberUtils.h NatSet.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -1,28 +1,10 @@
-/*********************************************************************
-Author: Antti Hyvarinen <antti.hyvarinen@gmail.com>
-
-OpenSMT2 -- Copyright (C) 2012 - 2014 Antti Hyvarinen
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*********************************************************************/
-
+/*
+ * Copyright (c) 2012-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2021-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #ifndef Common_TreeOps_h
 #define Common_TreeOps_h

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -35,6 +35,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "OsmtApiException.h"
 #include "FunctionTools.h"
 #include "TypeUtils.h"
+#include "NatSet.h"
+
 #include <cassert>
 #include <cstring>
 #include <cstdlib>
@@ -97,6 +99,8 @@ class Logic {
     SStore              sort_store;
     SymStore            sym_store;
     PtStore             term_store;
+
+    nat_set             auxiliaryNatSet;
 
     SSymRef             sym_IndexedSort;
 
@@ -193,6 +197,7 @@ class Logic {
     const Pterm& getPterm     (const PTRef tr)        const { return term_store[tr];  }
     PtermIter   getPtermIter  ()                            { return term_store.getPtermIter(); }
 
+    nat_set & getTermSet() { return auxiliaryNatSet; }
     // Default values for the logic
 
     // Deprecated! Use getDefaultValuePTRef instead

--- a/src/rewriters/Rewriter.h
+++ b/src/rewriters/Rewriter.h
@@ -1,6 +1,10 @@
-//
-// Created by Martin Blicha on 10.02.21.
-//
+/*
+ * Copyright (c) 2021-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2021-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #ifndef OPENSMT_REWRITER_H
 #define OPENSMT_REWRITER_H


### PR DESCRIPTION
This PR suggests 2 ways to optimize memory usage in Rewriter:
1. The auxiliary vector for marking processed terms can be reused. I suggest to put it in `Logic` as it can be re-used for other purposes as well. Using `nat_set` instead of `vec` has the advantage that it can be cleared in constant time.
2. When building a new version of the term with rewriting already applied to its children, we need to collect the new children. Previously we were constructing new vector for every term, we can re-use a single vector for the whole rewriting process.