### PR TITLE
Small cleanup related to resolution proof graph

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -218,7 +218,7 @@ std::unique_ptr<Model> MainSolver::getModel() {
 std::unique_ptr<InterpolationContext> MainSolver::getInterpolationContext() {
     if (status != s_False) { throw OsmtApiException("Interpolation context cannot be created if solver is not in UNSAT state"); }
     return std::make_unique<InterpolationContext>(
-            config, *theory, *term_mapper, getSMTSolver().getProof(), pmanager, getSMTSolver().nVars()
+            config, *theory, *term_mapper, getSMTSolver().getProof(), pmanager
     );
 }
 

--- a/src/cnfizers/TermMapper.h
+++ b/src/cnfizers/TermMapper.h
@@ -87,6 +87,12 @@ public:
         return varToTerm[v];
     }
 
+    PTRef litToPTRef(Lit l) const {
+        Var v = var(l);
+        PTRef atom = varToPTRef(v);
+        return sign(l) ? logic.mkNot(atom) : atom;
+    }
+
     int nVars() const { return varToTerm.size(); }
 };
 

--- a/src/common/VerificationUtils.cc
+++ b/src/common/VerificationUtils.cc
@@ -1,81 +1,14 @@
-//
-// Created by Martin Blicha on 29.07.20.
-//
+/*
+ *  Copyright (c) 2020-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #include "VerificationUtils.h"
 
 #include "MainSolver.h"
 #include "TreeOps.h"
-
-#include <sys/wait.h>
-#include <unistd.h>
-
-bool VerificationUtils::impliesExternal(PTRef implicant, PTRef implicated) const {
-    const char * implies = "implies.smt2";
-    std::ofstream dump_out( implies );
-    logic.dumpHeaderToFile(dump_out);
-
-    logic.dumpFormulaToFile(dump_out, implicant);
-    logic.dumpFormulaToFile(dump_out, implicated, true);
-    dump_out << "(check-sat)" << '\n';
-    dump_out << "(exit)" << '\n';
-    dump_out.close( );
-    // Check !
-    bool tool_res;
-    int pid = fork();
-    if(pid == -1){
-        std::cerr << "Failed to fork\n";
-        // consider throwing and exception
-        return false;
-    }
-    else if( pid == 0){
-        // child process
-        execlp( config.certifying_solver, config.certifying_solver, implies, NULL );
-        perror( "Child process error: " );
-        exit( 1 );
-    }
-    else{
-        // parent
-        int status;
-        waitpid(pid, &status, 0);
-        switch ( WEXITSTATUS( status ) )
-        {
-            case 0:
-//                std::cerr << "Implication holds!\n";
-                tool_res = false;
-                break;
-            case 1:
-//                std::cerr << "Implication does not hold!\n";
-//                std::cerr << "Antecedent: " << logic.printTerm(implicant) << '\n';
-//                std::cerr << "Consequent: " << logic.printTerm(implicated) << '\n';
-                tool_res = true;
-                break;
-            default:
-                perror( "Parent process error" );
-                exit( EXIT_FAILURE );
-        }
-    }
-
-    return !tool_res;
-}
-
-bool VerificationUtils::verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp) const {
-    bool verbose = config.verbosity() > 0;
-    if(verbose) {
-        std::cout << "; Verifying final interpolant" << std::endl;
-    }
-    bool res = impliesExternal(partA, itp);
-    if(!res) { return false; }
-    if(verbose) {
-        std::cout << "; A -> I holds" << std::endl;
-    }
-    res = impliesExternal(itp, logic.mkNot(partB));
-    if(!res) { return false; }
-    if(verbose) {
-        std::cout << "; B -> !I holds" << std::endl;
-    }
-    return res;
-}
 
 bool VerificationUtils::verifyInterpolantInternal(PTRef Apartition, PTRef Bpartition, PTRef itp) {
     SMTConfig validationConfig;

--- a/src/common/VerificationUtils.h
+++ b/src/common/VerificationUtils.h
@@ -1,22 +1,19 @@
-//
-// Created by Martin Blicha on 29.07.20.
-//
+/*
+ *  Copyright (c) 2020-2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #ifndef OPENSMT_VERIFICATIONUTILS_H
 #define OPENSMT_VERIFICATIONUTILS_H
 
-#include "SMTConfig.h"
 #include "Logic.h"
 
 class VerificationUtils {
-    SMTConfig const & config;
     Logic & logic;
 public:
-    VerificationUtils(SMTConfig const & config, Logic & logic) : config(config), logic(logic) {}
-
-    bool impliesExternal(PTRef, PTRef) const; // Check the result with an external solver
-
-    bool verifyInterpolantExternal(PTRef partA, PTRef partB, PTRef itp) const; // Verify interpolant using an external solver
+    VerificationUtils(Logic & logic) : logic(logic) {}
 
     bool verifyInterpolantInternal(PTRef partA, PTRef partB, PTRef itp); // Verify interpolant internally, using OpenSMT's MainSolver
 

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -842,9 +842,9 @@ void SingleInterpolationComputationContext::setLeafMcMillanPrimeLabeling(ProofNo
 /************************ INTERPOLATION CONTEXT ************************************************************/
 
 InterpolationContext::InterpolationContext(SMTConfig & c, Theory & th, TermMapper & termMapper, Proof const & proof,
-                                           PartitionManager & pmanager, int n)
+                                           PartitionManager & pmanager)
         : config(c), theory(th), termMapper(termMapper), logic(th.getLogic()), pmanager(pmanager),
