### PR TITLE
Implement "reverse operators" for auxiliary variables

### DIFF
--- a/src/itehandler/IteHandler.cc
+++ b/src/itehandler/IteHandler.cc
@@ -15,10 +15,28 @@ PTRef IteHandler::rewrite(PTRef root) {
 
 PTRef IteHandler::getAuxVarFor(PTRef ite) {
     assert(logic.isIte(ite));
-    std::string name(".ite");
+    std::string name(itePrefix);
     name += std::to_string(ite.x);
     name += suffix;
     return logic.mkVar(logic.getSortRef(ite), name.c_str());
+}
+
+PTRef IteHandler::getIteTermFor(Logic const & logic, PTRef auxVar) {
+
+    std::string const & name = logic.getSymName(auxVar);
+    assert(name.compare(0, itePrefix.size(), itePrefix) == 0);
+    std::string numberStr;
+    for (auto it = name.begin() + itePrefix.size(); it != name.end(); ++it) {
+        if ('0' <= *it and *it <= '9') {
+            numberStr += *it;
+        } else {
+            break;
+        }
+    }
+    auto number = static_cast<uint32_t>(std::stoi(numberStr));
+    PTRef ite = { number };
+    assert(logic.isIte(ite));
+    return ite;
 }
 
 PTRef IteHandler::replaceItes(PTRef root) {

--- a/src/itehandler/IteHandler.cc
+++ b/src/itehandler/IteHandler.cc
@@ -33,7 +33,7 @@ PTRef IteHandler::getIteTermFor(Logic const & logic, PTRef auxVar) {
             break;
         }
     }
-    auto number = static_cast<uint32_t>(std::stoi(numberStr));
+    auto number = static_cast<uint32_t>(std::stoul(numberStr));
     PTRef ite = { number };
     assert(logic.isIte(ite));
     return ite;

--- a/src/itehandler/IteHandler.h
+++ b/src/itehandler/IteHandler.h
@@ -27,6 +27,10 @@ public:
     IteHandler(Logic & logic, unsigned long partitionNumber) : logic(logic), suffix('_' + std::to_string(partitionNumber)) {}
 
     PTRef rewrite(PTRef root);
+
+    static PTRef getIteTermFor(Logic const & logic, PTRef auxVar); // The inverse of getAuxVarFor
+
+    static std::string_view constexpr itePrefix = ".ite";
 };
 
 #endif //OPENSMT_ITEHANDLER_H

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -634,7 +634,6 @@ PTRef ArithLogic::mkMod(vec<PTRef> && args) {
         assert(intMod.sign() >= 0 and intMod < abs(divisorValue));
         return mkIntConst(intMod);
     }
-    divsAndModsSeen = true;
     return mkFun(sym_Int_MOD, {dividend, divisor});
 }
 
@@ -655,7 +654,6 @@ PTRef ArithLogic::mkIntDiv(vec<PTRef> && args) {
         auto intDiv = divisorValue.sign() > 0 ? realDiv.floor() : realDiv.ceil();
         return mkIntConst(intDiv);
     }
-    divsAndModsSeen = true;
     return mkFun(sym_Int_DIV, std::move(args));
 }
 
@@ -980,10 +978,9 @@ PTRef ArithLogic::removeAuxVars(PTRef tr) {
             return tr;
         }
     };
