### PR TITLE
Logic: Use wrapper with nicer interface for term marking

### DIFF
--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -20,10 +20,10 @@
 
 template<typename TConfig>
 class TermVisitor {
-    Logic & logic;
+    Logic const & logic;
     TConfig & cfg;
 public:
-    TermVisitor(Logic & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
+    TermVisitor(Logic const & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
 
     void visit(PTRef root) {
         struct DFSEntry {
@@ -94,10 +94,10 @@ public:
 };
 
 class TopLevelConjunctsConfig : public DefaultVisitorConfig {
-    Logic & logic;
+    Logic const & logic;
     vec<PTRef> & conjuncts;
 public:
-    TopLevelConjunctsConfig(Logic & logic, vec<PTRef> & res) : logic(logic), conjuncts(res) {}
+    TopLevelConjunctsConfig(Logic const & logic, vec<PTRef> & res) : logic(logic), conjuncts(res) {}
 
     bool previsit(PTRef term) override {
         if (not logic.isAnd(term)) {
@@ -108,12 +108,12 @@ public:
     }
 };
 
-inline void topLevelConjuncts(Logic & logic, PTRef fla, vec<PTRef> & res) {
+inline void topLevelConjuncts(Logic const & logic, PTRef fla, vec<PTRef> & res) {
     TopLevelConjunctsConfig config(logic, res);
     TermVisitor<TopLevelConjunctsConfig>(logic, config).visit(fla);
 }
 
-inline vec<PTRef> topLevelConjuncts(Logic & logic, PTRef fla) {
+inline vec<PTRef> topLevelConjuncts(Logic const & logic, PTRef fla) {
     vec<PTRef> res;
     topLevelConjuncts(logic, fla, res);
     return res;

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -32,37 +32,34 @@ public:
             unsigned int nextChild = 0;
         };
         // MB: Relies on an invariant that id of a child is lower than id of a parent.
-        auto size = Idx(logic.getPterm(root).getId()) + 1;
-        auto & termSet = logic.getTermSet();
-        termSet.assure_domain(size);
-        termSet.reset();
+        auto termMarks = logic.getTermMarks(logic.getPterm(root).getId());
         std::vector<DFSEntry> toProcess;
         toProcess.emplace_back(root);
         while (not toProcess.empty()) {
             auto & currentEntry = toProcess.back();
             PTRef currentRef = currentEntry.term;
-            auto currentId = Idx(logic.getPterm(currentRef).getId());
+            auto currentId = logic.getPterm(currentRef).getId();
             if (not cfg.previsit(currentRef)) {
                 toProcess.pop_back();
-                termSet.insert(currentId);
+                termMarks.mark(currentId);
                 continue;
             }
-            assert(not termSet.contains(currentId));
+            assert(not termMarks.isMarked(currentId));
             Pterm const & term = logic.getPterm(currentRef);
             unsigned childrenCount = term.size();
             if (currentEntry.nextChild < childrenCount) {
                 PTRef nextChild = term[currentEntry.nextChild];
                 ++currentEntry.nextChild;
-                auto childId = Idx(logic.getPterm(nextChild).getId());
-                if (not termSet.contains(childId)) {
+                auto childId = logic.getPterm(nextChild).getId();
+                if (not termMarks.isMarked(childId)) {
                     toProcess.push_back(DFSEntry(nextChild));
                 }
                 continue;
             }
             // If we are here, we have already processed all children
-            assert(not termSet.contains(currentId));
+            assert(not termMarks.isMarked(currentId));
             cfg.visit(currentRef);
-            termSet.insert(currentId);
+            termMarks.mark(currentId);
             toProcess.pop_back();
         }
     }

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -26,12 +26,18 @@ public:
     TermVisitor(Logic const & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
 
     void visit(PTRef root) {
+        // Avoid initializations if no traversal will be done
+        if (logic.isVar(root)) {
+            if (cfg.previsit(root))
+                cfg.visit(root);
+            return;
+        }
         struct DFSEntry {
             DFSEntry(PTRef term) : term(term) {}
             PTRef term;
             unsigned int nextChild = 0;
         };
-        // MB: Relies on an invariant that id of a child is lower than id of a parent.
+
         auto termMarks = logic.getTermMarks(logic.getPterm(root).getId());
         std::vector<DFSEntry> toProcess;
         toProcess.emplace_back(root);

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1,27 +1,10 @@
-/*********************************************************************
-Author: Antti Hyvarinen <antti.hyvarinen@gmail.com>
-
-OpenSMT2 -- Copyright (C) 2012 - 2014 Antti Hyvarinen
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*********************************************************************/
+/*
+ * Copyright (c) 2012-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2018-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #include "Logic.h"
 #include "SStore.h"

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -1,27 +1,10 @@
-/*********************************************************************
-Author: Antti Hyvarinen <antti.hyvarinen@gmail.com>
-
-OpenSMT2 -- Copyright (C) 2012 - 2015 Antti Hyvarinen
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*********************************************************************/
+/*
+ * Copyright (c) 2012-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2018-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 
 #ifndef LOGIC_H

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -100,7 +100,17 @@ class Logic {
     SymStore            sym_store;
     PtStore             term_store;
 
-    nat_set             auxiliaryNatSet;
+    class TermMarks {
+        nat_set & innerSet;
+    public:
+        TermMarks(nat_set & innerSet, unsigned int domainSize) : innerSet(innerSet){
+            innerSet.assure_domain(domainSize);
+            innerSet.reset();
+        }
+        inline void mark(PTId id) { innerSet.insert(Idx(id)); }
+        inline bool isMarked(PTId id) const { return innerSet.contains(Idx(id)); }
+    };
+    mutable nat_set     auxiliaryNatSet;
 
     SSymRef             sym_IndexedSort;
 
@@ -197,7 +207,7 @@ class Logic {
     const Pterm& getPterm     (const PTRef tr)        const { return term_store[tr];  }
     PtermIter   getPtermIter  ()                            { return term_store.getPtermIter(); }
 
-    nat_set & getTermSet() { return auxiliaryNatSet; }
+    TermMarks getTermMarks(PTId maxTermId) const { return TermMarks(auxiliaryNatSet, Idx(maxTermId) + 1); }
     // Default values for the logic
 
     // Deprecated! Use getDefaultValuePTRef instead

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -190,6 +190,11 @@ class Logic {
     const Pterm& getPterm     (const PTRef tr)        const { return term_store[tr];  }
     PtermIter   getPtermIter  ()                            { return term_store.getPtermIter(); }
 
+    /*
+     * Provides an efficient data structure for representing a set of terms through "marking".
+     *
+     * Relies on a term invariant that id of a child is lower than id of a parent.
+     */
     TermMarks getTermMarks(PTId maxTermId) const { return TermMarks(auxiliaryNatSet, Idx(maxTermId) + 1); }
     // Default values for the logic
 

--- a/src/rewriters/Rewriter.h
+++ b/src/rewriters/Rewriter.h
@@ -30,7 +30,6 @@ public:
             PTRef term;
             unsigned int nextChild = 0;
         };
-        // MB: Relies on an invariant that id of a child is lower than id of a parent.
         auto termMarks = logic.getTermMarks(logic.getPterm(root).getId());
         Map<PTRef, PTRef, PTRefHash> substitutions;
         vec<PTRef> auxiliaryArgs;


### PR DESCRIPTION
We can hide the implementation details of using nat_set and provide a nicer interface (especially the constructor takes care of setting up the  low-level data structure) for term markings.

We can also mark the nat_set mutable (basically not considering it a logical part of the Logic state) and thus allowing the method for creating TermMarks helper constant on Logic.