### PR TITLE
Build image update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,27 @@ jobs:
                 name: Release build llvm
                 command: ./ci/run_travis_commands.sh
 
-    # To set up the centos-7 environment:
-    #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel
-    #  - scl enable devtoolset-8 bash
-    build-starexec:
+    build-starexec-debug:
+        docker:
+            - image: verifyusi/verify-env:starexec
+              auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD
+              environment:
+                FLAGS: -Wall -Wextra -Werror
+                OSMT_INSTALL: ~/osmt-install
+                USE_READLINE: OFF
+                CMAKE_BUILD_TYPE: Debug
+                MODEL_VALIDATION: pySMT
+
+        steps:
+            - checkout
+            - run:
+                name: Debug build gcc under devtoolset-8
+                command: |
+                    cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash
+
+    build-starexec-release:
         docker:
             - image: verifyusi/verify-env:starexec
               auth:
@@ -107,23 +124,13 @@ jobs:
                 FLAGS: -Wall -Wextra -Werror
                 OSMT_INSTALL: ~/osmt-install
                 USE_READLINE: OFF
-
+                PARALLEL: ON
         steps:
             - checkout
-            - run:
-                name: Debug build gcc under devtoolset-8
-                command: |
-                    cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash
-                environment:
-                    CMAKE_BUILD_TYPE: Debug
-                    MODEL_VALIDATION: pySMT
             - run:
                 name: Release build gcc under devtoolset-8
                 command: |
                     cat ./ci/build_maximally_static.sh |scl enable devtoolset-8 bash
-                environment:
-                    CMAKE_BUILD_TYPE: Release
-                    PARALLEL: ON
 
     build-macos:
         macos:
@@ -153,10 +160,13 @@ workflows:
   build-test:
       jobs:
         - formatter
-        - build-starexec:
+        - build-starexec-debug:
           filters: &filters-build-test
             tags:
               only: /^v.*/
+        - build-starexec-release:
+          filters:
+            <<: *filters-build-test
         - build-recent-gcc-debug:
           filters:
             <<: *filters-build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,6 @@ jobs:
         steps:
             - checkout
             - run:
-                  name: apt-get update
-                  command: sudo apt-get update
-            - run:
-                  name: install dependencies
-                  command: sudo apt-get install clang-format
-            - run:
                   name: run clang formatter
                   command: cat .clang-files | xargs clang-format --Werror --dry-run
 
@@ -35,18 +29,8 @@ jobs:
         steps:
             - checkout
             - run:
-                name: apt-get update
-                command: sudo apt-get update
-            - run:
-                name: install dependencies
-                command: sudo apt-get install libgmp-dev libedit-dev bison flex cmake opam
-            - run:
                 name: install modern model validation environment
-                command: |
-                  opam init -y --disable-sandboxing # Note: do not disable sandboxing if running outside docker / other safety system
-                  opam update -y
-                  opam upgrade -y
-                  eval $(opam env)
+                command:
                   ./regression_models/bin/setup-env-modern.sh
             - run:
                 name: Debug build gcc
@@ -61,10 +45,8 @@ jobs:
                 environment:
                     CMAKE_BUILD_TYPE: Release
             - run:
-                name: Install clang
-                command: |
-                    sudo apt-get install clang
-                    sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
+                name: Setup clang
+                command: sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
             - run:
                 name: Debug build llvm
                 command: ./ci/run_travis_commands.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,28 @@ jobs:
                   name: run clang formatter
                   command: cat .clang-files | xargs clang-format --Werror --dry-run
 
-    build-recent:
+    build-recent-gcc-debug:
+        docker:
+          - image: verifyusi/verify-env:current
+            auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD
+            environment:
+                CMAKE_BUILD_TYPE: Debug
+                MODEL_VALIDATION: Dolmen
+                ENABLE_LINE_EDITING: ON
+                PARALLEL: ON
+                FLAGS: -Wall -Wextra -Werror
+                OSMT_INSTALL: ~/osmt-install
+        steps:
+            - checkout
+            - run:
+                name: Debug build gcc
+                command: |
+                    eval $(opam env)
+                    ./ci/run_travis_commands.sh
+
+    build-recent-gcc-release:
         docker:
           - image: verifyusi/verify-env:current
             auth:
@@ -25,40 +46,52 @@ jobs:
                 OSMT_INSTALL: ~/osmt-install
                 USE_READLINE: OFF
                 PARALLEL: OFF
-
         steps:
             - checkout
             - run:
-                name: install modern model validation environment
-                command:
-                  ./regression_models/bin/setup-env-modern.sh
-            - run:
-                name: Debug build gcc
-                command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Debug
-                    ENABLE_LINE_EDITING: ON
-                    PARALLEL: ON
-            - run:
                 name: Release build gcc
                 command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Release
