### PR TITLE
Terms: Add generic subterms collector

### DIFF
--- a/src/api/PartitionManager.cc
+++ b/src/api/PartitionManager.cc
@@ -37,14 +37,7 @@ void PartitionManager::propagatePartitionMask(PTRef root) {
 }
 
 ipartitions_t PartitionManager::computeAllowedPartitions(PTRef p) {
-    vec<PtChild> subterms;
-    getTermList(p, subterms, logic);
-    vec<PTRef> vars;
-    for (int i = 0; i < subterms.size(); ++i) {
-        if (logic.isVar(subterms[i].tr)) {
-            vars.push(subterms[i].tr);
-        }
-    }
+    vec<PTRef> vars = variables(logic, p);
     if (vars.size() == 0) { return 0; }
     ipartitions_t allowed = getIPartitions(vars[0]);
     for (int i = 1; i < vars.size(); ++i) {

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -270,18 +270,18 @@ public:
 };
 
 template<typename TPred>
-static vec<PTRef> subTerms(Logic & logic, PTRef term, TPred predicate) {
+static vec<PTRef> subTerms(Logic const & logic, PTRef term, TPred predicate) {
     TermCollectorConfig<TPred> config(predicate);
     TermVisitor<decltype(config)>(logic, config).visit(term);
     return config.extractCollectedTerms();
 }
 
-inline vec<PTRef> subTerms(Logic & logic, PTRef term) {
+inline vec<PTRef> subTerms(Logic const & logic, PTRef term) {
     return subTerms(logic, term, [](PTRef){ return true; });
 }
 
 /* Returns all variables present in the given term */
-inline vec<PTRef> variables(Logic & logic, PTRef term) {
+inline vec<PTRef> variables(Logic const & logic, PTRef term) {
     return subTerms(logic, term, [&](PTRef subTerm) { return logic.isVar(subTerm); });
 }
 

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -221,6 +221,7 @@ getVars(PTRef tr, Logic& logic, MapWithKeys<PTRef,bool,PTRefHash>& vars)
     }
 }
 
+[[deprecated]]
 inline std::vector<PTRef>
 getAtoms(PTRef tr, Logic & logic)
 {

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -270,19 +270,19 @@ public:
 };
 
 template<typename TPred>
-static vec<PTRef> subTerms(Logic const & logic, PTRef term, TPred predicate) {
+static vec<PTRef> matchingSubTerms(Logic const & logic, PTRef term, TPred predicate) {
     TermCollectorConfig<TPred> config(predicate);
     TermVisitor<decltype(config)>(logic, config).visit(term);
     return config.extractCollectedTerms();
 }
 
 inline vec<PTRef> subTerms(Logic const & logic, PTRef term) {
-    return subTerms(logic, term, [](PTRef){ return true; });
+    return matchingSubTerms(logic, term, [](PTRef) { return true; });
 }
 
 /* Returns all variables present in the given term */
 inline vec<PTRef> variables(Logic const & logic, PTRef term) {
-    return subTerms(logic, term, [&](PTRef subTerm) { return logic.isVar(subTerm); });
+    return matchingSubTerms(logic, term, [&](PTRef subTerm) { return logic.isVar(subTerm); });
 }
 
 #endif

--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -141,6 +141,7 @@ class Qel {
 // However, the list_out will not contain duplicates.
 //
 template<class T>
+[[deprecated]]
 void getTermsList(const vec<PTRef>& trs, vec<T>& list_out, Logic& logic) {
     vec<Qel<PtChild> > queue;
     Map<PtChild,bool,PtChildHash> seen;
@@ -178,7 +179,9 @@ void getTermsList(const vec<PTRef>& trs, vec<T>& list_out, Logic& logic) {
     }
 }
 
+
 template<class T>
+[[deprecated]]
 void getTermList(PTRef tr, vec<T>& list_out, Logic& logic) {
     getTermsList({tr}, list_out, logic);
 }

--- a/src/common/VerificationUtils.cc
+++ b/src/common/VerificationUtils.cc
@@ -97,12 +97,10 @@ bool VerificationUtils::verifyInterpolantInternal(PTRef Apartition, PTRef Bparti
 }
 
 bool VerificationUtils::checkSubsetCondition(PTRef p1, PTRef p2) const {
-    MapWithKeys<PTRef, bool, PTRefHash> vars_p1;
-    getVars(p1, logic, vars_p1);
-    MapWithKeys<PTRef, bool, PTRefHash> vars_p2;
-    getVars(p2, logic, vars_p2);
-    for (PTRef key : vars_p1.getKeys()) {
-        if (vars_p1[key] and (not vars_p2.has(key))) {
+    auto vars_p1 = variables(logic, p1);
+    auto vars_p2 = variables(logic, p2);
+    for (PTRef key : vars_p1) {
+        if (std::find(vars_p2.begin(), vars_p2.end(), key) == vars_p2.end()) {
             return false;
         }
     }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -213,13 +213,13 @@ target_sources(ArithLogicApiTest
 target_link_libraries(ArithLogicApiTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET ArithLogicApiTest)
 
-add_executable(SortsTest)
-target_sources(SortsTest
+add_executable(TermsTest)
+target_sources(TermsTest
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Sorts.cc"
         )
 
-target_link_libraries(SortsTest OpenSMT gtest gtest_main)
-gtest_add_tests(TARGET SortsTest)
+target_link_libraries(TermsTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET TermsTest)
 
 add_executable(LASolverIncrementalityTest)
 target_sources(LASolverIncrementalityTest

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -216,6 +216,7 @@ gtest_add_tests(TARGET ArithLogicApiTest)
 add_executable(TermsTest)
 target_sources(TermsTest
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Sorts.cc"
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Visitors.cc"
         )
 
 target_link_libraries(TermsTest OpenSMT gtest gtest_main)

--- a/test/unit/test_Ites.cc
+++ b/test/unit/test_Ites.cc
@@ -210,8 +210,8 @@ TEST_F(LogicIteTest, test_IteHandlerNestedIte) {
     PTRef res = handler.rewrite(outer);
     std::cout << logic.pp(res) << std::endl;
     // only 1 variable should be introduced for the single top-level ITE
-    auto atoms = getAtoms(res, logic);
-    ASSERT_EQ(atoms.size(), 5); // 4 original + 1 auxiliary variable
+    auto vars = variables(logic, res);
+    ASSERT_EQ(vars.size(), 5); // 4 original + 1 auxiliary variable
 }
 
 TEST_F(LogicIteTest, test_IteHandlerNestedAndTopLevelAtTheSameTime) {
@@ -228,8 +228,8 @@ TEST_F(LogicIteTest, test_IteHandlerNestedAndTopLevelAtTheSameTime) {
     PTRef res = handler.rewrite(fla);
     std::cout << logic.pp(res) << std::endl;
     // 2 variables should be introduced since the ITE that is nested in the first part is top-level in the second part of the formula
-    auto atoms = getAtoms(res, logic);
-    ASSERT_EQ(atoms.size(), 6); // 4 original + 2 auxiliary variables
+    auto vars = variables(logic, res);
+    ASSERT_EQ(vars.size(), 6); // 4 original + 2 auxiliary variables
 }
 
 TEST_F(LogicIteTest, test_IteHandler_RewriteTwiceSame) {

--- a/test/unit/test_Visitors.cc
+++ b/test/unit/test_Visitors.cc
@@ -77,7 +77,7 @@ TEST_F(VisitorTest, test_GetSubTermsArbitraryPredicate) {
     PTRef plus1 = logic.mkPlus(x,y);
     PTRef plus2 = logic.mkPlus(x,z);
     PTRef fla = logic.mkAnd(logic.mkGeq(plus1, zero), logic.mkGeq(plus2, zero));
-    auto subterms = subTerms(logic, fla, [&](PTRef subterm) { return logic.isPlus(subterm); });
+    auto subterms = matchingSubTerms(logic, fla, [&](PTRef subterm) { return logic.isPlus(subterm); });
     ASSERT_TRUE(subterms.size() == 2);
     EXPECT_TRUE(contains(subterms,plus1));
     EXPECT_TRUE(contains(subterms,plus2));

--- a/test/unit/test_Visitors.cc
+++ b/test/unit/test_Visitors.cc
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <ArithLogic.h>
+#include <TreeOps.h>
+
+#include <algorithm>
+
+class VisitorTest : public ::testing::Test {
+protected:
+    VisitorTest() : logic{opensmt::Logic_t::QF_LRA} {}
+
+    virtual void SetUp() {
+        x = logic.mkRealVar("x");
+        y = logic.mkRealVar("y");
+        z = logic.mkRealVar("z");
+        b = logic.mkBoolVar("b");
+    }
+
+    ArithLogic logic;
+    PTRef x, y, z;
+    PTRef b;
+
+    bool contains(vec<PTRef> const & terms, PTRef term) const { return std::find(terms.begin(), terms.end(), term) != terms.end(); }
+};
+
+TEST_F(VisitorTest, test_GetVariablesZero) {
+    auto vars = variables(logic, logic.getTerm_RealZero());
+    ASSERT_TRUE(vars.size() == 0);
+}
+
+TEST_F(VisitorTest, test_GetVariablesOne) {
+    auto vars = variables(logic, x);
+    ASSERT_TRUE(vars.size() == 1);
+    ASSERT_EQ(vars[0], x);
+}
+
+TEST_F(VisitorTest, test_GetVariablesMany) {
+    auto vars = variables(logic, logic.mkPlus(vec<PTRef>{x, y, logic.mkTimes(z, logic.mkRealConst(2))}));
+    ASSERT_TRUE(vars.size() == 3);
+    EXPECT_TRUE(contains(vars,x));
+    EXPECT_TRUE(contains(vars,y));
+    EXPECT_TRUE(contains(vars,z));
+}
+
+TEST_F(VisitorTest, test_GetVariablesNoDuplicates) {
+    PTRef term = logic.mkAnd(logic.mkGeq(x, y), logic.mkGeq(x,z));
+    auto vars = variables(logic, term);
+    ASSERT_TRUE(vars.size() == 3);
+    EXPECT_TRUE(contains(vars,x));
+    EXPECT_TRUE(contains(vars,y));
+    EXPECT_TRUE(contains(vars,z));
+}
+
+TEST_F(VisitorTest, test_GetAllSubTermsConstant) {
+    auto subterms = subTerms(logic, logic.getTerm_true());
+    ASSERT_TRUE(subterms.size() == 1);
+    ASSERT_EQ(subterms[0], logic.getTerm_true());
+}
+
+TEST_F(VisitorTest, test_GetAllSubTermsBasicSum) {
+    PTRef sum = logic.mkPlus(x,y);
+    auto subterms = subTerms(logic, sum);
+    ASSERT_TRUE(subterms.size() == 3);
+    EXPECT_TRUE(contains(subterms,x));
+    EXPECT_TRUE(contains(subterms,y));
+    EXPECT_TRUE(contains(subterms,sum));
+}
+
+TEST_F(VisitorTest, test_GetSubTermsArbitraryPredicate) {
+    PTRef zero = logic.getTerm_RealZero();
+    PTRef plus1 = logic.mkPlus(x,y);
+    PTRef plus2 = logic.mkPlus(x,z);
+    PTRef fla = logic.mkAnd(logic.mkGeq(plus1, zero), logic.mkGeq(plus2, zero));
+    auto subterms = subTerms(logic, fla, [&](PTRef subterm) { return logic.isPlus(subterm); });
+    ASSERT_TRUE(subterms.size() == 2);
+    EXPECT_TRUE(contains(subterms,plus1));
+    EXPECT_TRUE(contains(subterms,plus2));
+}


### PR DESCRIPTION
This PR adds a generic visitor for collecting subterms of a term, templated by a predicate the subterms need to satisfy.
Two helper methods are added for collecting all subterms and for collecting all variables.

This follows the pattern of uniting all operations on terms on our base `Visitor` and `Rewriter`.

Some existing methods are marked as deprecated and I suggest to remove them in the future. This is subject for discussion.