### PR TITLE
Update `build-recent` to use the image `cimg/base:current`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,8 @@ jobs:
                 command: sudo apt-get install libgmp-dev libedit-dev bison flex cmake opam
             - run:
                 name: install modern model validation environment
-                no_output_timeout: 30m # Note: opam switch create might be slow on some systems
                 command: |
                   opam init -y --disable-sandboxing # Note: do not disable sandboxing if running outside docker / other safety system
-                  opam switch create -y 4.14.0
                   opam update -y
                   opam upgrade -y
                   eval $(opam env)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
                 command: sudo apt-get update
             - run:
                 name: install dependencies
-                command: sudo apt-get install libgmp-dev libedit-dev bison flex cmake libubsan0 opam
+                command: sudo apt-get install libgmp-dev libedit-dev bison flex cmake opam
             - run:
                 name: install modern model validation environment
                 no_output_timeout: 30m # Note: opam switch create might be slow on some systems

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             - run:
                 name: Install clang
                 command: |
-                    sudo apt-get install clang-15
+                    sudo apt-get install clang
                     sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
             - run:
                 name: Debug build llvm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
     formatter:
         docker:
-            - image: cimg/base:stable
+            - image: cimg/base:current
               auth:
                   username: mydockerhub-user
                   password: $DOCKERHUB_PASSWORD
@@ -21,7 +21,7 @@ jobs:
 
     build-recent:
         docker:
-          - image: cimg/base:stable
+          - image: cimg/base:current
             auth:
                 username: mydockerhub-user
                 password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             - run:
                 name: Install clang
                 command: |
-                    sudo apt-get install clang
+                    sudo apt-get install clang-15
                     sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
             - run:
                 name: Debug build llvm


### PR DESCRIPTION
The tag we used for the stable build is deprecated in circleci.  This PR suggests to switch to a tag that is updated more often and hopefully helps us to keep opensmt building in modern debians.