### PR TITLE
CI: Update MacOS image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
 
     build-macos:
         macos:
-            xcode: 12.4.0
+            xcode: 13.4.1
         steps:
             - run:
                 name: Packages


### PR DESCRIPTION
Apparently, CircleCI is deprecating the image we are currently using: https://discuss.circleci.com/t/xcode-image-deprecation/44294
