### PR TITLE
Assert throws

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ option(BUILD_EXECUTABLES "Build executables" ON)
 option(PACKAGE_TESTS "Build the tests" ON)
 option(PACKAGE_BENCHMARKS "Build the benchmarks" OFF)
 
+option(OSMT_ASSERT_THROWS "Assert throws an exception" OFF)
+
 option(MAXIMALLY_STATIC_BINARY "Link to static versions of the libraries as much as reasonably possible" OFF)
 
 if (MAXIMALLY_STATIC_BINARY)
@@ -153,6 +155,10 @@ endif()
 
 if (MATRIX_DEBUG)
     add_definitions(-DENABLE_MATRIX_TRACE)
+endif()
+
+if (OSMT_ASSERT_THROWS)
+    add_definitions(-DOSMT_ASSERT_THROWS)
 endif()
 
 add_subdirectory(${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,3 +195,9 @@ if (ENABLE_LINE_EDITING AND USE_READLINE)
           "As these libraries are covered under the GPL, so will the resulting binary of OpenSMT.")
 endif()
 
+if (OSMT_ASSERT_THROWS)
+    message(WARNING "OpenSMT will be built with an option that turns `assert` statements into `throw`s of "
+            "`OsmtAssertException`s.  This setup is recommended only when debugging OpenSMT API in an "
+            "environment where detecting assertion failures is difficult, such as when running the "
+            "API in a client over the network.  Be warned.")
+endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -19,12 +19,13 @@ target_sources(common
     "${CMAKE_CURRENT_LIST_DIR}/PartitionInfo.cc"
     "${CMAKE_CURRENT_LIST_DIR}/VerificationUtils.cc"
     "${CMAKE_CURRENT_LIST_DIR}/ReportUtils.h"
+    "${CMAKE_CURRENT_LIST_DIR}/OpensmtAssert.h"
 )
 
 install(FILES
         Integer.h Number.h FastRational.h XAlloc.h Alloc.h StringMap.h Timer.h osmtinttypes.h
-        TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h 
-        NumberUtils.h NatSet.h
+        TreeOps.h Real.h FlaPartitionMap.h PartitionInfo.h OsmtApiException.h TypeUtils.h
+        NumberUtils.h NatSet.h OpensmtAssert.h
 DESTINATION ${INSTALL_HEADERS_DIR})
 
 

--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -8,7 +8,7 @@ Copyright (c) 2008, 2009 Centre national de la recherche scientifique (CNRS)
 #define FAST_RATIONALS_H
 #include <string>
 #include <gmpxx.h>
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <climits>
 #include "Vec.h"
 #include <stack>

--- a/src/common/OpensmtAssert.h
+++ b/src/common/OpensmtAssert.h
@@ -1,0 +1,21 @@
+//
+// Created by usi on 09.05.22.
+//
+
+#ifndef OPENSMT_OPENSMTASSERT_H
+#define OPENSMT_OPENSMTASSERT_H
+
+#ifdef OSMT_ASSERT_THROWS
+#include "OsmtAssertException.h"
+
+#ifdef assert
+#undef assert
+#endif // assert
+
+#define	assert(e) \
+    do { if (!(e)) { throw OsmtAssertException(__FILE__, __LINE__, "assertion failed"); } } while (0)
+#else
+#include <cassert>
+#endif
+
+#endif //OPENSMT_OPENSMTASSERT_H

--- a/src/common/OpensmtAssert.h
+++ b/src/common/OpensmtAssert.h
@@ -1,6 +1,9 @@
-//
-// Created by usi on 09.05.22.
-//
+/*
+ * Copyright (c) 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2022, Masoud Asadzade <masoud.asadzade@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef OPENSMT_OPENSMTASSERT_H
 #define OPENSMT_OPENSMTASSERT_H

--- a/src/common/OsmtAssertException.h
+++ b/src/common/OsmtAssertException.h
@@ -1,6 +1,9 @@
-//
-// Created by prova on 13.05.20.
-//
+/*
+ * Copyright (c) 2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2022, Masoud Asadzade <masoud.asadzade@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifdef OSMT_ASSERT_EXCEPTION_H
 #else

--- a/src/common/OsmtAssertException.h
+++ b/src/common/OsmtAssertException.h
@@ -1,0 +1,18 @@
+//
+// Created by prova on 13.05.20.
+//
+
+#ifdef OSMT_ASSERT_EXCEPTION_H
+#else
+#define OSMT_ASSERT_EXCEPTION_H
+#include "OsmtInternalException.h"
+
+class OsmtAssertException : public OsmtInternalException {
+    std::string msg;
+public:
+    explicit OsmtAssertException(const char * file, unsigned line, const std::string & message) :
+            OsmtInternalException(message + " at " + file + ":" + std::to_string(line)) {}
+};
+
+
+#endif // OSMT_ASSERT_EXCEPTION_H

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -29,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string.h>
 #include <ostream>
 #include <iostream>
-#include <assert.h>
+#include "OpensmtAssert.h"
 #include <sys/time.h>
 #include <sys/resource.h>
 
@@ -114,14 +114,12 @@ class StopWatch {
         if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
             time_start = OSMTTimeVal(tmp_rusage);
         }
-        else assert(false);
     }
     ~StopWatch()
     {
         if (getrusage(RUSAGE_SELF, &tmp_rusage) == 0) {
             timer += OSMTTimeVal(tmp_rusage) - time_start;
         }
-        else assert(false);
     }
 };
 

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -29,7 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string.h>
 #include <ostream>
 #include <iostream>
-#include "OpensmtAssert.h"
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/src/interpolation/InterpolationUtils.h
+++ b/src/interpolation/InterpolationUtils.h
@@ -9,7 +9,7 @@
 
 #include <gmpxx.h>
 
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <set>
 
 namespace opensmt {

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -20,7 +20,7 @@
 #include "TypeUtils.h"
 #include "NatSet.h"
 
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <cstring>
 #include <cstdlib>
 

--- a/src/logics/SubstLoopBreaker.h
+++ b/src/logics/SubstLoopBreaker.h
@@ -8,7 +8,7 @@
 #include <PTRef.h>
 #include <Sort.h>
 #include <Alloc.h>
-#include <assert.h>
+#include "OpensmtAssert.h"
 #include <PtStructs.h>
 #include <Logic.h>
 

--- a/src/minisat/core/SolverTypes.h
+++ b/src/minisat/core/SolverTypes.h
@@ -22,7 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_SolverTypes_h
 #define Minisat_SolverTypes_h
 
-#include <assert.h>
+#include "OpensmtAssert.h"
 
 #include "osmtinttypes.h"
 #include "Alg.h"

--- a/src/minisat/mtl/BoxedVec.h
+++ b/src/minisat/mtl/BoxedVec.h
@@ -21,7 +21,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #define BoxedVec_h
 
 #include <cstdlib>
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <new>
 
 //=================================================================================================

--- a/src/minisat/mtl/Vec.h
+++ b/src/minisat/mtl/Vec.h
@@ -22,7 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_Vec_h
 #define Minisat_Vec_h
 
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <new>
 #include <initializer_list>
 #include <vector>

--- a/src/models/Model.h
+++ b/src/models/Model.h
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <algorithm>
 
-#include <cassert>
+#include "OpensmtAssert.h"
 
 #ifndef OPENSMT_MODEL_H
 #define OPENSMT_MODEL_H

--- a/src/parsers/smt2new/smt2newparser.yy
+++ b/src/parsers/smt2new/smt2newparser.yy
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 %{
 #include <cstdio>
 #include <cstdlib>
-#include <cassert>
+#include "OpensmtAssert.h"
 #include <vector>
 #include <list>
 #include <string>

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -11,7 +11,7 @@
 #include "ModelBuilder.h"
 
 #include <sys/wait.h>
-#include <assert.h>
+#include "OpensmtAssert.h"
 #include <sstream>
 
 void THandler::backtrack(int lev)

--- a/src/tsolvers/lasolver/LARefs.h
+++ b/src/tsolvers/lasolver/LARefs.h
@@ -2,7 +2,7 @@
 #define LABOUNDREFS_H
 #include "osmtinttypes.h"
 #include <ostream>
-#include <cassert>
+#include "OpensmtAssert.h"
 
 struct BoundT {
     char t;


### PR DESCRIPTION
This PR includes:

A common wrapper for assert
This commit introduces a layer that either takes `assert` from `cassert`, or depending on a new `cmake` option `OSMT_ASSERT_THROWS`, optionally defines `assert` as something that throws.
