### PR TITLE
PTRef: Use intuitive implementation of comparison operators 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 2.5.0 (unreleased)
 
-
+API changes:
+ - Pterms: Change operator < on PTRefs to more intuitive implementation 
 
 ### 2.4.3 (2022-11-21)
 

--- a/src/common/FlaPartitionMap.h
+++ b/src/common/FlaPartitionMap.h
@@ -11,8 +11,8 @@
 #include <vector>
 
 class FlaPartitionMap {
-    std::map<PTRef, unsigned int> top_level_flas;
-    std::map<PTRef, unsigned int> other_flas;
+    std::map<PTRef, unsigned int, std::greater<PTRef>> top_level_flas;
+    std::map<PTRef, unsigned int, std::greater<PTRef>> other_flas;
 
 public:
     void store_top_level_fla_index(PTRef fla, unsigned int idx) { top_level_flas[fla] = idx; }

--- a/src/common/FlaPartitionMap.h
+++ b/src/common/FlaPartitionMap.h
@@ -11,8 +11,8 @@
 #include <vector>
 
 class FlaPartitionMap {
-    std::map<PTRef, unsigned int, std::greater<PTRef>> top_level_flas;
-    std::map<PTRef, unsigned int, std::greater<PTRef>> other_flas;
+    std::map<PTRef, unsigned int> top_level_flas;
+    std::map<PTRef, unsigned int> other_flas;
 
 public:
     void store_top_level_fla_index(PTRef fla, unsigned int idx) { top_level_flas[fla] = idx; }

--- a/src/interpolation/InterpolationUtils.h
+++ b/src/interpolation/InterpolationUtils.h
@@ -10,7 +10,6 @@
 #include <gmpxx.h>
 
 #include <cassert>
-#include <map>
 #include <set>
 
 namespace opensmt {

--- a/src/interpolation/InterpolationUtils.h
+++ b/src/interpolation/InterpolationUtils.h
@@ -10,6 +10,7 @@
 #include <gmpxx.h>
 
 #include <cassert>
+#include <map>
 #include <set>
 
 namespace opensmt {

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -345,10 +345,7 @@ Logic::SubstMap collectSingleEqualitySubstitutions(ArithLogic & logic, std::vect
     // MB: We enforce order to ensure that later-created terms are processed first.
     //     This ensures that from an equality "f(x) = x" we get a substitution "f(x) -> x" and not the other way
     //     around, which would cause infinite cycle in transitive closure
-    struct PTRefGreaterThan {
-        bool operator()(PTRef first, PTRef second) const { return first.x > second.x; }
-    };
-    std::map<PTRef, std::vector<std::size_t>, PTRefGreaterThan> varToPolyIndices;
+    std::map<PTRef, std::vector<std::size_t>, std::greater<PTRef>> varToPolyIndices;
 
     Logic::SubstMap substitutions;
     for (std::size_t i = 0; i < zeroPolynomials.size(); ++i) {

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1589,7 +1589,7 @@ bool        Logic::hasSortBool(SymRef sr) const { return sym_store[sr].rsort() =
 bool        Logic::isArraySelect(SymRef sr) const { return selects.has(sr); }
 bool        Logic::isArrayStore(SymRef sr) const { return stores.has(sr); }
 
-void Logic::termSort(vec<PTRef>& v) const { sort(v, LessThan_PTRef()); }
+void Logic::termSort(vec<PTRef>& v) const { sort(v, std::less<PTRef>{}); }
 
 void  Logic::purify     (PTRef r, PTRef& p, lbool& sgn) const {p = r; sgn = l_True; while (isNot(p)) { sgn = sgn^1; p = getPterm(p)[0]; }}
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -532,7 +532,7 @@ PTRef Logic::mkXor(vec<PTRef>&& args) {
     else if (args[0] == getTerm_false() || args[1] == getTerm_false())
         return (args[0] == getTerm_false() ? args[1] : args[0]);
 
-    sort(args);
+    sort(args, std::greater<PTRef>{});
     tr = mkFun(getSym_xor(), std::move(args));
 
     if(tr == PTRef_Undef) {
@@ -1304,7 +1304,7 @@ std::string Logic::dumpWithLets(PTRef formula) const {
 void Logic::dumpWithLets(std::ostream & dump_out, PTRef formula) const {
     uint32_t random_Idx = 0;
     vector<PTRef> unprocessed_enodes;
-    map<PTRef, string> enode_to_def;
+    map<PTRef, string, std::greater<PTRef>> enode_to_def;
     unsigned num_lets = 0;
 
     unprocessed_enodes.push_back(formula);
@@ -1460,7 +1460,7 @@ PTRef Logic::instantiateFunctionTemplate(TemplateFunction const & tmplt, vec<PTR
 void
 Logic::collectStats(PTRef root, int& n_of_conn, int& n_of_eq, int& n_of_uf, int& n_of_if)
 {
-    set<PTRef> seen_terms;
+    set<PTRef, std::greater<PTRef>> seen_terms;
     queue<PTRef> to_visit;
     n_of_conn = n_of_eq = n_of_uf = n_of_if = 0;
     to_visit.push(root);

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1304,7 +1304,7 @@ std::string Logic::dumpWithLets(PTRef formula) const {
 void Logic::dumpWithLets(std::ostream & dump_out, PTRef formula) const {
     uint32_t random_Idx = 0;
     vector<PTRef> unprocessed_enodes;
-    map<PTRef, string, std::greater<PTRef>> enode_to_def;
+    map<PTRef, string> enode_to_def;
     unsigned num_lets = 0;
 
     unprocessed_enodes.push_back(formula);
@@ -1460,7 +1460,7 @@ PTRef Logic::instantiateFunctionTemplate(TemplateFunction const & tmplt, vec<PTR
 void
 Logic::collectStats(PTRef root, int& n_of_conn, int& n_of_eq, int& n_of_uf, int& n_of_if)
 {
-    set<PTRef, std::greater<PTRef>> seen_terms;
+    set<PTRef> seen_terms;
     queue<PTRef> to_visit;
     n_of_conn = n_of_eq = n_of_uf = n_of_if = 0;
     to_visit.push(root);

--- a/src/logics/SubstLoopBreaker.cc
+++ b/src/logics/SubstLoopBreaker.cc
@@ -81,7 +81,7 @@ TargetVarList::TargetVarList(vec<PTRef>&& _children)
 
 TVLRef TargetVarListAllocator::alloc(vec<PTRef>&& _children)
 {
-    sort(_children);
+    sort(_children, std::greater<PTRef>{});
     uint32_t v = RegionAllocator<uint32_t>::alloc(targetVarList32Size(_children.size()));
     TVLRef sid = {v};
     auto size = (unsigned)_children.size();

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -691,7 +691,7 @@ PTRef SingleInterpolationComputationContext::computePartialInterpolantForTheoryC
         assert(false);
         throw OsmtInternalException("Asserting negation of theory clause did not result in conflict in theory solver!");
     }
-    std::map<PTRef, icolor_t, std::greater<PTRef>> ptref2label;
+    THandler::ItpColorMap ptref2label;
     for (Lit l : oldvec) {
         ptref2label.insert({varToPTRef(var(l)), getVarColor(n, var(l))});
     }

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -691,7 +691,7 @@ PTRef SingleInterpolationComputationContext::computePartialInterpolantForTheoryC
         assert(false);
         throw OsmtInternalException("Asserting negation of theory clause did not result in conflict in theory solver!");
     }
-    std::map<PTRef, icolor_t> ptref2label;
+    std::map<PTRef, icolor_t, std::greater<PTRef>> ptref2label;
     for (Lit l : oldvec) {
         ptref2label.insert({varToPTRef(var(l)), getVarColor(n, var(l))});
     }

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -16,6 +16,7 @@ struct PTRef {
     inline friend bool operator== (PTRef a1, PTRef a2) { return a1.x == a2.x; }
     inline friend bool operator!= (PTRef a1, PTRef a2) { return a1.x != a2.x; }
     inline friend bool operator> (PTRef a1, PTRef a2) { return a1.x > a2.x; }
+    inline friend bool operator< (PTRef a1, PTRef a2) { return a1.x < a2.x; }
     static const PTRef Undef;
 };
 

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -34,7 +34,7 @@ struct PTRef {
 //    void operator= (uint32_t v) { x = v; }
     inline friend bool operator== (const PTRef& a1, const PTRef& a2)   { return a1.x == a2.x; }
     inline friend bool operator!= (const PTRef& a1, const PTRef& a2)   { return a1.x != a2.x; }
-    inline friend bool operator< (const PTRef& a1, const PTRef& a2)    { return a1.x > a2.x;  }
+    inline friend bool operator> (const PTRef& a1, const PTRef& a2)    { return a1.x > a2.x;  }
     static const PTRef Undef;
 };
 

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -1,27 +1,9 @@
-/*********************************************************************
-Author: Antti Hyvarinen <antti.hyvarinen@gmail.com>
-
-OpenSMT2 -- Copyright (C) 2012 - 2014 Antti Hyvarinen
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*********************************************************************/
+/*
+ * Copyright (c) 2012-2022, Antti Hyvarinen <antti.hyvarinen@gmail.com>
+ * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef OPENSMT_PTREF_H
 #define OPENSMT_PTREF_H
@@ -31,10 +13,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct PTRef {
     uint32_t x;
-//    void operator= (uint32_t v) { x = v; }
-    inline friend bool operator== (const PTRef& a1, const PTRef& a2)   { return a1.x == a2.x; }
-    inline friend bool operator!= (const PTRef& a1, const PTRef& a2)   { return a1.x != a2.x; }
-    inline friend bool operator> (const PTRef& a1, const PTRef& a2)    { return a1.x > a2.x;  }
+    inline friend bool operator== (PTRef a1, PTRef a2) { return a1.x == a2.x; }
+    inline friend bool operator!= (PTRef a1, PTRef a2) { return a1.x != a2.x; }
+    inline friend bool operator> (PTRef a1, PTRef a2) { return a1.x > a2.x; }
     static const PTRef Undef;
 };
 
@@ -42,7 +23,7 @@ const struct PTRef PTRef_Undef = {INT32_MAX};
 inline constexpr PTRef PTRef::Undef = PTRef { INT32_MAX };
 
 struct PTRefHash {
-    uint32_t operator () (const PTRef& s) const {
+    uint32_t operator () (PTRef s) const {
         return (uint32_t)s.x; }
 };
 
@@ -56,7 +37,7 @@ struct PTRefPairHash {
 
 template <>
 struct Equal<const PTRef> {
-    bool operator() (const PTRef& s1, const PTRef& s2) const { return s1 == s2; }
+    bool operator() (PTRef s1, PTRef s2) const { return s1 == s2; }
 };
 
 #endif //OPENSMT_PTREF_H

--- a/src/pterms/PTRef.h
+++ b/src/pterms/PTRef.h
@@ -8,7 +8,7 @@
 #ifndef OPENSMT_PTREF_H
 #define OPENSMT_PTREF_H
 
-#include "Map.h"
+#include <cstdint>
 #include <functional>
 
 struct PTRef {
@@ -32,12 +32,6 @@ struct PTRefPairHash {
         std::hash<uint32_t> hasher;
         return (hasher(p.first.x) ^ hasher(p.second.x));
     }
-};
-
-
-template <>
-struct Equal<const PTRef> {
-    bool operator() (PTRef s1, PTRef s2) const { return s1 == s2; }
 };
 
 #endif //OPENSMT_PTREF_H

--- a/src/pterms/PtStructs.cc
+++ b/src/pterms/PtStructs.cc
@@ -1,11 +1,5 @@
 #include <PtStructs.h>
 
-
-bool PtAsgn::operator== (const PtAsgn& other) const { return tr == other.tr && sgn == other.sgn; }
-bool PtAsgn::operator!= (const PtAsgn& other) const { return !(*this == other); }
-bool PtAsgn::operator> (const PtAsgn& other) const { return tr > other.tr || (tr == other.tr && toInt(sgn) > toInt(other.sgn)); }
-
-
 uint32_t PtAsgnHash::operator () (const PtAsgn& s) const {
     return ((uint32_t)s.tr.x << 2) + toInt(s.sgn);
 }

--- a/src/pterms/PtStructs.cc
+++ b/src/pterms/PtStructs.cc
@@ -12,9 +12,6 @@ uint32_t PtAsgnHash::operator () (const PtAsgn& s) const {
 
 
 
-bool LessThan_PTRef::operator () (PTRef& x, PTRef& y) { return x.x < y.x; }
-
-
 ValPair::~ValPair() {
     if (val != NULL)
         free(val);

--- a/src/pterms/PtStructs.cc
+++ b/src/pterms/PtStructs.cc
@@ -3,7 +3,7 @@
 
 bool PtAsgn::operator== (const PtAsgn& other) const { return tr == other.tr && sgn == other.sgn; }
 bool PtAsgn::operator!= (const PtAsgn& other) const { return !(*this == other); }
-bool PtAsgn::operator< (const PtAsgn& other) const { return tr < other.tr || (tr == other.tr && toInt(sgn) < toInt(other.sgn)); }
+bool PtAsgn::operator> (const PtAsgn& other) const { return tr > other.tr || (tr == other.tr && toInt(sgn) > toInt(other.sgn)); }
 
 
 uint32_t PtAsgnHash::operator () (const PtAsgn& s) const {

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -65,10 +65,6 @@ public:
 
 static class PtAsgn_reason PtAsgn_reason_Undef(PTRef_Undef, l_Undef, PTRef_Undef);
 
-struct LessThan_PTRef {
-    bool operator () (PTRef& x, PTRef& y);// { return x.x < y.x; }
-};
-
 struct LessThan_PtAsgn {
     bool operator () (PtAsgn x, PtAsgn y) {
         return x.tr.x < y.tr.x;

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -36,9 +36,10 @@ public:
     lbool sgn;
     PtAsgn(PTRef tr_, lbool sgn_) : tr(tr_), sgn(sgn_) {}
     PtAsgn() : tr(PTRef_Undef), sgn(l_Undef) {}
-    bool operator== (const PtAsgn& other) const;// { return tr == other.tr && sgn == other.sgn; }
-    bool operator!= (const PtAsgn& other) const ;//{ return !(*this == other); }
-    bool operator> (const PtAsgn& other) const;// { return tr < other.tr || (tr == other.tr && toInt(sgn) < toInt(other.sgn)); }
+    bool operator== (PtAsgn const & other) const { return tr == other.tr and sgn == other.sgn; }
+    bool operator!= (PtAsgn const & other) const { return not (*this == other); }
+    bool operator> (PtAsgn const & other) const { return tr > other.tr or (tr == other.tr and toInt(sgn) > toInt(other.sgn)); }
+    bool operator< (PtAsgn const & other) const { return tr < other.tr or (tr == other.tr and toInt(sgn) < toInt(other.sgn)); }
 };
 
 

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -38,7 +38,7 @@ public:
     PtAsgn() : tr(PTRef_Undef), sgn(l_Undef) {}
     bool operator== (const PtAsgn& other) const;// { return tr == other.tr && sgn == other.sgn; }
     bool operator!= (const PtAsgn& other) const ;//{ return !(*this == other); }
-    bool operator< (const PtAsgn& other) const;// { return tr < other.tr || (tr == other.tr && toInt(sgn) < toInt(other.sgn)); }
+    bool operator> (const PtAsgn& other) const;// { return tr < other.tr || (tr == other.tr && toInt(sgn) < toInt(other.sgn)); }
 };
 
 

--- a/src/pterms/PtStructs.h
+++ b/src/pterms/PtStructs.h
@@ -42,6 +42,13 @@ public:
     bool operator< (PtAsgn const & other) const { return tr < other.tr or (tr == other.tr and toInt(sgn) < toInt(other.sgn)); }
 };
 
+// Strict weak ordering of PtAsgn: Instances with same tr, but different sgn are treated as equivalent.
+// OK to be used in sorting, see https://en.cppreference.com/w/cpp/named_req/Compare
+struct LessThan_PtAsgn {
+    bool operator() (PtAsgn x, PtAsgn y) {
+        return x.tr.x < y.tr.x;
+    }
+};
 
 static class PtAsgn PtAsgn_Undef(PTRef_Undef, l_Undef);
 
@@ -65,12 +72,6 @@ public:
 };
 
 static class PtAsgn_reason PtAsgn_reason_Undef(PTRef_Undef, l_Undef, PTRef_Undef);
-
-struct LessThan_PtAsgn {
-    bool operator () (PtAsgn x, PtAsgn y) {
-        return x.tr.x < y.tr.x;
-    }
-};
 
 // DEPRECATED in favour of new Model structure, should not be used anymore!
 class ValPair

--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -244,16 +244,4 @@ class PtermAllocator : public RegionAllocator<uint32_t>
     friend class PtStore;
 };
 
-inline void ptermSort(Pterm& t) { sort(t.args, t.size(), LessThan_PTRef()); }
-
-inline bool isSorted(vec<PTRef>& args) {
-    LessThan_PTRef lt;
-    if (args.size() == 0) return true;
-    PTRef c = args[0];
-    for (int i = 1; i < args.size(); i++) {
-        if (!lt.operator()(c, args[i])) return false;
-        c = args[i];
-    }
-    return true;
-}
 #endif

--- a/src/simplifiers/LA.h
+++ b/src/simplifiers/LA.h
@@ -57,7 +57,7 @@ public:
         return polynome.size() == 1 && (r == OP::EQ ? polynome[PTRef_Undef] != 0 : polynome[PTRef_Undef] < 0);
     }
 
-    using polynome_t = std::map<PTRef, opensmt::Real>;
+    using polynome_t = std::map<PTRef, opensmt::Real, std::greater<PTRef>>;
 
     void initialize(PTRef, bool canonize = true);      // Initialize
     PTRef solve();           // Solve w.r.t. some variable

--- a/src/smtsolvers/TheoryInterpolator.h
+++ b/src/smtsolvers/TheoryInterpolator.h
@@ -139,7 +139,7 @@ private:
 class TheoryInterpolator
 {
 public:
-    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
+    using ItpColorMap = std::map<PTRef, icolor_t>;
     virtual PTRef getInterpolant(const ipartitions_t&, ItpColorMap *, PartitionManager &pmanager) = 0;
 };
 

--- a/src/smtsolvers/TheoryInterpolator.h
+++ b/src/smtsolvers/TheoryInterpolator.h
@@ -139,7 +139,8 @@ private:
 class TheoryInterpolator
 {
 public:
-    virtual PTRef getInterpolant(const ipartitions_t&, std::map<PTRef, icolor_t>*, PartitionManager &pmanager) = 0;
+    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
+    virtual PTRef getInterpolant(const ipartitions_t&, ItpColorMap *, PartitionManager &pmanager) = 0;
 };
 
 #endif //THEORY_INTERPOLATOR_H

--- a/src/tsolvers/ArrayTHandler.h
+++ b/src/tsolvers/ArrayTHandler.h
@@ -23,7 +23,7 @@ public:
 
     Logic const & getLogic() const override { return logic; }
 
-    PTRef getInterpolant(const ipartitions_t & , std::map<PTRef, icolor_t> *, PartitionManager &) override { throw OsmtInternalException("Interpolation not supported yet"); };
+    PTRef getInterpolant(const ipartitions_t & , ItpColorMap *, PartitionManager &) override { throw OsmtInternalException("Interpolation not supported yet"); };
 
 };
 

--- a/src/tsolvers/IDLTHandler.h
+++ b/src/tsolvers/IDLTHandler.h
@@ -21,7 +21,7 @@ public:
     virtual Logic& getLogic() override;
     virtual const Logic& getLogic() const override;
 //    virtual lbool getPolaritySuggestion(PTRef) const override;
-    virtual PTRef getInterpolant(const ipartitions_t&, std::map<PTRef, icolor_t>*, PartitionManager&) override {
+    virtual PTRef getInterpolant(const ipartitions_t&, ItpColorMap *, PartitionManager&) override {
         throw std::logic_error("Not implemented yet");
     }
 

--- a/src/tsolvers/LATHandler.cc
+++ b/src/tsolvers/LATHandler.cc
@@ -15,7 +15,7 @@ LATHandler::LATHandler(SMTConfig & c, ArithLogic & l)
     setSolverSchedule({lasolver});
 }
 
-PTRef LATHandler::getInterpolant(ipartitions_t const & mask, std::map<PTRef, icolor_t> * labels, PartitionManager & pmanager) {
+PTRef LATHandler::getInterpolant(ipartitions_t const & mask, ItpColorMap * labels, PartitionManager & pmanager) {
     if (logic.hasReals() and not logic.hasIntegers()) {
         return lasolver->getRealInterpolant(mask, labels, pmanager);
     } else if (logic.hasIntegers() and not logic.hasReals()) {

--- a/src/tsolvers/LATHandler.h
+++ b/src/tsolvers/LATHandler.h
@@ -24,7 +24,7 @@ public:
     virtual Logic const & getLogic() const override { return logic; }
     virtual lbool getPolaritySuggestion(PTRef p) const override { return lasolver->getPolaritySuggestion(p); }
 
-    virtual PTRef getInterpolant(ipartitions_t const & mask, std::map<PTRef, icolor_t> * labels, PartitionManager & pmanager) override;
+    virtual PTRef getInterpolant(ipartitions_t const & mask, ItpColorMap * labels, PartitionManager & pmanager) override;
 };
 
 #endif //OPENSMT_LATHANDLER_H

--- a/src/tsolvers/RDLTHandler.h
+++ b/src/tsolvers/RDLTHandler.h
@@ -16,7 +16,7 @@ public:
     virtual ~RDLTHandler() = default;
     Logic &getLogic() override;
     const Logic &getLogic() const override;
-    PTRef getInterpolant(const ipartitions_t &, std::map<PTRef, icolor_t>*, PartitionManager&) override {
+    PTRef getInterpolant(const ipartitions_t &, ItpColorMap *, PartitionManager&) override {
         throw std::logic_error("Not implemented yet");
     }
 

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -255,7 +255,7 @@ void
 THandler::dumpFormulaToFile( std::ostream & dump_out, PTRef formula, bool negate )
 {
 	std::vector< PTRef > unprocessed_enodes;
-	std::map< PTRef, std::string, std::greater<PTRef> > enode_to_def;
+	std::map<PTRef, std::string> enode_to_def;
 	unsigned num_lets = 0;
     Logic& logic = getLogic();
 

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -11,8 +11,9 @@
 #include "ModelBuilder.h"
 
 #include <sys/wait.h>
-#include <assert.h>
+#include <cassert>
 #include <sstream>
+#include <unordered_set>
 
 void THandler::backtrack(int lev)
 {
@@ -85,7 +86,7 @@ std::vector<vec<Lit>> THandler::getNewSplits() {
     if (newSplits.size() == 0) {
         return splitClauses;
     }
-    assert(std::set<PTRef>(newSplits.begin(), newSplits.end()).size() == newSplits.size_()); // No duplicates in splits
+    assert((std::unordered_set<PTRef, PTRefHash>{newSplits.begin(), newSplits.end()}.size() == newSplits.size_())); // No duplicates in splits
     for (PTRef clause : newSplits) {
         splitClauses.emplace_back();
         Logic const & logic = getLogic();
@@ -154,7 +155,7 @@ void THandler::getConflict (
 
 
 PTRef
-THandler::getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager)
+THandler::getInterpolant(const ipartitions_t& mask, ItpColorMap * labels, PartitionManager &pmanager)
 {
     return getSolverHandler().getInterpolant(mask, labels, pmanager);
 }
@@ -254,7 +255,7 @@ void
 THandler::dumpFormulaToFile( std::ostream & dump_out, PTRef formula, bool negate )
 {
 	std::vector< PTRef > unprocessed_enodes;
-	std::map< PTRef, std::string > enode_to_def;
+	std::map< PTRef, std::string, std::greater<PTRef> > enode_to_def;
 	unsigned num_lets = 0;
     Logic& logic = getLogic();
 

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -41,6 +41,7 @@ private:
     vec<bool>         declared;                 // Cache for quick check if given SAT variable has been declared to theory solvers
 
 public:
+    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
 
     THandler(Theory & tsh, TermMapper & termMapper)
     : theory             (tsh)
@@ -65,7 +66,7 @@ public:
     void    getConflict          ( vec<Lit>&, vec<VarData>&, int & ); // Returns theory conflict in terms of literals
     std::vector<vec<Lit>> getNewSplits(); // Return the new splits as a vector of literals that needs to be interpreted as a clause.
 
-    PTRef   getInterpolant       (const ipartitions_t&, std::map<PTRef, icolor_t>*, PartitionManager &pmanager);
+    PTRef   getInterpolant       (const ipartitions_t&, ItpColorMap *, PartitionManager &pmanager);
     Lit     getDeduction         ();                      // Returns a literal that is implied by the current state and the reason literal
     Lit     getSuggestion        ( );                     // Returns a literal that is suggested by the current state
     void    getReason            ( Lit, vec< Lit > &);    // Returns the explanation for a deduced literal

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -41,7 +41,7 @@ private:
     vec<bool>         declared;                 // Cache for quick check if given SAT variable has been declared to theory solvers
 
 public:
-    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
+    using ItpColorMap = std::map<PTRef, icolor_t>;
 
     THandler(Theory & tsh, TermMapper & termMapper)
     : theory             (tsh)

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -48,7 +48,7 @@ protected:
     TSolverHandler(SMTConfig & c) : config(c) { }
     void setSolverSchedule(vec<TSolver*> && schedule) { solverSchedule = std::move(schedule); }
 public:
-    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
+    using ItpColorMap = std::map<PTRef, icolor_t>;
 
     virtual ~TSolverHandler();
 

--- a/src/tsolvers/TSolverHandler.h
+++ b/src/tsolvers/TSolverHandler.h
@@ -48,13 +48,15 @@ protected:
     TSolverHandler(SMTConfig & c) : config(c) { }
     void setSolverSchedule(vec<TSolver*> && schedule) { solverSchedule = std::move(schedule); }
 public:
+    using ItpColorMap = std::map<PTRef, icolor_t, std::greater<PTRef>>;
+
     virtual ~TSolverHandler();
 
     virtual void clearSolver(); // Clear the solver state
 
     virtual       Logic& getLogic() = 0;
     virtual const Logic& getLogic() const = 0;
-    virtual PTRef getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t>*, PartitionManager& pmanager) = 0;
+    virtual PTRef getInterpolant(const ipartitions_t& mask, ItpColorMap *, PartitionManager& pmanager) = 0;
 
     void    computeModel      ();                      // Computes a model in the solver if necessary
     bool    assertLit         (PtAsgn);                // Push the assignment to all theory solvers

--- a/src/tsolvers/UFLATHandler.cc
+++ b/src/tsolvers/UFLATHandler.cc
@@ -12,7 +12,7 @@ UFLATHandler::UFLATHandler(SMTConfig & c, ArithLogic & l)
     setSolverSchedule({ufsolver,lasolver});
 }
 
-PTRef UFLATHandler::getInterpolant(const ipartitions_t&, std::map<PTRef, icolor_t> *, PartitionManager &)
+PTRef UFLATHandler::getInterpolant(const ipartitions_t&, ItpColorMap *, PartitionManager &)
 {
     throw std::logic_error("Not implemented");
 }

--- a/src/tsolvers/UFLATHandler.h
+++ b/src/tsolvers/UFLATHandler.h
@@ -49,7 +49,7 @@ class UFLATHandler : public TSolverHandler
     Logic & getLogic() override { return logic; }
     Logic const & getLogic() const override { return logic; }
 
-    PTRef getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager) override;
+    PTRef getInterpolant(const ipartitions_t& mask, ItpColorMap * labels, PartitionManager &pmanager) override;
 
     lbool getPolaritySuggestion(PTRef pt) const override;
 

--- a/src/tsolvers/UFTHandler.cc
+++ b/src/tsolvers/UFTHandler.cc
@@ -29,7 +29,7 @@ lbool UFTHandler::getPolaritySuggestion(PTRef p) const {
     return l_Undef;
 }
 
-PTRef UFTHandler::getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager)
+PTRef UFTHandler::getInterpolant(const ipartitions_t& mask, ItpColorMap * labels, PartitionManager &pmanager)
 {
     InterpolatingEgraph* iegraph = dynamic_cast<InterpolatingEgraph*>(egraph);
     assert(iegraph);

--- a/src/tsolvers/UFTHandler.h
+++ b/src/tsolvers/UFTHandler.h
@@ -49,7 +49,7 @@ class UFTHandler : public TSolverHandler
     virtual const Logic& getLogic() const override;
     virtual lbool getPolaritySuggestion(PTRef) const override;
 
-    virtual PTRef getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager) override;
+    virtual PTRef getInterpolant(const ipartitions_t& mask, ItpColorMap * labels, PartitionManager &pmanager) override;
 };
 
 #endif

--- a/src/tsolvers/bvsolver/Bvector.h
+++ b/src/tsolvers/bvsolver/Bvector.h
@@ -29,6 +29,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Alloc.h"
 #include "PTRef.h"
 
+#include "Map.h"
+
 struct BVRef {
     uint32_t x;
     void operator= (uint32_t v) { x = v; }

--- a/src/tsolvers/egraph/InterpolatingEgraph.h
+++ b/src/tsolvers/egraph/InterpolatingEgraph.h
@@ -15,7 +15,7 @@ public:
     {}
 
 
-    PTRef getInterpolant(const ipartitions_t& mask, std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager)
+    PTRef getInterpolant(const ipartitions_t& mask, UFInterpolator::ItpColorMap * labels, PartitionManager &pmanager)
     {
         InterpolatingExplainer * itp_explainer = static_cast<InterpolatingExplainer*>(explainer.get());
         auto cgraph = itp_explainer->getCGraph();

--- a/src/tsolvers/egraph/UFInterpolator.cc
+++ b/src/tsolvers/egraph/UFInterpolator.cc
@@ -296,7 +296,7 @@ void UFInterpolator::colorCongruenceEdge(CEdge * edge) {
     }
 }
 
-icolor_t UFInterpolator::determineDisequalityColor(PTRef t1, PTRef t2, std::map<PTRef, icolor_t> const & conflictColors) const {
+icolor_t UFInterpolator::determineDisequalityColor(PTRef t1, PTRef t2, ItpColorMap const & conflictColors) const {
     icolor_t conf_color = icolor_t::I_UNDEF;
     PTRef eq = logic.mkEq(t1, t2);
     if (conflictColors.find(eq) != conflictColors.end()) {
@@ -338,7 +338,7 @@ icolor_t UFInterpolator::determineDisequalityColor(PTRef t1, PTRef t2, std::map<
 // formula into A and B.
 //
 PTRef
-UFInterpolator::getInterpolant(const ipartitions_t & mask, std::map<PTRef, icolor_t> * labels, PartitionManager & pmanager) {
+UFInterpolator::getInterpolant(const ipartitions_t & mask, ItpColorMap * labels, PartitionManager & pmanager) {
     assert(labels);
     if (labels) {
         colorInfo = std::make_unique<GlobalTermColorInfo>(pmanager, mask);

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -78,7 +78,7 @@ struct CEdge {
 class CGraph {
     std::vector<CNode *>          cnodes;
     std::vector<CEdge *>          cedges;
-    std::map<PTRef, CNode *, std::greater<PTRef>> cnodes_store;
+    std::map<PTRef, CNode *> cnodes_store;
 
     PTRef conf1 = PTRef_Undef;
     PTRef conf2 = PTRef_Undef;

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -78,7 +78,7 @@ struct CEdge {
 class CGraph {
     std::vector<CNode *>          cnodes;
     std::vector<CEdge *>          cedges;
-    std::map<PTRef, CNode *>      cnodes_store;
+    std::map<PTRef, CNode *, std::greater<PTRef>> cnodes_store;
 
     PTRef conf1 = PTRef_Undef;
     PTRef conf2 = PTRef_Undef;
@@ -121,7 +121,7 @@ public:
 
     inline int verbose() const { return config.verbosity(); }
 
-    PTRef getInterpolant(const ipartitions_t &, std::map<PTRef, icolor_t> *, PartitionManager &) override;
+    PTRef getInterpolant(const ipartitions_t &, ItpColorMap *, PartitionManager &) override;
 
     void printAsDotty(std::ostream &);
 
@@ -136,7 +136,7 @@ private:
         return colorInfo->getColorFor(term);
     }
 
-    icolor_t determineDisequalityColor(PTRef t1, PTRef t2, std::map<PTRef, icolor_t> const & conflictColors) const;
+    icolor_t determineDisequalityColor(PTRef t1, PTRef t2, ItpColorMap const & conflictColors) const;
 
     void colorCGraph();
     void colorNodes();
@@ -184,7 +184,7 @@ private:
     SMTConfig & config;
     Logic & logic;
     CGraph & cgraph;
-    std::map<PTRef, icolor_t> litColors; // MB: this is needed because edges need to be colored exactly as the literals in the conflict
+    ItpColorMap litColors; // MB: this is needed because edges need to be colored exactly as the literals in the conflict
     std::set<CNode *> colored_nodes;
     std::set<CEdge *> colored_edges;
     std::unique_ptr<TermColorInfo> colorInfo;

--- a/src/tsolvers/lasolver/FarkasInterpolator.h
+++ b/src/tsolvers/lasolver/FarkasInterpolator.h
@@ -42,8 +42,9 @@ struct DecomposedStatistics {
 
 class FarkasInterpolator {
 public:
+    using ItpColorMap = TheoryInterpolator::ItpColorMap;
     FarkasInterpolator(ArithLogic & logic, vec<PtAsgn> explanations, std::vector<opensmt::Real> coeffs,
-                       std::map<PTRef, icolor_t> labels)
+                       ItpColorMap labels)
         : logic(logic),
           explanations(std::move(explanations)),
           explanation_coeffs(std::move(coeffs)),
@@ -51,7 +52,7 @@ public:
     {}
 
     FarkasInterpolator(ArithLogic & logic, vec<PtAsgn> explanations, std::vector<opensmt::Real> coeffs,
-                       std::map<PTRef, icolor_t> labels, std::unique_ptr<TermColorInfo> colorInfo)
+                       ItpColorMap labels, std::unique_ptr<TermColorInfo> colorInfo)
         : logic(logic),
           explanations(std::move(explanations)),
           explanation_coeffs(std::move(coeffs)),
@@ -108,7 +109,7 @@ private:
     ArithLogic & logic;
     const vec<PtAsgn> explanations;
     const std::vector<opensmt::Real> explanation_coeffs;
-    const std::map<PTRef, icolor_t> labels;
+    const ItpColorMap labels;
     std::unique_ptr<TermColorInfo> termColorInfo;
 };
 

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -820,16 +820,16 @@ PTRef LASolver::interpolateUsingEngine(FarkasInterpolator & interpolator) const 
 // Compute interpolants for the conflict
 //
 PTRef
-LASolver::getRealInterpolant( const ipartitions_t & mask , std::map<PTRef, icolor_t> *labels, PartitionManager &pmanager) {
+LASolver::getRealInterpolant( const ipartitions_t & mask , ItpColorMap * labels, PartitionManager &pmanager) {
     assert(status == UNSAT);
     vec<PtAsgn> explCopy;
     explanation.copyTo(explCopy);
-    FarkasInterpolator interpolator(logic, std::move(explCopy), explanationCoefficients, labels ? *labels : std::map<PTRef, icolor_t>{},
+    FarkasInterpolator interpolator(logic, std::move(explCopy), explanationCoefficients, labels ? *labels : ItpColorMap{},
         std::make_unique<GlobalTermColorInfo>(pmanager, mask));
     return interpolateUsingEngine(interpolator);
 }
 
-PTRef LASolver::getIntegerInterpolant(std::map<PTRef, icolor_t> const& labels) {
+PTRef LASolver::getIntegerInterpolant(ItpColorMap const& labels) {
     assert(status == UNSAT);
     LIAInterpolator interpolator(logic, LAExplanations::getLIAExplanation(logic, explanation, explanationCoefficients, labels));
     return interpolateUsingEngine(interpolator);

--- a/src/tsolvers/lasolver/LASolver.h
+++ b/src/tsolvers/lasolver/LASolver.h
@@ -92,6 +92,7 @@ private:
     }
 
 public:
+    using ItpColorMap = TheoryInterpolator::ItpColorMap;
 
     LASolver(SMTConfig & c, ArithLogic & l);
     LASolver(SolverDescr dls, SMTConfig & c, ArithLogic & l);
@@ -114,8 +115,8 @@ public:
     void fillTheoryFunctions(ModelBuilder & modelBuilder) const override;
     vec<PTRef> collectEqualitiesFor(vec<PTRef> const & vars, std::unordered_set<PTRef, PTRefHash> const & knownEqualities) override;
 
-    PTRef getRealInterpolant(const ipartitions_t &, std::map<PTRef, icolor_t>*, PartitionManager & pmanager);
-    PTRef getIntegerInterpolant(std::map<PTRef, icolor_t> const &);
+    PTRef getRealInterpolant(const ipartitions_t &, ItpColorMap *, PartitionManager & pmanager);
+    PTRef getIntegerInterpolant(ItpColorMap const &);
 
     // Return the conflicting bounds
     void getConflict(vec<PtAsgn> &) override;

--- a/src/tsolvers/lasolver/LIAInterpolator.cc
+++ b/src/tsolvers/lasolver/LIAInterpolator.cc
@@ -9,7 +9,7 @@
 
 LAExplanations LAExplanations::getLIAExplanation(ArithLogic & logic, vec<PtAsgn> const & explanations,
                                                   std::vector<opensmt::Real> const & coeffs,
-                                                  std::map<PTRef, icolor_t> const & labels) {
+                                                  ItpColorMap const & labels) {
     LAExplanations liaExplanations;
     // We need to recompute the labels for the Farkas interpolator!
     // Consider this example: not (0 <= x - y) with label A; not (1 <= y - x) with label B

--- a/src/tsolvers/lasolver/LIAInterpolator.h
+++ b/src/tsolvers/lasolver/LIAInterpolator.h
@@ -7,14 +7,16 @@
 
 #include "FarkasInterpolator.h"
 
+using ItpColorMap = TheoryInterpolator::ItpColorMap;
+
 struct LAExplanations {
     vec<PtAsgn> explanations;
     std::vector<opensmt::Real> coeffs;
-    std::map<PTRef, icolor_t> labels;
+    ItpColorMap labels;
 
     static LAExplanations getLIAExplanation(ArithLogic & logic, vec<PtAsgn> const & explanations,
                                              std::vector<opensmt::Real> const & coeffs,
-                                             std::map<PTRef, icolor_t> const & labels);
+                                             ItpColorMap const & labels);
 };
 
 class LIAInterpolator : public FarkasInterpolator {

--- a/test/unit/test_LIAInterpolation.cc
+++ b/test/unit/test_LIAInterpolation.cc
@@ -8,6 +8,8 @@
 #include <LIAInterpolator.h>
 #include <MainSolver.h>
 
+using ItpColorMap = LIAInterpolator::ItpColorMap;
+
 class LIAInterpolationTest : public ::testing::Test {
 protected:
     LIAInterpolationTest(): logic{opensmt::Logic_t::QF_LIA} {}
@@ -40,7 +42,7 @@ TEST_F(LIAInterpolationTest, test_InterpolationLRASat){
     PTRef leq2 = logic.mkLt(x, one);
     vec<PtAsgn> conflict {PtAsgn(logic.mkNot(leq1), l_False), PtAsgn(logic.mkNot(leq2), l_False)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_B}};
     LIAInterpolator interpolator(logic, LAExplanations::getLIAExplanation(logic, conflict, {1,1}, labels));
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     std::cout << logic.pp(farkasItp) << std::endl;
@@ -76,7 +78,7 @@ TEST_F(LIAInterpolationTest, test_DecompositionInLIA){
                           PtAsgn(logic.mkNot(leq3), l_False),
                           PtAsgn(logic.mkNot(leq4), l_False), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
                                       {conflict[3].tr, icolor_t::I_B}, {conflict[4].tr, icolor_t::I_B}, {conflict[5].tr, icolor_t::I_B}};
     LIAInterpolator interpolator(logic, LAExplanations::getLIAExplanation(logic, std::move(conflict), {2,1,1,1,1,2}, labels));
     PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();

--- a/test/unit/test_LRAInterpolation.cc
+++ b/test/unit/test_LRAInterpolation.cc
@@ -7,6 +7,8 @@
 #include <FarkasInterpolator.h>
 #include <VerificationUtils.h>
 
+using ItpColorMap = FarkasInterpolator::ItpColorMap;
+
 class LRAInterpolationTest : public ::testing::Test {
 protected:
     LRAInterpolationTest(): logic{opensmt::Logic_t::QF_LRA} {}
@@ -41,7 +43,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothNonstrict){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.pp(farkasItp) << std::endl;
@@ -69,7 +71,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Astrict){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(logic.mkNot(leq1), l_False), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.pp(farkasItp) << std::endl;
@@ -97,7 +99,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_Bstrict){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(logic.mkNot(leq3), l_False), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
 //    std::cout << logic.pp(farkasItp) << std::endl;
@@ -125,7 +127,7 @@ TEST_F(LRAInterpolationTest, test_FarkasInterpolation_BothStrict){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(logic.mkNot(leq1), l_False), PtAsgn(leq2, l_True), PtAsgn(logic.mkNot(leq3), l_False), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     std::cout << logic.pp(farkasItp) << std::endl;
@@ -152,7 +154,7 @@ TEST_F(LRAInterpolationTest, test_AllInA){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A}, {conflict[3].tr, icolor_t::I_A}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A}, {conflict[3].tr, icolor_t::I_A}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.mkAnd({leq1, leq2, leq3, leq4}), logic.getTerm_true(), farkasItp));
@@ -185,7 +187,7 @@ TEST_F(LRAInterpolationTest, test_AllInB){
     PTRef leq4 = logic.mkGeq(logic.mkMinus(x4,x3), zero);
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True), PtAsgn(leq4, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_B}, {conflict[1].tr, icolor_t::I_B}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_B}, {conflict[1].tr, icolor_t::I_B}, {conflict[2].tr, icolor_t::I_B}, {conflict[3].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {1,1,1,1}, labels);
     PTRef farkasItp = interpolator.getFarkasInterpolant();
     EXPECT_TRUE(verifyInterpolant(logic.getTerm_true(), logic.mkAnd({leq1, leq2, leq3, leq4}), farkasItp));
@@ -225,7 +227,7 @@ TEST_F(LRAInterpolationTest, test_Decomposition_NonStrict){
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(leq2, l_True), PtAsgn(leq3, l_True),
                           PtAsgn(leq4, l_True), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
                                       {conflict[3].tr, icolor_t::I_B}, {conflict[4].tr, icolor_t::I_B}, {conflict[5].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {2,1,1,1,1,2}, labels);
     PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();
@@ -257,7 +259,7 @@ TEST_F(LRAInterpolationTest, test_Decomposition_Strict){
     vec<PtAsgn> conflict {PtAsgn(leq1, l_True), PtAsgn(logic.mkNot(leq2), l_False), PtAsgn(leq3, l_True),
                           PtAsgn(logic.mkNot(leq4), l_False), PtAsgn(leq5, l_True), PtAsgn(leq6, l_True)};
     ASSERT_TRUE(std::all_of(conflict.begin(), conflict.end(), [this](PtAsgn p) { return not logic.isNot(p.tr); }));
-    std::map<PTRef, icolor_t> labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
+    ItpColorMap labels {{conflict[0].tr, icolor_t::I_A}, {conflict[1].tr, icolor_t::I_A}, {conflict[2].tr, icolor_t::I_A},
                                       {conflict[3].tr, icolor_t::I_B}, {conflict[4].tr, icolor_t::I_B}, {conflict[5].tr, icolor_t::I_B}};
     FarkasInterpolator interpolator(logic, std::move(conflict), {2,1,1,1,1,2}, labels);
     PTRef decomposedFarkasItp = interpolator.getDecomposedInterpolant();


### PR DESCRIPTION
Previously, PTRef was exposing `operator<` which was, however, using
`operator>` on the underlying `uint32_t` member. 
This is extremely counterintuitive.

This PR normalizes comparison of PTRefs.
To preserve the existing behaviour, all code that previously relied on 
`operator<` on `PTRefs` now relies on `operator>` (possibly through `std::greater`).
