### PR TITLE
LASolver: Remove redundant storage of information

### DIFF
--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -279,8 +279,9 @@ std::unique_ptr<Tableau::Polynomial> LASolver::expressionToLVarPoly(PTRef term) 
 
 
 //
-// Get a possibly new LAVar for a PTRef term.  We may assume that the term is of one of the following forms,
-// where x is a real variable or ite, and p_i are products of a real variable or ite and a real constant
+// Registers an arithmetic Pterm (polynomial) with the solver.
+// We may assume that the term is of one of the following forms,
+// where x is a variable or ite, and p_i are products of a variable or ite and a constant
 //
 // (1) x
 // (2a) (* x -1)
@@ -289,7 +290,8 @@ std::unique_ptr<Tableau::Polynomial> LASolver::expressionToLVarPoly(PTRef term) 
 // (4a) (* x -1) + p_1 + ... + p_n
 // (4b) (* -1 x) + p_1 + ... + p_n
 //
-LVRef LASolver::exprToLVar(PTRef expr) {
+// Returns internalized reference for the term
+LVRef LASolver::registerArithmeticTerm(PTRef expr) {
     LVRef x = LVRef::Undef;
     if (laVarMapper.hasVar(expr)){
         x = getVarForTerm(expr);
@@ -345,7 +347,7 @@ void LASolver::declareAtom(PTRef leq_tr)
         //    status = INCREMENT;
         assert( status == SAT );
         PTRef term = logic.getPterm(leq_tr)[1];
-        exprToLVar(term); // MB: We need to build the representation, but we don't actually need the result
+        registerArithmeticTerm(term);
         updateBound(leq_tr);
     }
     // DEBUG check
@@ -566,7 +568,7 @@ void LASolver::initSolver()
             PTRef term = leq_t[1];
 
             // Ensure that all variables exists, build the polynomial, and update the occurrences.
-            exprToLVar(term); // MB: We need to build the representation, but we don't actually need the result
+            registerArithmeticTerm(term);
 
             // Assumes that the LRA variable has been already declared
             setBound(leq_tr);

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -29,8 +29,7 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
 
     bool sum_term_is_negated = laVarMapper.isNegated(sum_tr);
 
-    LVRef v = laVarMapper.getVarByLeqId(logic.getPterm(leq_tr).getId());
-    assert(v == laVarMapper.getVarByPTId(logic.getPterm(sum_tr).getId()));
+    LVRef v = laVarMapper.getVarByPTId(logic.getPterm(sum_tr).getId());
 
     LABoundStore::BoundInfo bi;
     LABoundRef br_pos;
@@ -242,6 +241,12 @@ bool LASolver::hasVar(PTRef expr) {
     return laVarMapper.hasVar(id);
 }
 
+LVRef LASolver::getVarForLeq(PTRef ref) const {
+    assert(logic.isLeq(ref));
+    auto [constant, term] = logic.leqToConstantAndTerm(ref);
+    return laVarMapper.getVarByPTId(logic.getPterm(term).getId());
+}
+
 LVRef LASolver::getLAVar_single(PTRef expr_in) {
 
     assert(logic.isLinearTerm(expr_in));
@@ -340,8 +345,7 @@ void LASolver::declareAtom(PTRef leq_tr)
         //    status = INCREMENT;
         assert( status == SAT );
         PTRef term = logic.getPterm(leq_tr)[1];
-        LVRef v = exprToLVar(term);
-        laVarMapper.addLeqVar(leq_tr, v);
+        exprToLVar(term); // MB: We need to build the representation, but we don't actually need the result
         updateBound(leq_tr);
     }
     // DEBUG check
@@ -562,9 +566,7 @@ void LASolver::initSolver()
             PTRef term = leq_t[1];
 
             // Ensure that all variables exists, build the polynomial, and update the occurrences.
-            LVRef v = exprToLVar(term);
-
-            laVarMapper.addLeqVar(leq_tr, v);
+            exprToLVar(term); // MB: We need to build the representation, but we don't actually need the result
 
             // Assumes that the LRA variable has been already declared
             setBound(leq_tr);

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -131,7 +131,7 @@ private:
 
     LABoundStore::BoundInfo addBound(PTRef leq_tr);
     void updateBound(PTRef leq_tr);
-    LVRef exprToLVar(PTRef expr); // Ensures this term and all variables in it has corresponding LVAR.  Returns the LAVar for the term.
+    LVRef registerArithmeticTerm(PTRef expr); // Ensures this term and all variables in it has corresponding LVAR.  Returns the LAVar for the term.
     void storeExplanation(Simplex::Explanation &&explanationBounds);
 
     std::unique_ptr<Tableau::Polynomial> expressionToLVarPoly(PTRef term);

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -148,7 +148,7 @@ private:
 
     LVRef getLAVar_single(PTRef term);                      // Initialize a new LA var if needed, otherwise return the old var
     bool hasVar(PTRef expr);
-    LVRef getVarForLeq(PTRef ref)  const  { return laVarMapper.getVarByLeqId(logic.getPterm(ref).getId()); }
+    LVRef getVarForLeq(PTRef ref)  const;
     LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
     void notifyVar(LVRef);                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
 

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -1,6 +1,9 @@
-//
-// Created by prova on 06.09.19.
-//
+/*
+ *  Copyright (c) 2019-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *  Copyright (c) 2019-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ */
 
 #include "LAVarMapper.h"
 #include "ArithLogic.h"

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -37,20 +37,7 @@ void LAVarMapper::registerNewMapping(LVRef lv, PTRef e_orig) {
     ptermToLavar[Idx(id_neg)] = lv;
 }
 
-void LAVarMapper::addLeqVar(PTRef leq_tr, LVRef v)
-{
-    Pterm const & leq_t = logic.getPterm(leq_tr);
-    int idx = Idx(leq_t.getId());
-    for (int i = leqToLavar.size(); i <= idx; i++) {
-        leqToLavar.push(LVRef::Undef);
-    }
-    assert(leqToLavar[idx] == LVRef::Undef);
-    leqToLavar[idx] = v;
-}
-
 LVRef  LAVarMapper::getVarByPTId(PTId i) const { return ptermToLavar[Idx(i)]; }
-
-LVRef  LAVarMapper::getVarByLeqId(PTId i) const { return leqToLavar[Idx(i)]; }
 
 bool LAVarMapper::hasVar(PTRef tr) const { return hasVar(logic.getPterm(tr).getId()); }
 
@@ -77,7 +64,6 @@ bool LAVarMapper::isNegated(PTRef tr) const {
 }
 
 void LAVarMapper::clear() {
-    this->leqToLavar.clear();
     this->laVarToPTRef.clear();
     this->ptermToLavar.clear();
 }

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -1,6 +1,9 @@
-//
-// Created by prova on 06.09.19.
-//
+/*
+ *  Copyright (c) 2019-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *  Copyright (c) 2019-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ */
 
 #ifndef OPENSMT_LAVARMAPPER_H
 #define OPENSMT_LAVARMAPPER_H

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -24,9 +24,6 @@ class ArithLogic;
  */
 class LAVarMapper {
 private:
-    /** Convenience mapping of inequalities to LVRef representing the linear term without constant in the inequality*/
-    vec<LVRef>      leqToLavar;
-
     /** Mapping of linear Pterms to LVRefs */
     vec<LVRef>      ptermToLavar;
 
@@ -39,10 +36,7 @@ public:
 
     void   registerNewMapping(LVRef lv, PTRef e_orig);
 
-    void   addLeqVar(PTRef leq_tr, LVRef v); // Adds a binding from leq_tr to the "slack var" v
-
     LVRef  getVarByPTId(PTId i) const;
-    LVRef  getVarByLeqId(PTId i) const;
 
     bool   hasVar(PTId i) const;
     bool   hasVar(PTRef tr) const;


### PR DESCRIPTION
`LAMapper` stores two mappings:
1. For each `Pterm` that corresponds to arithmetic term the corresponding LVRef (Simplex variable)
2. For each `Pterm` that corresponds to arithmetic inequality the LVRef of the arithmetic term that is compared to a constant.

The second mapping is redundant. Given the inequality we can extract the term from the inequality and just ask for the representation of that.

This does not makes a big difference in single query context, but in scenarios such as in Golem, where new terms are created all the time, the initialization of the LASolver can actually spend a lot of time in creating the second mapping. The reason is that the mapping is represented by a vector and the initialization must `push` as many times as is the `id` of the inequality. In long runs there can be many new `Pterms` created and the `id` of inequalities can be quite high which means a lot of `push`es.

The proposed change is to completely remove this vector and thus save potentially significant amount of time on initializing `LASolver`.