### PR TITLE
Remove FPU control flags

### DIFF
--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -69,16 +69,7 @@ int main( int argc, char * argv[] )
 {
     signal( SIGTERM, opensmt::catcher );
     signal( SIGINT , opensmt::catcher );
-
-    //
-    // This trick (copied from Main.C of MiniSAT) is to allow
-    // the repeatability of experiments that might be compromised
-    // by the floating point unit approximations on doubles
-    //
-#if defined(__linux__)
-    fpu_control_t oldcw, newcw;
-    _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
-#endif
+    
 
 #ifdef PEDANTIC_DEBUG
     cerr << "; pedantic assertion checking enabled (very slow)" << endl;


### PR DESCRIPTION
It came to my attention that these flags are not present in all Linux environments, which could result in compilation errors.

It seems this was encountered also in MiniSAT some time ago: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=590254

I don't know what is the way to fix it, so here I am proposing to just remove this piece of code.