### PR TITLE
Avoid serialising big terms into smt-lib

### DIFF
--- a/src/common/TreeOps.h
+++ b/src/common/TreeOps.h
@@ -25,7 +25,7 @@ class TermVisitor {
 public:
     TermVisitor(Logic const & logic, TConfig & cfg) : logic(logic), cfg(cfg) {}
 
-    void visit(PTRef root) {
+    virtual void visit(PTRef root) {
         // Avoid initializations if no traversal will be done
         if (logic.isVar(root)) {
             if (cfg.previsit(root))

--- a/src/parallel/ScatterSplitter.cc
+++ b/src/parallel/ScatterSplitter.cc
@@ -48,8 +48,7 @@ Var ScatterSplitter::doActivityDecision() {
                     discarded.push(next);
                     next = var_Undef;
                 } else {
-                    PTRef tr = theory_handler.varToTerm(next);
-                    nodeCounter.visit(tr);
+                    nodeCounter.visit(theory_handler.varToTerm(next));
                     if (nodeCounter.limitReached()) {
                         // Do not branch on lengthy variables to avoid oversized terms
                         discarded.push(next);

--- a/src/parallel/ScatterSplitter.h
+++ b/src/parallel/ScatterSplitter.h
@@ -67,6 +67,8 @@ protected:
     void notifyEnd() override;
     lbool zeroLevelConflictHandler() override;                                // Common handling of zero-level conflict as it can happen at multiple places
 
+    void exposeUnitClauses(std::vector<PTPLib::net::Lemma> & learnedLemmas);
+    void exposeLongerClauses(std::vector<PTPLib::net::Lemma> & learnedLemmas);
     bool exposeClauses(std::vector<PTPLib::net::Lemma> & learnedLemmas);
 
     bool isPrefix(const vec<opensmt::pair<int,int>> &  prefix, const vec<opensmt::pair<int,int>> &  full)

--- a/src/parallel/ScatterSplitter.h
+++ b/src/parallel/ScatterSplitter.h
@@ -11,6 +11,7 @@
 #include "SplitData.h"
 #include "SplitContext.h"
 #include "Splitter.h"
+#include "TreeOps.h"
 
 #include <PTPLib/net/Channel.hpp>
 #include <PTPLib/common/Exception.hpp>
@@ -47,6 +48,8 @@ private:
     std::unordered_set<Var> assumptionVars;
 
     PTPLib::common::synced_stream * syncedStream = nullptr;
+
+    PtermNodeCounter nodeCounter;
 
     void runPeriodic() override;                                       // Check if solver is in clause share mode to starts clause exposing operation
 

--- a/test/unit/test_Visitors.cc
+++ b/test/unit/test_Visitors.cc
@@ -82,3 +82,32 @@ TEST_F(VisitorTest, test_GetSubTermsArbitraryPredicate) {
     EXPECT_TRUE(contains(subterms,plus1));
     EXPECT_TRUE(contains(subterms,plus2));
 }
+
+TEST_F(VisitorTest, test_PtermNodeCounter) {
+    PTRef zero = logic.getTerm_RealZero();
+    PTRef plus1 = logic.mkPlus(x, y);
+    PTRef plus2 = logic.mkPlus(x, z);
+    PTRef fla = logic.mkAnd(logic.mkGeq(plus1, zero), logic.mkGeq(plus2, zero));
+
+    for (auto limit : {UINT32_MAX, 2u, 9u, 10u}) {
+        PtermNodeCounter counter(logic, limit);
+        counter.visit(fla);
+        if (limit < 10) {
+            ASSERT_TRUE(counter.limitReached());
+        } else {
+            ASSERT_EQ(counter.getCount(), 9);
+            ASSERT_FALSE(counter.limitReached());
+        }
+    }
+
+    for (auto tr : {plus1, plus2, fla, fla}) {
+        PtermNodeCounter counter(logic, 4u);
+        counter.visit(tr);
+        if (tr == plus1 or tr == plus2) {
+            ASSERT_FALSE(counter.limitReached());
+            ASSERT_EQ(counter.getCount(), 3);
+        } else {
+            ASSERT_TRUE(counter.limitReached());
+        }
+    }
+}


### PR DESCRIPTION
When parallel solver needs to communicate terms they are serialised at the moment into smt-lib terms.  However, these terms might grow huge.  This PR suggests how the size can be kept in check using the number of sub-terms as a proxy for the smt-lib size of the term.