### PR TITLE
Logic: Rewrite mkAnd/mkOr to avoid memory allocations and term lookup

### DIFF
--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -238,6 +238,8 @@ protected:
     bool isInternalSort(SRef) const;
     void newUninterpretedSortHandler(SRef);
 
+    PtAsgn toPtAsgn(PTRef ref) const { return isNot(ref) ? PtAsgn(getPterm(ref)[0], l_False) : PtAsgn(ref, l_True); }
+
 public:
 
     // General disequalities


### PR DESCRIPTION
This PR suggests to change the simplification code of `mkAnd` and `mkOr` methods.
It uses slightly more complicated comparison method for sorting the arguments, but the benefits are
1. No auxiliary vector needed to store copy of the arguments
2. Even more importantly, it avoids relatively expensive lookup in `mkNot` which is currently called for every negated argument.

`mkNot` seems like a simple operation, but it itself needs to use auxiliary vector for its single argument and it needs to do the lookup in the boolean term table.

Profiles suggest that sorting is typically very fast, while the lookup and copies are more expensive, so I believe this is a good tradeoff.

This could be followed by automatically sorting all commutative operators in `Logic::mkFun`, as proposed in #491, in which case, we could introduce (developers-only) versions of `mkAnd/mkOr` that would skip the simplification altogether (if we are sure the arguments are already simplified.