### PR TITLE
benchmarking: first version of the scripts

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,67 @@
+# Simple scripts for benchmarking with visualisation
+
+Our typical use case is that there are two branches that differ in some
+intersting way in the implementation of a function.  Google's micro
+benchmarking provides a way to write benchmarks for the functionality.
+These scripts make it easier to visualise the run time difference in the
+two branches.
+
+## Benchmarking
+
+The process consists of three phases.
+
+1. In the fist phase the two branches are compiled and the resulting
+   benchmarks are *saved* (see below).
+2. In the second phase the two benchmarks are run and a bar chart is
+   produced as a `gnuplot` script.
+3. Cleanup.  Remove the stored benchmarks.
+
+### Saving the benchmark
+
+`save-benchmark.sh` takes as an argument a path to the benchmark.  It
+needs to be run in the build directory (the directory with
+`lib/libopensmt.so`).  It copies the benchmark to the directory `work`
+in the same directory where the `save-benchmark.sh` script is, along
+with `lib/libopensmt.so`, using the name of the current git (short)
+commit hash.  It makes therefore sense that the benchmark being saved is
+the one compiled in the current commit hash without changes.  For
+example:
+
+```
+$ cd build
+$ git checkout 9ceb3836; make -j4
+$ ../benchmarking/save-benchmark.sh benchmark/performance/MakeTermsBenchmarkBig
+$ git checkout c64fdd4e; make -j4
+$ ../benchmarking/save-benchmark.sh benchmark/performance/MakeTermsBenchmarkBig
+```
+
+As a result `../benchmarking/work/` will be populated as follows:
+
+```
+$ ls ../benchmarking/work
+c64fdd4e 9ceb3836 lib-c64fdd4e lib-9ceb3836
+```
+
+### Benchmarking Proper
+
+The benchmarks are run with the script `compare.sh` which uses the
+stored benchmarks from the first step.  Continuing the above example,
+the usage is
+
+```
+$ ../benchmarking/compare.sh 9ceb3836 c64fdd4e |gnuplot > test.png
+```
+
+This will place the bar plot in the file `test.png`.
+
+### Cleaning up
+
+The scripts do not remove the directory `../benchmarking/work/`.  To
+avoid it growing too big, clean the directory from time to time.
+
+## Notes
+
+For the visualisation to work, it is useful to design the benchmarks so
+that there aren't too many sub-tests in a benchmark (say, have only
+three per benchmark), and that the sub-test names are not too long.
+

--- a/benchmarking/compare.sh
+++ b/benchmarking/compare.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 workdir=$(cd $(dirname $0); pwd)/work
 
@@ -56,11 +56,17 @@ trap "rm -rf ${TMPDIR}" EXIT
 
 tests=`LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_list_tests`
 
-LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_format=csv \
-    |csvcut -c 'name,real_time' > $TMPDIR/bm1.csv
+echo "Running benchmark $benchmark1 three times and saving the last" >&2
+for ((j=0; j < 3; j++)); do
+    LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_format=csv \
+        |csvcut -c 'name,real_time' > $TMPDIR/bm1.csv
+done
 
-LD_LIBRARY_PATH=$lib2 $benchmark2 --benchmark_format=csv \
-    |csvcut -c 'name,real_time' > $TMPDIR/bm2.csv
+echo "Running benchmark $benchmark2 three times and saving the last" >&2
+for ((i=0; i < 3; i++)); do
+    LD_LIBRARY_PATH=$lib2 $benchmark2 --benchmark_format=csv \
+        |csvcut -c 'name,real_time' > $TMPDIR/bm2.csv
+done
 
 echo "set term pngcairo color"
 

