### PR TITLE
Do not use vectors indexed by Pterms' ids in LASolver

### DIFF
--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -210,12 +210,6 @@ const Delta LASolver::overBound(LVRef v) const
 }
 */
 
-void LASolver::setBound(PTRef leq_tr)
-{
-//    printf("Setting bound for %s\n", logic.printTerm(leq_tr));
-
-    addBound(leq_tr);
-}
 
 opensmt::Number LASolver::getNum(PTRef r) {
     return logic.getNumConst(r);
@@ -568,7 +562,7 @@ void LASolver::initSolver()
             registerArithmeticTerm(term);
 
             // Assumes that the LRA variable has been already declared
-            setBound(leq_tr);
+            addBound(leq_tr);
         }
         boundStore.buildBounds(); // Bounds are needed for gaussian elimination
 

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -29,7 +29,7 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
 
     bool sum_term_is_negated = laVarMapper.isNegated(sum_tr);
 
-    LVRef v = laVarMapper.getVarByPTId(logic.getPterm(sum_tr).getId());
+    LVRef v = getVarForTerm(sum_tr);
 
     LABoundStore::BoundInfo bi;
     LABoundRef br_pos;
@@ -236,23 +236,20 @@ void LASolver::markVarAsInt(LVRef v) {
 }
 
 bool LASolver::hasVar(PTRef expr) {
-    expr =  laVarMapper.isNegated(expr) ? logic.mkNeg(expr) : expr;
-    PTId id = logic.getPterm(expr).getId();
-    return laVarMapper.hasVar(id);
+    return laVarMapper.hasVar(expr);
 }
 
 LVRef LASolver::getVarForLeq(PTRef ref) const {
     assert(logic.isLeq(ref));
     auto [constant, term] = logic.leqToConstantAndTerm(ref);
-    return laVarMapper.getVarByPTId(logic.getPterm(term).getId());
+    return getVarForTerm(term);
 }
 
 LVRef LASolver::getLAVar_single(PTRef expr_in) {
 
     assert(logic.isLinearTerm(expr_in));
-    PTId id = logic.getPterm(expr_in).getId();
 
-    if (laVarMapper.hasVar(id)) {
+    if (laVarMapper.hasVar(expr_in)) {
         return getVarForTerm(expr_in);
     }
 
@@ -964,7 +961,7 @@ TRes LASolver::cutFromProof() {
     }
     auto getVarValue = [this](PTRef var) {
         assert(this->logic.isVar(var));
-        LVRef lvar = this->laVarMapper.getVarByPTId(logic.getPterm(var).getId());
+        LVRef lvar = this->getVarForTerm(var);
         Delta val = this->simplex.getValuation(lvar);
         assert(not val.hasDelta());
         return val.R();
@@ -999,7 +996,7 @@ vec<PTRef> LASolver::collectEqualitiesFor(vec<PTRef> const & vars, std::unordere
             if (not laVarMapper.hasVar(var)) { // LASolver does not have any constraints on this LA var
                 continue;
             }
-            LVRef v = laVarMapper.getVarByPTId(logic.getPterm(var).getId());
+            LVRef v = getVarForTerm(var);
             auto value = simplex.getValuation(v);
             eqClasses[value].push(var);
         }

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -49,8 +49,8 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
     }
     int br_pos_idx = boundStore[br_pos].getId();
     int br_neg_idx = boundStore[br_neg].getId();
-    assert(LeqToLABoundRefPair.find(leq_tr) == LeqToLABoundRefPair.end());
-    LeqToLABoundRefPair.insert({leq_tr, LABoundRefPair{br_pos, br_neg}});
+    assert(not LeqToLABoundRefPair.has(leq_tr));
+    LeqToLABoundRefPair.insert(leq_tr, LABoundRefPair{br_pos, br_neg});
 
     if (LABoundRefToLeqAsgn.size() <= std::max(br_pos_idx, br_neg_idx)) {
         LABoundRefToLeqAsgn.growTo(std::max(br_pos_idx, br_neg_idx) + 1);
@@ -63,7 +63,7 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
 void LASolver::updateBound(PTRef tr)
 {
     // If the bound already exists, do nothing.
-    if (LeqToLABoundRefPair.find(tr) != LeqToLABoundRefPair.end()) { return; }
+    if (LeqToLABoundRefPair.has(tr)) { return; }
 
     LABoundStore::BoundInfo bi = addBound(tr);
     boundStore.updateBound(bi);

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -49,12 +49,8 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
     }
     int br_pos_idx = boundStore[br_pos].getId();
     int br_neg_idx = boundStore[br_neg].getId();
-
-    int tid = Idx(logic.getPterm(leq_tr).getId());
-    if (LeqToLABoundRefPair.size() <= tid) {
-        LeqToLABoundRefPair.growTo(tid + 1);
-    }
-    LeqToLABoundRefPair[tid] = LABoundRefPair{br_pos, br_neg};
+    assert(LeqToLABoundRefPair.find(leq_tr) == LeqToLABoundRefPair.end());
+    LeqToLABoundRefPair.insert({leq_tr, LABoundRefPair{br_pos, br_neg}});
 
     if (LABoundRefToLeqAsgn.size() <= std::max(br_pos_idx, br_neg_idx)) {
         LABoundRefToLeqAsgn.growTo(std::max(br_pos_idx, br_neg_idx) + 1);
@@ -67,12 +63,7 @@ LABoundStore::BoundInfo LASolver::addBound(PTRef leq_tr) {
 void LASolver::updateBound(PTRef tr)
 {
     // If the bound already exists, do nothing.
-    int id = Idx(logic.getPterm(tr).getId());
-
-    if ((LeqToLABoundRefPair.size() > id) &&
-        !(LeqToLABoundRefPair[id] == LABoundRefPair{LABoundRef_Undef, LABoundRef_Undef})) {
-        return;
-    }
+    if (LeqToLABoundRefPair.find(tr) != LeqToLABoundRefPair.end()) { return; }
 
     LABoundStore::BoundInfo bi = addBound(tr);
     boundStore.updateBound(bi);

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -149,7 +149,7 @@ private:
     LVRef getLAVar_single(PTRef term);                      // Initialize a new LA var if needed, otherwise return the old var
     bool hasVar(PTRef expr);
     LVRef getVarForLeq(PTRef ref)  const;
-    LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVarByPTId(logic.getPterm(ref).getId()); }
+    LVRef getVarForTerm(PTRef ref) const  { return laVarMapper.getVar(ref); }
     void notifyVar(LVRef);                             // Notify the solver of the existence of the var. This is so that LIA can add it to integer vars list.
 
     // Random splitting heuristic

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -69,11 +69,10 @@ private:
 
     vec<PtAsgn>          LABoundRefToLeqAsgn;
     PtAsgn getAsgnByBound(LABoundRef br) const;
-    vec<LABoundRefPair>  LeqToLABoundRefPair;
-    LABoundRefPair getBoundRefPair(const PTRef leq) const {
-        auto index = Idx(logic.getPterm(leq).getId());
-        assert(index < LeqToLABoundRefPair.size_());
-        return LeqToLABoundRefPair[index];
+    std::unordered_map<PTRef, LABoundRefPair, PTRefHash>  LeqToLABoundRefPair;
+    LABoundRefPair getBoundRefPair(PTRef leq) const {
+        assert(LeqToLABoundRefPair.find(leq) != LeqToLABoundRefPair.end());
+        return LeqToLABoundRefPair.at(leq);
     }
 
     // Possible internal states of the solver

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -69,10 +69,10 @@ private:
 
     vec<PtAsgn>          LABoundRefToLeqAsgn;
     PtAsgn getAsgnByBound(LABoundRef br) const;
-    std::unordered_map<PTRef, LABoundRefPair, PTRefHash>  LeqToLABoundRefPair;
+    Map<PTRef, LABoundRefPair, PTRefHash>  LeqToLABoundRefPair;
     LABoundRefPair getBoundRefPair(PTRef leq) const {
-        assert(LeqToLABoundRefPair.find(leq) != LeqToLABoundRefPair.end());
-        return LeqToLABoundRefPair.at(leq);
+        assert(LeqToLABoundRefPair.has(leq));
+        return LeqToLABoundRefPair[leq];
     }
 
     // Possible internal states of the solver

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -84,7 +84,6 @@ private:
 
     LASolverStats laSolverStats;
 
-    void setBound(PTRef leq);
     bool assertBoundOnVar(LVRef it, LABoundRef itBound_ref);
 
     PTRef getVarPTRef(LVRef v) const {

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -29,13 +29,13 @@ void LAVarMapper::registerNewMapping(LVRef lv, PTRef e_orig) {
     PTRef neg = logic.mkNeg(e_orig);
     assert(!hasVar(e_orig));
 
-    ptermToLavar.insert({e_orig, lv});
-    ptermToLavar.insert({neg, lv});
+    ptermToLavar.insert(e_orig, lv);
+    ptermToLavar.insert(neg, lv);
 }
 
-LVRef LAVarMapper::getVar(PTRef term) const { assert(hasVar(term)); return ptermToLavar.at(term); }
+LVRef LAVarMapper::getVar(PTRef term) const { assert(hasVar(term)); return ptermToLavar[term]; }
 
-bool LAVarMapper::hasVar(PTRef tr) const { return ptermToLavar.find(tr) != ptermToLavar.end(); }
+bool LAVarMapper::hasVar(PTRef tr) const { return ptermToLavar.has(tr); }
 
 bool LAVarMapper::isNegated(PTRef tr) const {
     if (logic.isNumConst(tr))

--- a/src/tsolvers/lasolver/LAVarMapper.cc
+++ b/src/tsolvers/lasolver/LAVarMapper.cc
@@ -26,27 +26,16 @@ void LAVarMapper::registerNewMapping(LVRef lv, PTRef e_orig) {
     }
     laVarToPTRef[lv.x] = e_orig;
 
-    PTId id_pos = logic.getPterm(e_orig).getId();
-    PTId id_neg = logic.getPterm(logic.mkNeg(e_orig)).getId();
-    assert(!hasVar(id_pos));
-    int max_id = std::max(Idx(id_pos), Idx(id_neg));
+    PTRef neg = logic.mkNeg(e_orig);
+    assert(!hasVar(e_orig));
 
-    if (max_id >= ptermToLavar.size()) {
-        ptermToLavar.growTo(max_id + 1, LVRef::Undef);
-    }
-
-    assert(ptermToLavar[Idx(id_pos)] == ptermToLavar[Idx(id_neg)]);
-    ptermToLavar[Idx(id_pos)] = lv;
-    ptermToLavar[Idx(id_neg)] = lv;
+    ptermToLavar.insert({e_orig, lv});
+    ptermToLavar.insert({neg, lv});
 }
 
-LVRef  LAVarMapper::getVarByPTId(PTId i) const { return ptermToLavar[Idx(i)]; }
+LVRef LAVarMapper::getVar(PTRef term) const { assert(hasVar(term)); return ptermToLavar.at(term); }
 
-bool LAVarMapper::hasVar(PTRef tr) const { return hasVar(logic.getPterm(tr).getId()); }
-
-bool   LAVarMapper::hasVar(PTId i) const {
-    return static_cast<unsigned int>(ptermToLavar.size()) > Idx(i) && ptermToLavar[Idx(i)] != LVRef::Undef;
-}
+bool LAVarMapper::hasVar(PTRef tr) const { return ptermToLavar.find(tr) != ptermToLavar.end(); }
 
 bool LAVarMapper::isNegated(PTRef tr) const {
     if (logic.isNumConst(tr))

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -12,6 +12,8 @@
 #include "Pterm.h"
 #include "Vec.h"
 
+#include <unordered_map>
+
 class ArithLogic;
 
 
@@ -28,7 +30,7 @@ class ArithLogic;
 class LAVarMapper {
 private:
     /** Mapping of linear Pterms to LVRefs */
-    vec<LVRef>      ptermToLavar;
+    std::unordered_map<PTRef, LVRef, PTRefHash> ptermToLavar;
 
     /** The inverse of ptermToLavar, mapping LVRefs to PTRefs */
     vec<PTRef>      laVarToPTRef;
@@ -39,9 +41,8 @@ public:
 
     void   registerNewMapping(LVRef lv, PTRef e_orig);
 
-    LVRef  getVarByPTId(PTId i) const;
+    LVRef  getVar(PTRef) const;
 
-    bool   hasVar(PTId i) const;
     bool   hasVar(PTRef tr) const;
 
     inline PTRef getVarPTRef(LVRef ref) const { return laVarToPTRef[ref.x]; }

--- a/src/tsolvers/lasolver/LAVarMapper.h
+++ b/src/tsolvers/lasolver/LAVarMapper.h
@@ -9,10 +9,9 @@
 #define OPENSMT_LAVARMAPPER_H
 
 #include "LARefs.h"
+#include "Map.h"
 #include "Pterm.h"
 #include "Vec.h"
-
-#include <unordered_map>
 
 class ArithLogic;
 
@@ -30,7 +29,7 @@ class ArithLogic;
 class LAVarMapper {
 private:
     /** Mapping of linear Pterms to LVRefs */
-    std::unordered_map<PTRef, LVRef, PTRefHash> ptermToLavar;
+    Map<PTRef, LVRef, PTRefHash> ptermToLavar;
 
     /** The inverse of ptermToLavar, mapping LVRefs to PTRefs */
     vec<PTRef>      laVarToPTRef;


### PR DESCRIPTION
This PR suggests to replace the inner representation of how LASolver maintains mappings from Pterms to its inner representations (LVRefs and bounds).
Instead of vectors indexed by PTId, I suggest to use just normal HashMap.
The disadvantage of current representation is its memory inefficiency, because the size of the vectors possibly depends on the number of terms in Logic. But Logic may contain a huge number of terms compared to a few atoms that need to be represented in LASolver.

For OpenSMT itself this does not make much difference, but for Golem, it can have noticeable impact, as `LASolver` is re-initialized on every check-sat call, and Golem makes quite a lot of them.