### PR TITLE
Tsolverhandler cleanup

### DIFF
--- a/src/tsolvers/ArrayTHandler.cc
+++ b/src/tsolvers/ArrayTHandler.cc
@@ -15,12 +15,6 @@ ArrayTHandler::ArrayTHandler(SMTConfig & c, Logic & l)
     egraph = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic)
                                         : new Egraph(config, logic);
 
-    SolverId my_id = egraph->getId();
-    tsolvers[my_id.id] = egraph;
-    solverSchedule.push(my_id.id);
-
     arraySolver = new ArraySolver(logic, *egraph, c);
-    my_id = arraySolver->getId();
-    tsolvers[my_id.id] = arraySolver;
-    solverSchedule.push(my_id.id);
+    setSolverSchedule({egraph, arraySolver});
 }

--- a/src/tsolvers/IDLTHandler.cc
+++ b/src/tsolvers/IDLTHandler.cc
@@ -12,9 +12,7 @@ IDLTHandler::IDLTHandler(SMTConfig& c, ArithLogic& l)
         , logic(l)
 {
     idlsolver = new IDLSolver(config, logic);
-    SolverId my_id = idlsolver->getId();
-    tsolvers[my_id.id] = idlsolver;
-    solverSchedule.push(my_id.id);
+    setSolverSchedule({idlsolver});
 }
 
 Logic &IDLTHandler::getLogic()

