### PR TITLE
CI: Make build script build-system-agnostic

### DIFF
--- a/ci/build_maximally_static.sh
+++ b/ci/build_maximally_static.sh
@@ -23,7 +23,7 @@ cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       ${LINKER_OPTIONS} \
       ..
 
-make -j4
+cmake --build . -j 4
 
 strip opensmt
 


### PR DESCRIPTION
CMake can be instructed to build the project with the build system that has been used in configuration.
For example, I now use ninja as the default build system in CMake, so
the script did not work for me before.