### PR TITLE
Split perf_mkTerms to two

### DIFF
--- a/benchmark/performance/CMakeLists.txt
+++ b/benchmark/performance/CMakeLists.txt
@@ -5,9 +5,16 @@ target_sources(RationalEfficiencyBenchmark
 
 target_link_libraries(RationalEfficiencyBenchmark OpenSMT benchmark::benchmark benchmark_main)
 
-add_executable(MakeTermsBenchmark)
-target_sources(MakeTermsBenchmark
-        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/perf_mkTerms.cc"
+add_executable(MakeTermsBenchmarkSmall)
+target_sources(MakeTermsBenchmarkSmall
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/perf_mkTermsSmallConj.cc"
         )
 
-target_link_libraries(MakeTermsBenchmark OpenSMT benchmark::benchmark benchmark_main)
+target_link_libraries(MakeTermsBenchmarkSmall OpenSMT benchmark::benchmark benchmark_main)
+
+add_executable(MakeTermsBenchmarkBig)
+target_sources(MakeTermsBenchmarkBig
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/perf_mkTermsBigConj.cc"
+        )
+
+target_link_libraries(MakeTermsBenchmarkBig OpenSMT benchmark::benchmark benchmark_main)

--- a/benchmark/performance/perf_mkTermsBigConj.cc
+++ b/benchmark/performance/perf_mkTermsBigConj.cc
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+#include <benchmark/benchmark.h>
+#include <Logic.h>
+
+#include <algorithm>
+#include <random>
+
+class MkTerms : public ::benchmark::Fixture {
+protected:
+
+
+public:
+    void SetUp(const ::benchmark::State&) {
+    }
+
+    void TearDown(const ::benchmark::State&) {
+    }
+};
+
+BENCHMARK_F(MkTerms, Pos)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    vec<PTRef> args = vars;
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}
+
+BENCHMARK_F(MkTerms, Neg)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+
+    vec<PTRef> args;
+    args.capacity(vars.size());
+    for (PTRef var : vars) {
+        args.push(logic.mkNot(var));
+    }
+
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}
+
+BENCHMARK_F(MkTerms, PosRand)(benchmark::State& st) {
+    Logic logic{opensmt::Logic_t::QF_UF};
+    std::vector<PTRef> vars;
+    for (int i = 0; i < 100; ++i) {
+        auto name = std::string("b") + std::to_string(i);
+        vars.push_back(logic.mkBoolVar(name.c_str()));
+    }
+    vec<PTRef> args = vars;
+    std::shuffle(args.begin(), args.end(), std::default_random_engine(0));
+
+    for (auto _ : st) {
+        PTRef conj = logic.mkAnd(args);
+        benchmark::DoNotOptimize(conj);
+    }
+}

--- a/benchmark/performance/perf_mkTermsSmallConj.cc
+++ b/benchmark/performance/perf_mkTermsSmallConj.cc
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <random>
 
-class MkTermsFixture : public ::benchmark::Fixture {
+class MkTerms : public ::benchmark::Fixture {
 protected:
 
 
@@ -22,7 +22,7 @@ public:
     }
 };
 
-BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyPositive)(benchmark::State& st) {
+BENCHMARK_F(MkTerms, Pos)(benchmark::State& st) {
     Logic logic{opensmt::Logic_t::QF_UF};
     std::vector<PTRef> vars;
     for (int i = 0; i < 50; ++i) {
@@ -41,7 +41,7 @@ BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyPositive)(benchmark::State
     }
 }
 
-BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyNegative)(benchmark::State& st) {
+BENCHMARK_F(MkTerms, Neg)(benchmark::State& st) {
     Logic logic{opensmt::Logic_t::QF_UF};
     std::vector<PTRef> vars;
     for (int i = 0; i < 50; ++i) {
@@ -60,7 +60,7 @@ BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_OnlyNegative)(benchmark::State
     }
 }
 
-BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_Mixed)(benchmark::State& st) {
+BENCHMARK_F(MkTerms, Mix)(benchmark::State& st) {
     Logic logic{opensmt::Logic_t::QF_UF};
     std::vector<PTRef> vars;
     for (int i = 0; i < 25; ++i) {
@@ -80,56 +80,5 @@ BENCHMARK_F(MkTermsFixture, ManySmallConjunctions_Mixed)(benchmark::State& st) {
                 benchmark::DoNotOptimize(conj);
             }
         }
-    }
-}
-
-BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyPositive)(benchmark::State& st) {
-    Logic logic{opensmt::Logic_t::QF_UF};
-    std::vector<PTRef> vars;
-    for (int i = 0; i < 100; ++i) {
-        auto name = std::string("b") + std::to_string(i);
-        vars.push_back(logic.mkBoolVar(name.c_str()));
-    }
-
-    vec<PTRef> args = vars;
-    for (auto _ : st) {
-        PTRef conj = logic.mkAnd(args);
-        benchmark::DoNotOptimize(conj);
-    }
-}
-
-BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyNegative)(benchmark::State& st) {
-    Logic logic{opensmt::Logic_t::QF_UF};
-    std::vector<PTRef> vars;
-    for (int i = 0; i < 100; ++i) {
-        auto name = std::string("b") + std::to_string(i);
-        vars.push_back(logic.mkBoolVar(name.c_str()));
-    }
-
-    vec<PTRef> args;
-    args.capacity(vars.size());
-    for (PTRef var : vars) {
-        args.push(logic.mkNot(var));
-    }
-
-    for (auto _ : st) {
-        PTRef conj = logic.mkAnd(args);
-        benchmark::DoNotOptimize(conj);
-    }
-}
-
-BENCHMARK_F(MkTermsFixture, OneLargeConjunctions_OnlyPositive_Randomized)(benchmark::State& st) {
-    Logic logic{opensmt::Logic_t::QF_UF};
-    std::vector<PTRef> vars;
-    for (int i = 0; i < 100; ++i) {
-        auto name = std::string("b") + std::to_string(i);
-        vars.push_back(logic.mkBoolVar(name.c_str()));
-    }
-    vec<PTRef> args = vars;
-    std::shuffle(args.begin(), args.end(), std::default_random_engine(0));
-
-    for (auto _ : st) {
-        PTRef conj = logic.mkAnd(args);
-        benchmark::DoNotOptimize(conj);
     }
 }


### PR DESCRIPTION
This PR
 * splits the mkTerms benchmark into two so that benchmarks in the same order of magnitude are run together, and
 * uses shorter benchmark names so that plotting them in a readable way is nicer.