### PR TITLE
Adding vivification + glue recalc on analyze

### DIFF
--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -94,7 +94,7 @@ int main( int argc, char * argv[] )
 
     SMTConfig c;
     bool pipe = false;
-    while ((opt = getopt(argc, argv, "hdpir:")) != -1) {
+    while ((opt = getopt(argc, argv, "hdpir:v")) != -1) {
         switch (opt) {
 
             case 'h':
@@ -112,6 +112,9 @@ int main( int argc, char * argv[] )
                 break;
             case 'i':
                 c.setOption(SMTConfig::o_produce_inter, SMTOption(true), msg);
+                break;
+            case 'v':
+                c.setOption(SMTConfig::o_verbosity, SMTOption(true), msg);
                 break;
             case 'p':
                 pipe = true;

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -142,7 +142,8 @@ class Clause {
         unsigned has_extra : 1;
         unsigned reloced   : 1;
         unsigned glue      : 3;
-        unsigned size      : 24; }                            header;
+        unsigned vivifed   : 1;
+        unsigned size      : 23; }                            header;
     union { Lit lit; float act; uint32_t abs; CRef rel; } data[0];
 
     friend class ClauseAllocator;
@@ -156,6 +157,7 @@ class Clause {
         header.reloced   = 0;
         header.size      = ps.size();
         header.glue      = 7;
+        header.vivifed   = false;
 
         for (unsigned i = 0; i < (unsigned)ps.size(); i++)
             data[i].lit = ps[i];
@@ -165,11 +167,6 @@ class Clause {
                 data[header.size].act = 0; 
             else 
                 calcAbstraction(); }
-    }
-
-    void setGlue(const uint32_t glue) {
-        assert(glue < 8);
-        header.glue = glue;
     }
 
 public:
@@ -207,6 +204,16 @@ public:
     void         strengthen  (Lit p);
     uint32_t     getGlue() const {
         return header.glue;
+    }
+    void setGlue(const uint32_t glue) {
+        assert(glue < 8);
+        header.glue = glue;
+    }
+    bool         getVivif() const {
+        return header.vivifed;
+    }
+    void         setVivif(bool val) {
+        header.vivifed = val;
     }
 };
 

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -131,6 +131,15 @@ public:
     void    toDimacs     (const char* file, Lit p, Lit q);
     void    toDimacs     (const char* file, Lit p, Lit q, Lit r);
 
+    // Vivification
+    std::vector<Lit> vivif_tmp_lits;
+    std::vector<Lit> vivif_new;
+    bool     vivify_if_needed();
+    bool     vivify_one_clause(Clause& cl, CRef offs);
+    uint64_t next_vivify = 25000;
+    uint64_t vivif_lit_rem = 0;
+    uint64_t vivif_cl_rem = 0;
+
     // Variable mode:
     //
     void    setDecisionVar (Var v, bool b); // Declare if a variable should be eligible for selection in the decision heuristic.
@@ -376,7 +385,8 @@ protected:
     CRef     propagate        ();                                                      // Perform unit propagation. Returns possibly conflicting clause.
     virtual void cancelUntil  (int level);                                             // Backtrack until a certain level.
     void     analyze          (CRef confl, vec<Lit>& out_learnt, int& out_btlevel);    // (bt = backtrack)
-    uint32_t computeGlue(vec<Lit> const & ps);
+    template<class T>
+    uint32_t computeGlue(T const & ps);
     nat_set  levelsInClause;
     void     analyzeFinal     (Lit p, vec<Lit>& out_conflict);                         // COULD THIS BE IMPLEMENTED BY THE ORDINARIY "analyze" BY SOME REASONABLE GENERALIZATION?
     bool     litRedundant     (Lit p, uint32_t abstract_levels);                       // (helper method for 'analyze()')

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -84,6 +84,7 @@ SimpSMTSolver::~SimpSMTSolver( )
 void SimpSMTSolver::initialize( )
 {
     CoreSMTSolver::initialize( );
+    if (config.verbosity()) verbosity = true;
 
     if (config.produce_inter()) {
         if (config.sat_preprocess_booleans != 0


### PR DESCRIPTION
Well, here goes another try. The vilification should be limited, to be honest, by mems (as Donald Knuth puts it), but I didn't bother because this is just a quick hack to see what gives. Also, I added the `-v` option to `opensmt` because I needed visibility :)

Recomputing the glue during analyze is standard. All systems I know do this, and they update the glue only in case it's lower. This way, as we progress the search, and reach a part of the search where the clause would be low-glue, we lock the clause in.


The code actually looks cleaner than I imagined when I was writing it... Huh. Maybe I'm not the worst coder in the universe, only in the bottom 25%? :smiley: 