### PR TITLE
Interpret: Fix printing of models for functions

### DIFF
--- a/regression_models/instances/uflra_printing.smt2
+++ b/regression_models/instances/uflra_printing.smt2
@@ -1,0 +1,6 @@
+(set-info :status sat)
+(set-logic QF_UFLRA)
+(declare-fun x () Real)
+(declare-fun f (Real) Real)
+(assert (= (/ 1 2) (f x)))
+(check-sat)

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -805,10 +805,10 @@ std::string Interpret::printDefinitionSmtlib(PTRef tr, PTRef val) {
     return ss.str();
 }
 
-std::string Interpret::printDefinitionSmtlib(const TemplateFunction & templateFun) const {
+std::string Interpret::printDefinitionSmtlib(TemplateFunction const & templateFun) const {
     std::stringstream ss;
     ss << "  (define-fun " << templateFun.getName() << " (";
-    const vec<PTRef>& args = templateFun.getArgs();
+    vec<PTRef> const & args = templateFun.getArgs();
     for (int i = 0; i < args.size(); i++) {
         auto sortString = logic->printSort(logic->getSortRef(args[i]));
         ss << "(" << logic->protectName(logic->getSymRef(args[i])) << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -814,7 +814,7 @@ std::string Interpret::printDefinitionSmtlib(const TemplateFunction & templateFu
         ss << "(" << logic->protectName(logic->getSymRef(args[i])) << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");
     }
     ss << ")" << " " << logic->printSort(templateFun.getRetSort()) << "\n";
-    ss << "    " << logic->pp(templateFun.getBody()) << ")\n";
+    ss << "    " << logic->printTerm(templateFun.getBody()) << ")\n";
     return ss.str();
 }
 


### PR DESCRIPTION
Logic::pp should not be used for output to the user.
It prints rationals in infix format, but models should be printed in SMT-LIB format (using Logic::printTerm).