-          proof_graph{new ProofGraph(c, th.getLogic(), termMapper, proof, n)} {
+          proof_graph{new ProofGraph(c, th.getLogic(), termMapper, proof)} {
     ensureNoLiteralsWithoutPartition();
     if (c.proof_reduce()) {
         reduceProofGraph();

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -455,7 +455,7 @@ bool SingleInterpolationComputationContext::verifyPartialInterpolantA(ProofNode 
     PTRef cl_ptref = logic.mkNot(logic.mkOr(std::move(restricted_clause)));
     PTRef implicant = logic.mkAnd({pmanager.getPartition(A_mask, PartitionManager::part::A), cl_ptref});
 
-    bool res = VerificationUtils(config, logic).impliesExternal(implicant, getPartialInterpolant(n));
+    bool res = VerificationUtils(logic).impliesInternal(implicant, getPartialInterpolant(n));
     assert(res);
     return res;
 }
@@ -483,7 +483,7 @@ bool SingleInterpolationComputationContext::verifyPartialInterpolantB(ProofNode 
     PTRef cl_ptref = logic.mkNot(logic.mkOr(std::move(restricted_clause)));
     PTRef implicant = logic.mkAnd(pmanager.getPartition(A_mask, PartitionManager::part::B), cl_ptref);
 
-    bool res = VerificationUtils(config, logic).impliesExternal(implicant, logic.mkNot(getPartialInterpolant(n)));
+    bool res = VerificationUtils(logic).impliesInternal(implicant, logic.mkNot(getPartialInterpolant(n)));
     assert(res);
     return res;
 }
@@ -901,7 +901,7 @@ bool InterpolationContext::getPathInterpolants(vec<PTRef> & interpolants, const 
             PTRef previous_itp = interpolants[interpolants.size() - 2];
             PTRef next_itp = interpolants[interpolants.size() - 1];
             PTRef movedPartitions = logic.mkAnd(pmanager.getPartitions(A_masks[i] ^ A_masks[i - 1]));
-            propertySatisfied &= VerificationUtils(config, logic).impliesInternal(logic.mkAnd(previous_itp, movedPartitions), next_itp);
+            propertySatisfied &= VerificationUtils(logic).impliesInternal(logic.mkAnd(previous_itp, movedPartitions), next_itp);
             if (not propertySatisfied) {
                 std::cerr << "; Path interpolation does not hold for:\n"
                           << "First interpolant: " << logic.printTerm(previous_itp) << '\n'
@@ -933,7 +933,7 @@ void InterpolationContext::transformProofForCNFInterpolants() {
 bool InterpolationContext::verifyInterpolant(PTRef itp, const ipartitions_t & A_mask) const {
     PTRef partA = pmanager.getPartition(A_mask, PartitionManager::part::A);
     PTRef partB = pmanager.getPartition(A_mask, PartitionManager::part::B);
-    bool sound = VerificationUtils(config, logic).verifyInterpolantInternal(partA, partB, itp);
+    bool sound = VerificationUtils(logic).verifyInterpolantInternal(partA, partB, itp);
     return sound;
 }
 

--- a/src/proof/InterpolationContext.h
+++ b/src/proof/InterpolationContext.h
@@ -25,7 +25,7 @@ class InterpolationContext {
     std::unique_ptr<ProofGraph> proof_graph;
 public:
     InterpolationContext(SMTConfig & c, Theory & th, TermMapper & termMapper, Proof const & t,
-                         PartitionManager & pmanager, int n = -1);
+                         PartitionManager & pmanager);
 
     ~InterpolationContext();
 

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -297,7 +297,6 @@ public:
     std::set<clauseid_t> const & getLeaves() const { return leaves_ids; };
     std::set<Var> const & getVariables() const { return proof_variables; }
 
-    void              printClause           (std::ostream&, std::vector<Lit> const& lits);
     void              printClause           ( ProofNode * );
     void              printClause           ( ProofNode *, std::ostream & );
     inline ProofNode* getNode               ( clauseid_t id ) const { assert(id < graph.size()); return graph[id]; }

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -215,14 +215,14 @@ public:
             , Logic & logic
             , TermMapper const & termMapper
             , Proof const &   proof
-			, int             varCount)
+			)
 : config   ( c )
 , logic_ ( logic )
 , termMapper(termMapper)
 {
 		mpz_init(visited_1);
 		mpz_init(visited_2);
-		buildProofGraph(proof, varCount);
+		buildProofGraph(proof);
 }
 
 	~ProofGraph()
@@ -366,7 +366,7 @@ public:
     void eliminateNoPartitionTheoryVars(std::vector<Var> const & noParititionTheoryVars);
 
 private:
-    void buildProofGraph(Proof const & proof, int varCount);
+    void buildProofGraph(Proof const & proof);
     ProofNode * createProofNodeFor(CRef cref, clause_type _ctype, Proof const & proof); // Helper method for building the proof graph
 
     inline void       addLeaf(clauseid_t id)      {  leaves_ids.insert(id); }
@@ -394,7 +394,6 @@ private:
     unsigned                       max_id_variable;             // Highest value for a variable
     std::vector<Lit> assumedLiterals;
 
-    int                            num_vars_limit;               // Number of variables in the problem (not nec in the proof)
 
     // Info on graph dimension
     int    num_nodes;

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -297,7 +297,6 @@ public:
     std::set<clauseid_t> const & getLeaves() const { return leaves_ids; };
     std::set<Var> const & getVariables() const { return proof_variables; }
 
-    void              printProofNode        ( clauseid_t );
     void              printClause           (std::ostream&, std::vector<Lit> const& lits);
     void              printClause           ( ProofNode * );
     void              printClause           ( ProofNode *, std::ostream & );

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -87,7 +87,7 @@ ProofNode * ProofGraph::createProofNodeFor(CRef clause, clause_type _ctype, Proo
     return n;
 }
 
-void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
+void ProofGraph::buildProofGraph(const Proof & proof) {
     if (verbose()) { std::cerr << "# " << "Proof graph building begin" << '\n'; }
     if (verbose() > 0) {
         uint64_t mem_used = memUsed();
@@ -95,9 +95,6 @@ void ProofGraph::buildProofGraph(const Proof & proof, int varCount) {
     }
 
     const double initTime=cpuTime();
-    // Nominal number of variables
-    assert(varCount > 0);
-    num_vars_limit = varCount;
     max_id_variable=0;
 
     av_cla_size=0; max_cla_size=0;

--- a/src/proof/PGCheck.cc
+++ b/src/proof/PGCheck.cc
@@ -26,14 +26,13 @@ along with Periplo. If not, see <http://www.gnu.org/licenses/>.
 #include <deque>
 
 
-void ProofGraph::verifyLeavesInconsistency( )
-{
+void ProofGraph::verifyLeavesInconsistency() {
     if (verbose() > 0) { std::cerr << "# Verifying unsatisfiability of the set of proof leaves" << std::endl; }
 
-	std::vector<clauseid_t> proofleaves;
-	std::vector<clauseid_t> q;
-	std::vector<unsigned> visited_count(getGraphSize(), 0u);
-	q.push_back(getRoot()->getId());
+    std::vector<clauseid_t> proofleaves;
+    std::vector<clauseid_t> q;
+    std::vector<unsigned> visited_count(getGraphSize(), 0u);
+    q.push_back(getRoot()->getId());
     do {
         clauseid_t id = q.back();
         ProofNode * node = getNode(id);
@@ -58,14 +57,15 @@ void ProofGraph::verifyLeavesInconsistency( )
     } while (!q.empty());
 
     vec<PTRef> clauses;
-	for (clauseid_t leaf_id : leaves_ids) {
+    for (clauseid_t leaf_id : leaves_ids) {
         auto const & clause = getNode(leaf_id)->getClause();
         vec<PTRef> lits;
+        lits.capacity(clause.size());
         for (Lit l : clause) {
             lits.push(termMapper.litToPTRef(l));
         }
         clauses.push(logic_.mkOr(std::move(lits)));
-	}
+    }
     bool unsat = VerificationUtils(logic_).impliesInternal(logic_.mkAnd(std::move(clauses)), logic_.getTerm_false());
     if (not unsat) {
         throw std::logic_error("The set of proof leaves is satisfiable!");

--- a/src/proof/PGMain.cc
+++ b/src/proof/PGMain.cc
@@ -96,8 +96,6 @@ void ProofGraph::transfProofForReduction( )
 		std::cerr << "# ------------------------------------" << '\n';
 		std::cerr << "# Structural properties" << '\n';
 		std::cerr << "# ---------------------" << '\n';
-		std::cerr << "# Nominal num proof variables: ";
-		fprintf( stderr, "%-10d\n", num_vars_limit );
 		std::cerr << "# Actual num proof variables.: ";
 		fprintf( stderr, "%-10d %-10d\n", numvars, (int)proof_variables.size() );
 		std::cerr << "# Nodes......................: ";

--- a/src/proof/PGPrint.cc
+++ b/src/proof/PGPrint.cc
@@ -169,29 +169,6 @@ void ProofGraph::printClause(std::ostream & out, std::vector<Lit> const & c) {
     if ( c.size( ) > 1 ) out << ")";
 }
 
-void ProofGraph::printProofNode(clauseid_t vid)
-{
-	ProofNode* v=getNode(vid);
-	if(v==NULL)
-	{
-		std::cerr << vid << " removed"<< '\n'<<'\n';
-		return;
-	}
-	std::cerr << "Node id: " << v->getId() << "   Type: " << v->getType();
-	if(v->getAnt1()!=NULL && v->getAnt2()!=NULL)
-	{
-		std::cerr << "   Parents: " << v->getAnt1()->getId() << " " << v->getAnt2()->getId() << "   Pivot: " << v->getPivot();
-	}
-	std::cerr << "   Clause: ";
-	for(size_t i=0;i<v->getClauseSize();i++)
-	{
-		if(sign(v->getClause()[i])) std::cerr << "~";
-		//FIXME std::cerr << thandler.varToEnode( var(v->getClause()[i]) ) << " ";
-	}
-	std::cerr << '\n';
-
-}
-
 void ProofGraph::printRuleApplicationStatus()
 {
 	std::cerr << "# Rules application status " << '\n';

--- a/src/proof/PGPrint.cc
+++ b/src/proof/PGPrint.cc
@@ -157,18 +157,6 @@ void ProofGraph::printClause(ProofNode* n, std::ostream & os)
 	}
 }
 
-void ProofGraph::printClause(std::ostream & out, std::vector<Lit> const & c) {
-    if ( c.size( ) == 0 ) out << "-";
-    if ( c.size( ) > 1 ) out << "(or ";
-    for (unsigned i = 0; i < c.size(); i++)
-    {
-        Var v = var(c[i]);
-        if ( v <= 1 ) continue;
-        out << (sign(c[i])?"(not ":"") << logic_.printTerm(termMapper.varToPTRef(v)) << (sign(c[i])?") ":" ");
-    }
-    if ( c.size( ) > 1 ) out << ")";
-}
-
 void ProofGraph::printRuleApplicationStatus()
 {
 	std::cerr << "# Rules application status " << '\n';

--- a/test/unit/test_LIAInterpolation.cc
+++ b/test/unit/test_LIAInterpolation.cc
@@ -24,7 +24,7 @@ protected:
     PTRef x, y, x1, x2, x3, x4;
 
     bool verifyInterpolant(PTRef A, PTRef B, PTRef itp) {
-        return VerificationUtils(config, logic).verifyInterpolantInternal(A, B, itp);
+        return VerificationUtils(logic).verifyInterpolantInternal(A, B, itp);
     }
 };
 

--- a/test/unit/test_LRAInterpolation.cc
+++ b/test/unit/test_LRAInterpolation.cc
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 #include <ArithLogic.h>
-#include "VerificationUtils.h"
 #include <FarkasInterpolator.h>
+#include <VerificationUtils.h>
 
 class LRAInterpolationTest : public ::testing::Test {
 protected:
@@ -19,11 +19,10 @@ protected:
         x4 = logic.mkRealVar("x4");
     }
     ArithLogic logic;
-    SMTConfig config;
     PTRef x, y, x1, x2, x3, x4;
 
     bool verifyInterpolant(PTRef A, PTRef B, PTRef itp) {
-        return VerificationUtils(config, logic).verifyInterpolantInternal(A, B, itp);
+        return VerificationUtils(logic).verifyInterpolantInternal(A, B, itp);
     }
 };
 

--- a/test/unit/test_Proof.cc
+++ b/test/unit/test_Proof.cc
@@ -171,8 +171,7 @@ TEST_F(ReductionTest, test_recyclePivots) {
     proof.addResolutionStep(nd, var(d));
     proof.endChain(CRef_Undef);
 
-    int nVars = 4;
-    ProofGraph pg(config, theory.getLogic(), termMapper, proof, nVars);
+    ProofGraph pg(config, theory.getLogic(), termMapper, proof);
     pg.fillProofGraph();
     pg.checkProof(true);
 //    pg.printProofAsDotty(std::cout);
@@ -231,8 +230,7 @@ TEST_F(ReductionTest, test_recyclePivots_IdenticalAntecedents) {
     proof.addResolutionStep(ne, var(e));
     proof.endChain(CRef_Undef);
 
-    int nVars = 5;
-    ProofGraph pg(config, theory.getLogic(), termMapper, proof, nVars);
+    ProofGraph pg(config, theory.getLogic(), termMapper, proof);
     pg.fillProofGraph();
     pg.checkProof(true);
 //    pg.printProofAsDotty(std::cout);
@@ -293,8 +291,7 @@ TEST_F(ReductionTest, test_recyclePivots_IdenticalAntecedents_AfterPhaseOneRepla
     proof.addResolutionStep(ne, var(e));
     proof.endChain(CRef_Undef);
 
-    int nVars = 5;
-    ProofGraph pg(config, theory.getLogic(), termMapper, proof, nVars);
+    ProofGraph pg(config, theory.getLogic(), termMapper, proof);
     pg.fillProofGraph();
     pg.checkProof(true);
 //    pg.printProofAsDotty(std::cout);
@@ -337,8 +334,7 @@ TEST_F(ReductionTest, test_proofTransformAndRestructure) {
     proof.addResolutionStep(nd, var(d));
     proof.endChain(CRef_Undef);
 
-    int nVars = 5;
-    ProofGraph pg(config, theory.getLogic(), termMapper, proof, nVars);
+    ProofGraph pg(config, theory.getLogic(), termMapper, proof);
     pg.fillProofGraph();
     pg.checkProof(true);
 //    pg.printProofAsDotty(std::cout);
@@ -404,8 +400,7 @@ TEST_F(ReductionTest, test_proofTransformAndRestructure_IdenticalAntecedents) {
     proof.addResolutionStep(nc, var(c));
     proof.endChain(CRef_Undef);
 
-    int nVars = 5;
-    ProofGraph pg(config, theory.getLogic(), termMapper, proof, nVars);
+    ProofGraph pg(config, theory.getLogic(), termMapper, proof);
     pg.fillProofGraph();
     pg.checkProof(true);
 //    pg.printProofAsDotty(std::cout);

--- a/test/unit/test_ResolutionProofInterpolation.cc
+++ b/test/unit/test_ResolutionProofInterpolation.cc
@@ -41,7 +41,7 @@ protected:
     PTRef A_part, B_part;
 
     bool verifyInterpolant(PTRef A, PTRef B, PTRef itp) {
-        return VerificationUtils(config, logic).verifyInterpolantInternal(A, B, itp);
+        return VerificationUtils(logic).verifyInterpolantInternal(A, B, itp);
     }
 };
 
@@ -113,7 +113,7 @@ protected:
     PTRef A_part, B_part;
 
     bool verifyInterpolant(PTRef A, PTRef B, PTRef itp) {
-        return VerificationUtils(config, logic).verifyInterpolantInternal(A, B, itp);
+        return VerificationUtils(logic).verifyInterpolantInternal(A, B, itp);
     }
 };
 
@@ -161,7 +161,7 @@ protected:
     PTRef A_part, B_part;
 
     bool verifyInterpolant(PTRef A, PTRef B, PTRef itp) {
-        return VerificationUtils(config, logic).verifyInterpolantInternal(A, B, itp);
+        return VerificationUtils(logic).verifyInterpolantInternal(A, B, itp);
     }
 };
 

--- a/test/unit/test_UFInterpolation.cc
+++ b/test/unit/test_UFInterpolation.cc
@@ -7,8 +7,8 @@
 #include <MainSolver.h>
 #include "VerificationUtils.h"
 
-bool verifyInterpolant(PTRef itp, PartitionManager & pManager, ipartitions_t const & Amask, SMTConfig & config, Logic & logic) {
-    return VerificationUtils(config, logic).verifyInterpolantInternal(pManager.getPartition(Amask, PartitionManager::part::A), pManager.getPartition(Amask, PartitionManager::part::B), itp);
+bool verifyInterpolant(PTRef itp, PartitionManager & pManager, ipartitions_t const & Amask, Logic & logic) {
+    return VerificationUtils(logic).verifyInterpolantInternal(pManager.getPartition(Amask, PartitionManager::part::A), pManager.getPartition(Amask, PartitionManager::part::B), itp);
 }
 
 class UFInterpolationTest : public ::testing::Test {
@@ -43,7 +43,7 @@ protected:
     SymRef f, g, p;
 
     bool verifyInterpolant(PTRef itp, PartitionManager & pManager, ipartitions_t const & Amask) {
-        return ::verifyInterpolant(itp, pManager, Amask, config, logic);
+        return ::verifyInterpolant(itp, pManager, Amask, logic);
     }
 };
 
@@ -445,7 +445,7 @@ TEST_F(UFInterpolationTest, test_LocalColorInformationInsufficient){
     opensmt::setbit(mask, 1);
     itpCtx->getSingleInterpolant(interpolants, mask);
 //    std::cout << logic.printTerm(interpolants[0]) << std::endl;
-    EXPECT_TRUE(::verifyInterpolant(interpolants[0], solver.getPartitionManager(), mask, config, logic));
+    EXPECT_TRUE(::verifyInterpolant(interpolants[0], solver.getPartitionManager(), mask, logic));
 }
 
 TEST_F(UFInterpolationTest, test_DistinctInA){


### PR DESCRIPTION
This PR removes some of the unused fields and methods in `ProofGraph` and also removes the last usage of implication verification using external tool.
Internal verification should be sufficient in my opinion.