-    if (divsAndModsSeen) {
-        AuxSymbolMatcherConfig config(*this);
-        tr = Rewriter(*this, config).rewrite(tr);
-    }
+    // Note: this has negligible impact on performance, no need to check if there are divs or mods
+    AuxSymbolMatcherConfig config(*this);
+    tr = Rewriter(*this, config).rewrite(tr);
     return Logic::removeAuxVars(tr);
 }
 

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -965,11 +965,10 @@ ArithLogic::getDefaultValuePTRef(const SRef sref) const
 
 PTRef ArithLogic::removeAuxVars(PTRef tr) {
     // Note: Since ites are removed first and div/mod's then, it is important to first reintroduce div/mod's and then ites
-    class AuxSymbolMatcherConfig : DefaultRewriterConfig {
+    class AuxSymbolMatcherConfig : public DefaultRewriterConfig {
         ArithLogic & logic;
     public:
         AuxSymbolMatcherConfig(ArithLogic & logic) : logic(logic) {}
-        bool previsit(PTRef) override { return true; }
         PTRef rewrite(PTRef tr) override {
             if (not logic.isVar(tr)) return tr; // Only variables can match
             auto symName = std::string_view(logic.getSymName(tr));

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -102,10 +102,11 @@ protected:
     SymRef              sym_Int_ITE;
     SymRef              sym_Int_DISTINCT;
 
+    bool divsAndModsSeen = false;
 public:
     ArithLogic(opensmt::Logic_t type);
     ~ArithLogic() { for (auto number : numbers) { delete number; } }
-
+    bool             hasDivsAndMods() const { return divsAndModsSeen; }
     bool             isBuiltinFunction(SymRef sr) const override;
     PTRef            insertTerm       (SymRef sym, vec<PTRef> && terms) override;
     SRef             getSort_real     () const { return sort_REAL; }
@@ -369,6 +370,8 @@ public:
 
     opensmt::pair<lbool,SubstMap> retrieveSubstitutions(vec<PtAsgn> const & facts) override;
     void termSort(vec<PTRef> &v) const override;
+
+    PTRef removeAuxVars(PTRef) override;
 
     std::string printTerm_(PTRef tr, bool ext, bool s) const override;
 

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -102,11 +102,9 @@ protected:
     SymRef              sym_Int_ITE;
     SymRef              sym_Int_DISTINCT;
 
-    bool divsAndModsSeen = false;
 public:
     ArithLogic(opensmt::Logic_t type);
     ~ArithLogic() { for (auto number : numbers) { delete number; } }
-    bool             hasDivsAndMods() const { return divsAndModsSeen; }
     bool             isBuiltinFunction(SymRef sr) const override;
     PTRef            insertTerm       (SymRef sym, vec<PTRef> && terms) override;
     SRef             getSort_real     () const { return sort_REAL; }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1266,7 +1266,7 @@ PTRef Logic::learnEqTransitivity(PTRef formula)
 }
 
 PTRef Logic::removeAuxVars(PTRef tr) {
-    class AuxSymbolMatcherConfig : DefaultRewriterConfig {
+    class AuxSymbolMatcherConfig : public DefaultRewriterConfig {
         Logic const & logic;
         bool match(PTRef tr) const {
             if (not logic.isVar(tr)) return false; // Only variables can match
@@ -1275,7 +1275,6 @@ PTRef Logic::removeAuxVars(PTRef tr) {
         }
     public:
         AuxSymbolMatcherConfig(Logic const & logic) : logic(logic) {}
-        bool previsit(PTRef) override { return true; }
         PTRef rewrite(PTRef tr) override { return (match(tr)) ? IteHandler::getIteTermFor(logic, tr) : tr; }
     };
     AuxSymbolMatcherConfig config(*this);

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -383,7 +383,6 @@ public:
 
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 
-public:
     virtual PTRef removeAuxVars(PTRef tr);
 
     bool hasQuotableChars(std::string const & name) const;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -383,6 +383,8 @@ public:
 
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 
+public:
+    virtual PTRef removeAuxVars(PTRef tr);
 
     bool hasQuotableChars(std::string const & name) const;
     bool isReservedWord(std::string const & name) const;

--- a/src/rewriters/DivModRewriter.h
+++ b/src/rewriters/DivModRewriter.h
@@ -51,19 +51,13 @@ class DivModConfig : public DefaultRewriterConfig {
             } else if (not parsingDividend and '0' <= *it and *it <= '9') {
                 divisorNumberStr += *it;
             } else if (*it == '_') {
-                assert([](bool parsingDividend, std::string_view const name) {
-                    if (not parsingDividend) {
-                        throw OsmtInternalException("Parse error in auxiliary variable symbol: " + std::string(name));
-                        return false;
-                    } else {
-                        return true;
-                    }
-                }(parsingDividend, name));
+                if (not parsingDividend)
+                    throw OsmtInternalException("Parse error in auxiliary variable symbol: " + std::string(name));
                 parsingDividend = false;
             }
         }
-        return {{static_cast<uint32_t>(std::stoi(dividendNumberStr))},
-                {static_cast<uint32_t>(std::stoi(divisorNumberStr))}};
+        return {{static_cast<uint32_t>(std::stoul(dividendNumberStr))},
+                {static_cast<uint32_t>(std::stoul(divisorNumberStr))}};
     }
 
 public:


### PR DESCRIPTION
Currently when we print terms there is no support for avoiding printing internal auxiliary expansion variables (currently `.ite`, `.div`, `.mod`).  This is a problem when terms need to be communicated to other solvers, and seems to cause (soundess) problems also if the terms are communicated within different opensmt instances.

This PR introduces reverse operators that allow expressing terms using the original terms defined over the input vocabulary.  This is done by syntactically obtaining the PTRef number from the symbol name and running a rewriter-based dag-traversal.