### PR TITLE
STPSolver: hack to support incrementality

### DIFF
--- a/src/tsolvers/TSolver.h
+++ b/src/tsolvers/TSolver.h
@@ -185,7 +185,7 @@ public:
     virtual void  informNewSplit(PTRef) { };
     virtual Logic& getLogic() = 0;
     virtual bool isValid(PTRef tr) = 0;
-    bool         isKnown(PTRef tr);
+    virtual bool isKnown(PTRef tr);
     void         setKnown(PTRef tr);
 
     virtual void printStatistics(std::ostream & os);

--- a/src/tsolvers/stpsolver/STPSolver.h
+++ b/src/tsolvers/stpsolver/STPSolver.h
@@ -70,6 +70,7 @@ public:
 
     bool isValid(PTRef tr) override;
 
+    bool isKnown(PTRef tr) override { return mapper.getEdgeRef(tr) != EdgeRef_Undef; }
 };
 
 #include "STPSolver_implementations.hpp"


### PR DESCRIPTION
This PR will fix an Assertion failed: (e != EdgeRef_Undef), function assertLit, file src/tsolvers/stpsolver/STPSolver_implementations.hpp in QF_RDL and QF_IDL instances.
Co-authored-by: Antti Hyvärinen <antti.hyvarinen@gmail.com>