### PR TITLE
Logic: make abstract value counter member of logic

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -54,11 +54,11 @@ const char* Logic::s_ite_prefix = ".oite";
 const char* Logic::s_framev_prefix = ".frame";
 const char* Logic::s_abstract_value_prefix = "@";
 
-std::size_t Logic::abstractValueCount = 0;
 
 // The constructor initiates the base logic (Boolean)
 Logic::Logic(opensmt::Logic_t _logicType) :
       logicType(_logicType)
+    , abstractValueCount(0)
     , distinctClassCount(0)
     , sort_store()
     , term_store(sym_store)

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -58,7 +58,6 @@ const char* Logic::s_abstract_value_prefix = "@";
 // The constructor initiates the base logic (Boolean)
 Logic::Logic(opensmt::Logic_t _logicType) :
       logicType(_logicType)
-    , abstractValueCount(0)
     , distinctClassCount(0)
     , sort_store()
     , term_store(sym_store)

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -47,7 +47,7 @@ class Logic {
 
     bool isKnownToUser(std::string_view name) const { return name[0] != s_abstract_value_prefix[0]; }
     bool isKnownToUser(SymRef sr) const { return isKnownToUser(getSymName(sr)); }
-    std::size_t abstractValueCount;
+    std::size_t abstractValueCount = 0;
     int distinctClassCount;
 
     class DefinedFunctions {

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -31,7 +31,6 @@ class Logic {
   public:
     using SubstMap = MapWithKeys<PTRef,PTRef,PTRefHash>;
   protected:
-    static std::size_t abstractValueCount;
     static const char* e_argnum_mismatch;
     static const char* e_bad_constant;
 
@@ -48,6 +47,7 @@ class Logic {
 
     bool isKnownToUser(std::string_view name) const { return name[0] != s_abstract_value_prefix[0]; }
     bool isKnownToUser(SymRef sr) const { return isKnownToUser(getSymName(sr)); }
+    std::size_t abstractValueCount;
     int distinctClassCount;
 
     class DefinedFunctions {


### PR DESCRIPTION
Right now I see no reason why the abstract value counter, used for getting unique names for values in uninterpreted function models, should be a global variable.  This PR suggests to turn it into a member of `Logic`.