+
+    build-recent-clang-debug:
+        docker:
+          - image: verifyusi/verify-env:current
+            auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD
+            environment:
+                CMAKE_BUILD_TYPE: Debug
+                MODEL_VALIDATION: Dolmen
+                ENABLE_LINE_EDITING: ON
+                PARALLEL: ON
+                FLAGS: -Wall -Wextra -Werror -fsanitize=signed-integer-overflow,address,undefined
+                OSMT_INSTALL: ~/osmt-install
+        steps:
+            - checkout
             - run:
                 name: Setup clang
                 command: sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
             - run:
                 name: Debug build llvm
-                command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Debug
-                    FLAGS: -Wall -Wextra -Werror -fsanitize=signed-integer-overflow,address,undefined
+                command: |
+                    eval $(opam env)
+                    ./ci/run_travis_commands.sh
+
+    build-recent-clang-release:
+        docker:
+          - image: verifyusi/verify-env:current
+            auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD
+            environment:
+                CMAKE_BUILD_TYPE: Release
+                PARALLEL: ON
+                FLAGS: -Wall -Wextra -Werror
+                OSMT_INSTALL: ~/osmt-install
+        steps:
+            - checkout
             - run:
                 name: Release build llvm
                 command: ./ci/run_travis_commands.sh
-                environment:
-                    CMAKE_BUILD_TYPE: Release
-                    PARALLEL: ON
 
     # To set up the centos-7 environment:
     #  - yum install centos-release-scl devtoolset-8 gmp-devel libedit-devel
@@ -122,6 +155,7 @@ jobs:
                     cat ./ci/run_travis_commands.sh |scl enable devtoolset-8 bash
                 environment:
                     CMAKE_BUILD_TYPE: Debug
+                    MODEL_VALIDATION: pySMT
             - run:
                 name: Release build gcc under devtoolset-8
                 command: |
@@ -162,7 +196,16 @@ workflows:
           filters: &filters-build-test
             tags:
               only: /^v.*/
-        - build-recent:
+        - build-recent-gcc-debug:
+          filters:
+            <<: *filters-build-test
+        - build-recent-gcc-release:
+          filters:
+            <<: *filters-build-test
+        - build-recent-clang-debug:
+          filters:
+            <<: *filters-build-test
+        - build-recent-clang-release:
           filters:
             <<: *filters-build-test
         - build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
     formatter:
         docker:
-            - image: cimg/base:current
+            - image: verifyusi/verify-env:current
               auth:
                   username: mydockerhub-user
                   password: $DOCKERHUB_PASSWORD
@@ -21,7 +21,7 @@ jobs:
 
     build-recent:
         docker:
-          - image: cimg/base:current
+          - image: verifyusi/verify-env:current
             auth:
                 username: mydockerhub-user
                 password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ jobs:
         steps:
             - checkout
             - run:
+                name: Setup clang
+                command: sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
+            - run:
                 name: Release build llvm
                 command: ./ci/run_travis_commands.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
     #  - scl enable devtoolset-8 bash
     build-starexec:
         docker:
-            - image: centos:7
+            - image: verifyusi/verify-env:starexec
               auth:
                 username: mydockerhub-user
                 password: $DOCKERHUB_PASSWORD
@@ -109,46 +109,7 @@ jobs:
                 USE_READLINE: OFF
 
         steps:
-            - run:
-                name: Install the environment
-                command: |
-                    yum -y install centos-release-scl
-                    yum -y install devtoolset-8
-                    yum -y install gmp-devel
-                    yum -y install gmp-static
-                    yum -y install libedit-devel
-                    yum -y install bison
-                    yum -y install git
-                    yum -y install wget
-                    yum -y install rh-python38
-                    yum -y install python3-pip
-                    yum -y install zlib-devel
-                    pip3 install --upgrade pip
-                    pip3 install wheel
-                    echo "pip3 install pyinstaller" |scl enable devtoolset-8 bash
-                    yum -y install Cython
-                    yum -y install patch
-                    yum -y install bzip2
-                    yum -y install glibc-static
-                    yum -y install libstdc++-static
-            - run:
-                name: Set up newer version of cmake
-                command: pip3 install cmake
-            - run:
-                name: Set up newer version of flex
-                command: |
-                    cd ~
-                    wget --no-verbose "https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz"
-                    tar -xvzf flex-2.6.4.tar.gz
-                    cd flex-2.6.4
-                    echo "./configure --prefix=/usr/local; make -j4; make install" | scl enable devtoolset-8 bash
-                    cd ..
-                    rm -rf flex-*
-                    flex --version
             - checkout
-            - run:
-                name: Set up smtcomp model validation environment
-                command: echo 'bash ./regression_models/bin/setup-env-smtcomp.sh' |scl enable devtoolset-8 bash
             - run:
                 name: Debug build gcc under devtoolset-8
                 command: |


### PR DESCRIPTION
This PR proposes the use of custom-built docker images in opensmt.  This should bring the build times down especially since the model validation environment doesn't need to be compiled every time.

In addition, the PR suggests to split the jobs into smaller jobs, one for each `(compiler, build type)` combination.