--- a/benchmarking/compare.sh
+++ b/benchmarking/compare.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+workdir=$(cd $(dirname $0); pwd)/work
+
+usage="Usage: $0 [-h] <hash1> <hash2>"
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -h|--help)
+            echo "${usage}"
+            exit 1
+            ;;
+        -*)
+            echo "Error: invalid option '$1'"
+            exit 1
+            ;;
+        *)
+            break
+    esac
+    shift; shift
+done
+
+if [ $# != 2 ]; then
+    echo ${usage}
+    exit 1
+fi
+
+benchmark1=$workdir/$1
+benchmark2=$workdir/$2
+
+lib1=$workdir/lib-$(basename $benchmark1)
+lib2=$workdir/lib-$(basename $benchmark2)
+
+if [ ! -x $benchmark1 ]; then
+    echo "Not executable: $benchmark1"
+    exit 1;
+fi
+
+if [ ! -x $benchmark2 ]; then
+    echo "Not executable: $benchmark2"
+    exit 1;
+fi
+
+if [ ! -d $lib1 ]; then
+    echo "library directory not found: $lib1"
+    exit 1;
+fi
+
+if [ ! -d $lib2 ]; then
+    echo "library directory not found: $lib2"
+    exit 1;
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf ${TMPDIR}" EXIT
+
+tests=`LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_list_tests`
+
+LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_format=csv \
+    |csvcut -c 'name,real_time' > $TMPDIR/bm1.csv
+
+LD_LIBRARY_PATH=$lib2 $benchmark2 --benchmark_format=csv \
+    |csvcut -c 'name,real_time' > $TMPDIR/bm2.csv
+
+echo "set term pngcairo color"
+
+echo -n "set xtics ("
+offset=0
+for test in $tests; do
+    echo -n "\"$test\" $(echo "$offset+0.25" | bc -l), "
+    offset=$(echo "$offset+1.5" | bc -l)
+done
+echo ")"
+
+echo set yrange [0:]
+echo set boxwidth 0.5
+echo set style fill solid
+echo "plot '-' using 1:2 with boxes ls 1 title '$(basename $benchmark1)', '-' using 1:2 with boxes ls 2 title '$(basename $benchmark2)'"
+
+offset=0
+for test in $tests; do
+    bm1res=$(csvgrep -m $test -c name $TMPDIR/bm1.csv |csvcut -c real_time |tail -1)
+    bm2res=$(csvgrep -m $test -c name $TMPDIR/bm2.csv |csvcut -c real_time |tail -1)
+    echo $offset $bm1res
+    offset=$(echo $offset + 1.5 |bc -l)
+done
+echo e
+
+offset=0
+for test in $tests; do
+    bm2res=$(csvgrep -m $test -c name $TMPDIR/bm2.csv |csvcut -c real_time |tail -1)
+    echo $(echo $offset+0.5 |bc -l) $bm2res
+    offset=$(echo $offset + 1.5 |bc -l)
+done

--- a/benchmarking/compare.sh
+++ b/benchmarking/compare.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+function run_with_lib() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        DYLD_LIBRARY_PATH=$1 $2 $3
+    else
+        LD_LIBRARY_PATH=$1 $2 $3
+    fi
+}
+
 workdir=$(cd $(dirname $0); pwd)/work
 
 usage="Usage: $0 [-h] <hash1> <hash2>"
@@ -54,17 +62,17 @@ fi
 TMPDIR=$(mktemp -d)
 trap "rm -rf ${TMPDIR}" EXIT
 
-tests=`LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_list_tests`
+tests=`run_with_lib $lib1 $benchmark1 --benchmark_list_tests`
 
 echo "Running benchmark $benchmark1 three times and saving the last" >&2
 for ((j=0; j < 3; j++)); do
-    LD_LIBRARY_PATH=$lib1 $benchmark1 --benchmark_format=csv \
+    run_with_lib $lib1 $benchmark1 --benchmark_format=csv \
         |csvcut -c 'name,real_time' > $TMPDIR/bm1.csv
 done
 
 echo "Running benchmark $benchmark2 three times and saving the last" >&2
 for ((i=0; i < 3; i++)); do
-    LD_LIBRARY_PATH=$lib2 $benchmark2 --benchmark_format=csv \
+    run_with_lib $lib2 $benchmark2 --benchmark_format=csv \
         |csvcut -c 'name,real_time' > $TMPDIR/bm2.csv
 done
 

--- a/benchmarking/save-benchmark.sh
+++ b/benchmarking/save-benchmark.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+workdir=$(cd $(dirname $0); pwd)/work
+
+usage="Usage: $0 [-h] <path-to-benchmark>"
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -h|--help)
+            echo "${usage}"
+            exit 1
+            ;;
+        -*)
+            echo "Error: invalid option '$1'"
+            exit 1
+            ;;
+        *)
+            break
+    esac
+    shift; shift
+done
+
+if [ $# -ne 1 ]; then
+    echo $usage
+    exit 1
+fi
+
+if [ ! -x $1 ]; then
+    echo "Benchmark $1 is not executable"
+fi
+
+current_head=`git rev-parse --short HEAD`
+benchmark=$1
+
+mkdir -p $workdir
+
+cp -R lib $workdir/lib-$current_head
+cp $benchmark $workdir/$current_head
+


### PR DESCRIPTION
Scripts for comparing benchmarks.  I'll write later a readme, and we can think of something nicer.  The problem is that I want to store the benchmark binaries to be able to run them later on one go, but the benchmarks link on the opensmt library that is currently in the `build` directory.