### PR TITLE
Benchmark: Add benchmarking of simple term creation

### DIFF
--- a/benchmark/performance/CMakeLists.txt
+++ b/benchmark/performance/CMakeLists.txt
@@ -4,3 +4,10 @@ target_sources(RationalEfficiencyBenchmark
         )
 
 target_link_libraries(RationalEfficiencyBenchmark OpenSMT benchmark::benchmark benchmark_main)
+
+add_executable(MakeTermsBenchmark)
+target_sources(MakeTermsBenchmark
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/perf_mkTerms.cc"
+        )
+
+target_link_libraries(MakeTermsBenchmark OpenSMT benchmark::benchmark benchmark_main)

--- a/benchmark/performance/perf_RationalEfficiency.cc
+++ b/benchmark/performance/perf_RationalEfficiency.cc
@@ -1,6 +1,9 @@
-//
-// Created by prova on 23.11.20.
-//
+/*
+ *  Copyright (c) 2020, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #include <benchmark/benchmark.h>
 #include <Real.h>

--- a/benchmark/performance/perf_mkTerms.cc
+++ b/benchmark/performance/perf_mkTerms.cc
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+#include <benchmark/benchmark.h>
+#include <Logic.h>
+
+#include <algorithm>
+#include <random>
+
+class MkTermsFixture : public ::benchmark::Fixture {
+protected:
+
+
+public:
+    void SetUp(const ::benchmark::State&) {
+    }
+
+    void TearDown(const ::benchmark::State&) {
+    }
+};
+
+BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyPositive)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 50; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    for (auto _ : st) {
+        for (auto i = 0u; i < vars.size(); ++i) {
+            PTRef var1 = vars[i];
+            for (auto j = 0u; j < vars.size(); ++j) {
+                PTRef conj = logic.mkAnd(var1, vars[j]);
+                benchmark::DoNotOptimize(conj);
+            }
+        }
+    }
+}
+
+BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyNegative)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 50; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkNot(logic.mkBoolVar(name.c_str())));
+    }
+
+    for (auto _ : st) {
+        for (auto i = 0u; i < vars.size(); ++i) {
+            PTRef var1 = vars[i];
+            for (auto j = 0u; j < vars.size(); ++j) {
+                PTRef conj = logic.mkAnd(var1, vars[j]);
+                benchmark::DoNotOptimize(conj);
+            }
+        }
+    }
+}
+
+BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_Mixed)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 25; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    for (int i = 0; i < 25; ++i) {
+        vars.push_back(logic.mkNot(vars[i]));
+    }
+
+    for (auto _ : st) {
+        for (auto i = 0u; i < vars.size(); ++i) {
+            PTRef var1 = vars[i];
+            for (auto j = 0u; j < vars.size(); ++j) {
+                PTRef conj = logic.mkAnd(var1, vars[j]);
+                benchmark::DoNotOptimize(conj);
+            }
+        }
+    }
+}
+
+BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyPositive)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    vec<PTRef> args = vars;
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}
+
+BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyNegative)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    vec<PTRef> args;
+    args.capacity(vars.size());
+    for (PTRef var : vars) {
+        args.push(logic.mkNot(var));
+    }
+
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}
+
+BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyPositive_Randomized)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+    vec<PTRef> args = vars;
+    std::shuffle(args.begin(), args.end(), std::default_random_engine(0));
+
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}


### PR DESCRIPTION
This PR adds benchmarking tests for creation of conjunctions.
There are tests for
1. Creating a lot of binary conjunctions
2. Creating one larger conjunction

In both cases, I added tests evaluating the impact of negated terms and in the second case comparing an ordered arguments and randomly shuffled arguments.