### PR TITLE
Lia random splitting

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,7 +24,7 @@ target_sources(common
 install(FILES
         Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h Timer.h osmtinttypes.h
         TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h 
-        NumberUtils.h NatSet.h
+        NumberUtils.h NatSet.h Random.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,7 +24,7 @@ target_sources(common
 install(FILES
         Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h Timer.h osmtinttypes.h
         TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h 
-        NumberUtils.h NatSet.h Random.h
+        NumberUtils.h NatSet.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/Random.h
+++ b/src/common/Random.h
@@ -1,0 +1,22 @@
+//
+// Created by Antti Hyvarinen on 07.05.22.
+//
+
+#ifndef OPENSMT_RANDOM_H
+#define OPENSMT_RANDOM_H
+
+namespace opensmt {
+    // Returns a random float 0 <= x < 1. Seed must never be 0.
+    static inline double drand(double &seed) {
+        seed *= 1389796;
+        int q = (int) (seed / 2147483647);
+        seed -= (double) q * 2147483647;
+        return seed / 2147483647;
+    }
+
+    // Returns a random integer 0 <= x < size. Seed must never be 0.
+    static inline int irand(double &seed, int size) {
+        return (int) (drand(seed) * size);
+    }
+}
+#endif //OPENSMT_RANDOM_H

--- a/src/common/Random.h
+++ b/src/common/Random.h
@@ -1,6 +1,9 @@
-//
-// Created by Antti Hyvarinen on 07.05.22.
-//
+/*
+ * Copyright (c) 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2003-2006, Niklas Een, Niklas Sorensson
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef OPENSMT_RANDOM_H
 #define OPENSMT_RANDOM_H

--- a/src/common/Random.h
+++ b/src/common/Random.h
@@ -8,6 +8,7 @@
 namespace opensmt {
     // Returns a random float 0 <= x < 1. Seed must never be 0.
     static inline double drand(double &seed) {
+        assert(seed != 0);
         seed *= 1389796;
         int q = (int) (seed / 2147483647);
         seed -= (double) q * 2147483647;

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -58,6 +58,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include "SystemQueries.h"
 #include "ReportUtils.h"
 
+#include "Random.h"
+
 namespace opensmt {
     extern bool stop;
 }

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -517,6 +517,10 @@ Var CoreSMTSolver::doRandomDecision() {
     return next;
 }
 
+bool CoreSMTSolver::branchLitRandom() {
+    return opensmt::drand(random_seed) < random_var_freq && !order_heap.empty();
+}
+
 Var CoreSMTSolver::doActivityDecision() {
     Var next = var_Undef;
     while (next == var_Undef || value(next) != l_Undef || !decision[next]) {

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -204,7 +204,7 @@ Var CoreSMTSolver::newVar(bool dvar)
     watches  .init(mkLit(v, true));
     assigns  .push(l_Undef);
     vardata  .push(mkVarData(CRef_Undef, 0));
-    activity .push(rnd_init_act ? drand(random_seed) * 0.00001 : 0);
+    activity .push(rnd_init_act ? opensmt::drand(random_seed) * 0.00001 : 0);
     seen     .push(0);
     decision .push();
     trail    .capacity(v+1);
@@ -510,7 +510,7 @@ void CoreSMTSolver::cancelUntilVarTempDone( )
 Var CoreSMTSolver::doRandomDecision() {
     Var next = var_Undef;
     if (branchLitRandom()) {
-        next = order_heap[irand(random_seed,order_heap.size())];
+        next = order_heap[opensmt::irand(random_seed,order_heap.size())];
         if (value(next) == l_Undef && decision[next])
             rnd_decisions++;
     }

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -62,6 +62,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include "SolverTypes.h"
 
 #include "Timer.h"
+#include "Random.h"
 
 class Proof;
 class ModelBuilder;
@@ -368,7 +369,7 @@ protected:
     Var doRandomDecision();
     Lit choosePolarity(Var next);
     virtual Var doActivityDecision();
-    virtual bool branchLitRandom() { return drand(random_seed) < random_var_freq && !order_heap.empty(); }
+    virtual bool branchLitRandom() { return opensmt::drand(random_seed) < random_var_freq && !order_heap.empty(); }
     virtual Lit  pickBranchLit ();                                                     // Return the next decision variable.
     virtual void newDecisionLevel ();                                                  // Begins a new decision level.
     void     uncheckedEnqueue (Lit p, CRef from = CRef_Undef);                         // Enqueue a literal. Assumes value of literal is undefined.
@@ -433,28 +434,6 @@ protected:
 
     //ADDED FOR MINIMIZATION
     void     printClause      ( vec< Lit > & );
-
-    // Static helpers:
-    //
-
-    // Returns a random float 0 <= x < 1. Seed must never be 0.
-    static inline double drand(double& seed)
-    {
-        seed *= 1389796;
-        int q = (int)(seed / 2147483647);
-        seed -= (double)q * 2147483647;
-        return seed / 2147483647;
-    }
-
-    // Returns a random integer 0 <= x < size. Seed must never be 0.
-    static inline int irand(double& seed, int size)
-    {
-        return (int)(drand(seed) * size);
-    }
-
-
-    //=================================================================================================
-    // Added Code
 
 public:
 

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -369,7 +369,7 @@ protected:
     Var doRandomDecision();
     Lit choosePolarity(Var next);
     virtual Var doActivityDecision();
-    virtual bool branchLitRandom() { return opensmt::drand(random_seed) < random_var_freq && !order_heap.empty(); }
+    virtual bool branchLitRandom();
     virtual Lit  pickBranchLit ();                                                     // Return the next decision variable.
     virtual void newDecisionLevel ();                                                  // Begins a new decision level.
     void     uncheckedEnqueue (Lit p, CRef from = CRef_Undef);                         // Enqueue a literal. Assumes value of literal is undefined.

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -62,7 +62,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include "SolverTypes.h"
 
 #include "Timer.h"
-#include "Random.h"
 
 class Proof;
 class ModelBuilder;

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -6,6 +6,8 @@
 
 #include "ReportUtils.h"
 
+#include "Random.h"
+
 #include <utility>
 
 bool GhostSMTSolver::isGhost(Lit l)

--- a/src/smtsolvers/GhostSMTSolver.cc
+++ b/src/smtsolvers/GhostSMTSolver.cc
@@ -90,7 +90,7 @@ GhostSMTSolver::pickRandomBranchVar() {
     if (order_heap.empty())
         return var_Undef;
     else
-        return order_heap[irand(random_seed,order_heap.size())];
+        return order_heap[opensmt::irand(random_seed,order_heap.size())];
 }
 
 // Activity based decision:
@@ -151,7 +151,7 @@ GhostSMTSolver::pickBranchLit() {
     opensmt::StopWatch s(branchTimer);
 #endif
 
-    if ((drand(random_seed) < random_var_freq) && !order_heap.empty()) {
+    if ((opensmt::drand(random_seed) < random_var_freq) && !order_heap.empty()) {
         Var v = pickRandomBranchVar();
         if (v != var_Undef && value(v) == l_Undef) {
             Lit l = pickBranchPolarity(v);

--- a/src/smtsolvers/ScatterSplitter.cc
+++ b/src/smtsolvers/ScatterSplitter.cc
@@ -9,9 +9,7 @@
 #include "Proof.h"
 #include "SystemQueries.h"
 #include "ReportUtils.h"
-
-#include "SystemQueries.h"
-#include "ReportUtils.h"
+#include "Random.h"
 
 namespace opensmt
 {

--- a/src/smtsolvers/ScatterSplitter.cc
+++ b/src/smtsolvers/ScatterSplitter.cc
@@ -24,7 +24,7 @@ ScatterSplitter::ScatterSplitter(SMTConfig & c, THandler & t)
 {}
 
 bool ScatterSplitter::branchLitRandom() {
-    return ((not splitContext.isInSplittingCycle() and drand(random_seed) < random_var_freq) or
+    return ((not splitContext.isInSplittingCycle() and opensmt::drand(random_seed) < random_var_freq) or
             (splitContext.isInSplittingCycle() and splitContext.preferRandom()))
            and not order_heap.empty();
 }

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -365,6 +365,27 @@ LVRef LASolver::splitOnMostInfeasible(vec<LVRef> const & varsToFix) const {
     return chosen;
 }
 
+namespace {
+    // Returns a random float 0 <= x < 1. Seed must never be 0.
+    static inline double drand(double &seed) {
+        seed *= 1389796;
+        int q = (int) (seed / 2147483647);
+        seed -= (double) q * 2147483647;
+        return seed / 2147483647;
+    }
+
+    // Returns a random integer 0 <= x < size. Seed must never be 0.
+    static inline int irand(double &seed, int size) {
+        return (int) (drand(seed) * size);
+    }
+}
+
+LVRef LASolver::splitOnRandom(vec<LVRef> const & varsToFix) const {
+    static double seed = 123;
+    int pick = irand(seed, varsToFix.size());
+    return varsToFix[pick];
+}
+
 TRes LASolver::checkIntegersAndSplit() {
 
     vec<LVRef> varsToFix;
@@ -389,7 +410,9 @@ TRes LASolver::checkIntegersAndSplit() {
         }
     }
 
-    LVRef chosen = splitOnMostInfeasible(varsToFix);
+//    static double seed = 123;
+//    LVRef chosen = drand(seed) < 0.4 ? splitOnRandom(varsToFix) : splitOnMostInfeasible(varsToFix);
+    LVRef chosen = splitOnRandom(varsToFix);
 
     assert(chosen != LVRef::Undef);
     auto splitLowerVal = simplex.getValuation(chosen).R().floor();

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -153,6 +153,8 @@ private:
 
     // Most-infeasible branching heuristic
     LVRef splitOnMostInfeasible(vec<LVRef> const &) const;
+    // Random branching heuristic
+    LVRef splitOnRandom(vec<LVRef> const &) const;
     TRes checkIntegersAndSplit();
     bool isModelInteger (LVRef v) const;
     TRes cutFromProof();

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -127,6 +127,7 @@ private:
 
     Map<LVRef, bool, LVRefHash> int_vars_map; // stores problem variables for duplicate check
     vec<LVRef> int_vars;                      // stores the list of problem variables without duplicates
+    double seed = 123;
 
     LABoundStore::BoundInfo addBound(PTRef leq_tr);
     void updateBound(PTRef leq_tr);
@@ -151,10 +152,8 @@ private:
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
     void notifyVar(LVRef);                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
 
-    // Most-infeasible branching heuristic
-    LVRef splitOnMostInfeasible(vec<LVRef> const &) const;
-    // Random branching heuristic
-    LVRef splitOnRandom(vec<LVRef> const &) const;
+    // Random splitting heuristic
+    LVRef splitOnRandom(vec<LVRef> const &);
     TRes checkIntegersAndSplit();
     bool isModelInteger (LVRef v) const;
     TRes cutFromProof();


### PR DESCRIPTION
The LIA solver, upon finding a solution to the linear system assigning non-integer values to integer variables, needs to communicate to the SAT solver how to fix a value to an integer.  Previously this was done by choosing the variable to be fixed by choosing the one furthest away from an integer.  It turns out that a completely random heuristic is better than the previous heuristic.  While we are trying to find a better heuristic, this PR suggests to switch to a completely random heuristic.