### PR TITLE
CI: Upgrade pip on CentOS before using

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
                     yum -y install rh-python38
                     yum -y install python3-pip
                     yum -y install zlib-devel
+                    pip3 install --upgrade pip
                     pip3 install wheel
                     echo "pip3 install pyinstaller" |scl enable devtoolset-8 bash
                     yum -y install Cython


### PR DESCRIPTION
I got an error in my other PR in `starexec` build, because of failing to install new `CMake`.
I found that upgrading `pip` should help.