### PR TITLE
Logic: Fix unintialized sort symbol

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -82,9 +82,7 @@ Logic::Logic(opensmt::Logic_t _logicType) :
     sortToEquality.insert(sort_BOOL, sym_EQ);
     sortToDisequality.insert(sort_BOOL, sym_DISTINCT);
     sortToIte.insert(sort_BOOL, sym_ITE);
-    if (hasArrays()) {
-        sym_ArraySort = sort_store.newSortSymbol(SortSymbol("Array", 2, SortSymbol::INTERNAL));
-    }
+    sym_ArraySort = sort_store.newSortSymbol(SortSymbol("Array", 2, SortSymbol::INTERNAL));
 }
 
 Logic::~Logic() = default;


### PR DESCRIPTION
After updating OpenSMT to latest release in Golem, I got some unit tests failing at a very weird place.
I tracked down the problem to uninitialized value of sort symbol `sym_ArraySort` (when `Logic` does *not* support arrays).

The code was not consistent before because it only creates array sort if the Logic does not have arrays, but the check for array sort in `Logic::getSort` is unconditional.
Thus, it is a check against uninitialized value.

This PR fixes to problem by initializing the symbol sort to `SSymRef_Undef` if the logic does not support arrays.