### PR TITLE
Style fixes pointed out by more recent compilers with `--wall -Wextra -Werror`

### DIFF
--- a/src/common/FastRational.cc
+++ b/src/common/FastRational.cc
@@ -110,7 +110,7 @@ std::string FastRational::get_str() const
 
 FastRational gcd(FastRational const & a, FastRational const & b)
 {
-    assert(a.isInteger() & b.isInteger());
+    assert(a.isInteger() and b.isInteger());
     if (a.wordPartValid() && b.wordPartValid()) {
         return FastRational(gcd(a.num, b.num));
     }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -549,26 +549,25 @@ PTRef Logic::mkImpl(vec<PTRef> && args) {
         if (!hasSortBool(args[i]))
             return PTRef_Undef;
 
-        assert(args.size() == 2);
-        PTRef tr = PTRef_Undef;
-        if (isFalse(args[0]))
-                tr = getTerm_true();
-        else if(isTrue(args[1]))
-                tr = getTerm_true();
-        else if(isTrue(args[0]) && isFalse(args[1]))
-                tr = getTerm_false();
-        else
-        {
-            args[0] = mkNot(args[0]);
-            tr = mkOr(std::move(args));
-        }
+    assert(args.size() == 2);
+    PTRef tr = PTRef_Undef;
+    if (isFalse(args[0]))
+        tr = getTerm_true();
+    else if (isTrue(args[1]))
+        tr = getTerm_true();
+    else if (isTrue(args[0]) && isFalse(args[1]))
+        tr = getTerm_false();
+    else {
+        args[0] = mkNot(args[0]);
+        tr = mkOr(std::move(args));
+    }
 
-        if (tr == PTRef_Undef) {
-                printf("Error in mkImpl");
-                assert(0);
-        }
+    if (tr == PTRef_Undef) {
+        printf("Error in mkImpl");
+        assert(0);
+    }
 
-        return tr;
+    return tr;
 }
 
 PTRef Logic::mkBinaryEq(PTRef lhs, PTRef rhs) {

--- a/src/proof/PGBuild.cc
+++ b/src/proof/PGBuild.cc
@@ -128,7 +128,6 @@ void ProofGraph::buildProofGraph(const Proof & proof) {
 
     ProofBuildingStatistics counters;
 
-    unsigned      num_clause = 0;
     unsigned      max_leaf_size = 0;
     double        avg_leaf_size = 0;
     unsigned      max_learnt_size = 0;
@@ -270,7 +269,6 @@ void ProofGraph::buildProofGraph(const Proof & proof) {
             assert(false);
         }
         visitedSet.insert(currClause);
-        num_clause++;
     } while(!q.empty());
 
     setRoot(clauseToIDMap.at(CRef_Undef));
@@ -285,11 +283,17 @@ void ProofGraph::buildProofGraph(const Proof & proof) {
 
     if (verbose() > 0) {
         unsigned num_non_null = 0;
+#ifdef PEDANTIC_DEBUG
         unsigned cl_non_null = 0;
+#endif
         for (size_t i = 0; i < getGraphSize(); i++) {
             if (getNode(i)) {
                 num_non_null++;
-                if (getNode(i)->getPClause()) { cl_non_null++; }
+#ifdef PEDANTIC_DEBUG
+                if (getNode(i)->getPClause()) {
+                    cl_non_null++;
+                }
+#endif
             }
         }
 #ifdef PEDANTIC_DEBUG
@@ -418,10 +422,8 @@ int ProofGraph::cleanProofGraph() {
     // Ideally it will be made of subgraphs not connected to the main graph
     unsigned removed = 0;
     bool done = false;
-    unsigned counter = 0;
     while (not done) {
         done = true;
-        counter++;
         for (size_t i = 0; i < getGraphSize(); i++) {
             if (getNode(i)  and getNode(i)->getNumResolvents() == 0 and getNode(i) != getRoot()) {
                 done = false;

--- a/src/smtsolvers/LookaheadSMTSolver.cc
+++ b/src/smtsolvers/LookaheadSMTSolver.cc
@@ -236,7 +236,6 @@ std::pair<LookaheadSMTSolver::laresult,Lit> LookaheadSMTSolver::lookaheadLoop() 
     int i = 0;
     int d = decisionLevel();
 
-    int count = 0;
     bool respect_logic_partitioning_hints = config.respect_logic_partitioning_hints();
     int skipped_vars_due_to_logic = 0;
 
@@ -300,7 +299,6 @@ std::pair<LookaheadSMTSolver::laresult,Lit> LookaheadSMTSolver::lookaheadLoop() 
             respect_logic_partitioning_hints = false;
             continue;
         }
-        count++;
         int p0 = 0, p1 = 0;
         for (int p : {0, 1}) { // for both polarities
             assert(decisionLevel() == d);

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -723,7 +723,7 @@ bool SimpSMTSolver::eliminate(bool turn_off_elim)
         }
 
         // printf("  ## (time = %6.2f s) ELIM: vars = %d\n", cpuTime(), elim_heap.size());
-        for (int cnt = 0; !elim_heap.empty(); cnt++)
+        while (!elim_heap.empty())
         {
             Var elim = elim_heap.removeMin();
 

--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -131,7 +131,6 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
     for (int index : sortedIndices) {
         auto & splitClause = splitClauses[index];
         unsigned satisfied = 0;
-        unsigned falsified = 0;
         unsigned unknown = 0;
         // MB: ensure the SAT solver knows about the variables and that they are active
         int impliedIndex = -1;
@@ -139,8 +138,7 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
             Lit l = splitClause[i];
             addVar_(var(l));
             if (value(l) == l_True) { ++satisfied; }
-            else if (value(l) == l_False) { ++falsified; }
-            else { ++unknown; impliedIndex = i; }
+            else if (value(l) != l_False) { ++unknown; impliedIndex = i; }
         }
         assert(satisfied != 0 or unknown != 0); // The clause cannot be falsified
         if (satisfied == 0 and unknown == 1) { // propagate
@@ -406,7 +404,6 @@ TPropRes CoreSMTSolver::checkTheory(bool complete, int& conflictC)
 void CoreSMTSolver::deduceTheory(vec<LitLev>& deductions)
 {
     Lit ded = lit_Undef;
-    int n_deductions = 0;
 
     while (true)
     {
@@ -415,8 +412,6 @@ void CoreSMTSolver::deduceTheory(vec<LitLev>& deductions)
         if (value(ded) != l_Undef) continue;
 
         // Found an unassigned deduction
-        n_deductions ++;
-
         deductions.push(LitLev(ded, decisionLevel()));
     }
 #ifdef PEDANTIC_DEBUG


### PR DESCRIPTION
It seems that some clang versions (14?) complain in our code where we are using `&` instead of `&&` (or `and`) when compiled with `--Wall -Wextra -Werror`.  I believe that the code should be using `and` in this case, so this PR suggests the fix.