### PR TITLE
TermVisitor: make top-level visit virtual

### DIFF
--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -25,7 +25,7 @@ class TermVisitor {
 public:
     TermVisitor(Logic const & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
 
-    void visit(PTRef root) {
+    virtual void visit(PTRef root) {
         // Avoid initializations if no traversal will be done
         if (logic.isVar(root)) {
             if (cfg.previsit(root))


### PR DESCRIPTION
In some use cases it is useful to perform special actions at top-level
visit, such as resetting the state of the config.  This commit suggests
to turn TermVisitor's top-level visit function into a virtual function
so that it can be fluidly overridden if needed.