--- a/src/tsolvers/LATHandler.cc
+++ b/src/tsolvers/LATHandler.cc
@@ -12,9 +12,7 @@ LATHandler::LATHandler(SMTConfig & c, ArithLogic & l)
     , logic(l)
 {
     lasolver = new LASolver(config, logic);
-    SolverId my_id = lasolver->getId();
-    tsolvers[my_id.id] = lasolver;
-    solverSchedule.push(my_id.id);
+    setSolverSchedule({lasolver});
 }
 
 PTRef LATHandler::getInterpolant(ipartitions_t const & mask, std::map<PTRef, icolor_t> * labels, PartitionManager & pmanager) {

--- a/src/tsolvers/RDLTHandler.cc
+++ b/src/tsolvers/RDLTHandler.cc
@@ -7,9 +7,7 @@ RDLTHandler::RDLTHandler(SMTConfig &c, ArithLogic &l)
         , logic(l)
 {
     rdlsolver = new RDLSolver(config, logic);
-    SolverId my_id = rdlsolver->getId();
-    tsolvers[my_id.id] = rdlsolver;
-    solverSchedule.push(my_id.id);
+    setSolverSchedule({rdlsolver});
 }
 
 Logic &RDLTHandler::getLogic()

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -119,11 +119,12 @@ void THandler::getConflict (
     // where li is the literal corresponding with ei with polarity !pi
     vec<PtAsgn> explanation;
     {
-        bool found;
+        bool found = false;
         for (auto solver : getSolverHandler().solverSchedule) {
             if (solver->hasExplanation()) {
                 solver->getConflict(explanation);
                 found = true;
+                break;
             }
         }
         (void)found;

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -29,9 +29,8 @@ void THandler::backtrack(int lev)
         if (not isDeclared(var(PTRefToLit(e)))) continue;
         ++backTrackPointsCounter;
     }
-    for (auto id : getSolverHandler().solverSchedule) {
-        auto & solver = *getSolverHandler().tsolvers[id];
-        solver.popBacktrackPoints(backTrackPointsCounter);
+    for (auto solver : getSolverHandler().solverSchedule) {
+        solver->popBacktrackPoints(backTrackPointsCounter);
     }
 
     checked_trail_size = stack.size( );
@@ -121,10 +120,9 @@ void THandler::getConflict (
     vec<PtAsgn> explanation;
     {
         bool found;
-        for (auto id : getSolverHandler().solverSchedule) {
-            auto & solver = *getSolverHandler().tsolvers[id];
-            if (solver.hasExplanation()) {
-                solver.getConflict(explanation);
+        for (auto solver : getSolverHandler().solverSchedule) {
+            if (solver->hasExplanation()) {
+                solver->getConflict(explanation);
                 found = true;
             }
         }
@@ -169,9 +167,8 @@ THandler::getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *l
 Lit THandler::getDeduction() {
     PtAsgn_reason e = PtAsgn_reason_Undef;
     while (true) {
-        for (auto id : getSolverHandler().solverSchedule) {
-            auto & solver = *getSolverHandler().tsolvers[id];
-            e = solver.getDeduction();
+        for (auto solver : getSolverHandler().solverSchedule) {
+            e = solver->getDeduction();
             if (e.tr != PTRef_Undef) break;
         }
         if ( e.tr == PTRef_Undef ) {

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -48,12 +48,9 @@ protected:
     vec<int>       solverSchedule;   // Why is this here and not in THandler?
     vec<TSolver*>  tsolvers;         // List of ordinary theory solvers
 
-    TSolverHandler(SMTConfig & c)
-        : config(c)
-    {
-        for (int i = 0; i < SolverDescr::getSolverList().size(); i++) {
-            SolverDescr* sd = SolverDescr::getSolverList()[i];
-            SolverId id = (SolverId)(*sd);
+    TSolverHandler(SMTConfig & c) : config(c) {
+        for (SolverDescr * solverDescr : SolverDescr::getSolverList()) {
+            SolverId id = (SolverId)(*solverDescr);
             while (id.id >= (unsigned)tsolvers.size()) tsolvers.push(nullptr);
         }
     }

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -42,18 +42,11 @@ class ModelBuilder;
 class TSolverHandler
 {
     friend THandler;
+    vec<TSolver*>  solverSchedule;
 protected:
     SMTConfig     &config;
-protected:
-    vec<int>       solverSchedule;   // Why is this here and not in THandler?
-    vec<TSolver*>  tsolvers;         // List of ordinary theory solvers
-
-    TSolverHandler(SMTConfig & c) : config(c) {
-        for (SolverDescr * solverDescr : SolverDescr::getSolverList()) {
-            SolverId id = (SolverId)(*solverDescr);
-            while (id.id >= (unsigned)tsolvers.size()) tsolvers.push(nullptr);
-        }
-    }
+    TSolverHandler(SMTConfig & c) : config(c) { }
+    void setSolverSchedule(vec<TSolver*> && schedule) { solverSchedule = std::move(schedule); }
 public:
     virtual ~TSolverHandler();
 

--- a/src/tsolvers/UFLATHandler.cc
+++ b/src/tsolvers/UFLATHandler.cc
@@ -8,16 +8,8 @@ UFLATHandler::UFLATHandler(SMTConfig & c, ArithLogic & l)
         , logic(l)
 {
     lasolver = new LASolver(config, logic);
-    SolverId lra_id = lasolver->getId();
-    tsolvers[lra_id.id] = lasolver;
-    solverSchedule.push(lra_id.id);
-
     ufsolver = new Egraph(config, logic);
-
-    SolverId uf_id = ufsolver->getId();
-    tsolvers[uf_id.id] = ufsolver;
-    solverSchedule.push(uf_id.id);
-
+    setSolverSchedule({lasolver, ufsolver});
 }
 
 PTRef UFLATHandler::getInterpolant(const ipartitions_t&, std::map<PTRef, icolor_t> *, PartitionManager &)

--- a/src/tsolvers/UFTHandler.cc
+++ b/src/tsolvers/UFTHandler.cc
@@ -9,10 +9,7 @@ UFTHandler::UFTHandler(SMTConfig & c, Logic & l)
 {
     egraph = config.produce_inter() > 0 ? new InterpolatingEgraph(config, logic)
             : new Egraph(config, logic);
-
-    SolverId my_id = egraph->getId();
-    tsolvers[my_id.id] = egraph;
-    solverSchedule.push(my_id.id); // Only UF for the QF_UF logic
+    setSolverSchedule({egraph});
 }
 
 UFTHandler::~UFTHandler() { }


### PR DESCRIPTION
Currently the order dictated in which solvers should be accessed, e.g., when asserting literals, is defined in a vector `TSolverHandler::SolverSchedule`.  However, the code does not respect this order.  Instead the code uses an order that is non-deterministic between systems as it depends on in which order certain static data structures are initialised.

This commit fixes the code to follow strictly the order from `TSolverHandler::SolverSchedule`.  As a result of the cleanup, we get rid of an extra data structure in `TSolverHandler` that was used to store the solvers based on their IDs.

Fixes #556.