### PR TITLE
Remove the ad-hoc 'anon' symbol

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -36,7 +36,6 @@ const char* Logic::tk_val_bool_default = "true";
 
 const char* Logic::tk_true     = "true";
 const char* Logic::tk_false    = "false";
-const char* Logic::tk_anon     = ".anon";
 const char* Logic::tk_not      = "not";
 const char* Logic::tk_uf_not   = ".uf-not";
 const char* Logic::tk_equals   = "=";
@@ -65,7 +64,6 @@ Logic::Logic(opensmt::Logic_t _logicType) :
     , term_FALSE(mkConst(getSort_bool(), tk_false))
     , sym_TRUE(getSymRef(term_TRUE))
     , sym_FALSE(getSymRef(term_FALSE))
-    , sym_ANON(sym_store.newSymb(tk_anon, {}))
     , sym_AND(declareFun_Commutative_NoScoping_LeftAssoc(tk_and, sort_BOOL, {sort_BOOL, sort_BOOL}))
     , sym_OR(declareFun_Commutative_NoScoping_LeftAssoc(tk_or, sort_BOOL, {sort_BOOL, sort_BOOL}))
     , sym_XOR(declareFun_Commutative_NoScoping_LeftAssoc(tk_xor, sort_BOOL, {sort_BOOL, sort_BOOL}))
@@ -1386,7 +1384,7 @@ Logic::dumpHeaderToFile(ostream& dump_out) const
 
     const vec<SymRef>& symbols = sym_store.getSymbols();
     for (SymRef s : symbols) {
-        if (s == getSym_true() || s == getSym_false() || s == getSym_anon())
+        if (s == getSym_true() || s == getSym_false())
             continue;
         if (isConstant(s)) {
             if (isBuiltinConstant(s)) continue;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -81,7 +81,6 @@ class Logic {
 
     SymRef              sym_TRUE;
     SymRef              sym_FALSE;
-    SymRef              sym_ANON;
     SymRef              sym_AND;
     SymRef              sym_OR;
     SymRef              sym_XOR;
@@ -279,7 +278,6 @@ public:
     // The Boolean connectives
     SymRef        getSym_true      ()              const;// { return sym_TRUE;     }
     SymRef        getSym_false     ()              const;// { return sym_FALSE;    }
-    SymRef        getSym_anon      ()              const    { return sym_ANON; }
     SymRef        getSym_and       ()              const;// { return sym_AND;      }
     SymRef        getSym_or        ()              const;// { return sym_OR;       }
     SymRef        getSym_xor       ()              const;// { return sym_XOR;      }
@@ -356,7 +354,6 @@ public:
     bool        isTrue(PTRef tr)  const ;//{ return isTrue(getPterm(tr).symb()); }
     bool        isFalse(SymRef sr) const;// { return sr == getSym_false(); }
     bool        isFalse(PTRef tr)  const;// { return isFalse(getPterm(tr).symb()); }
-    bool        isAnon(SymRef sr) const { return sr == getSym_anon(); }
     bool        isIff(SymRef sr) const;// { return sr == getSym_eq(); }
     bool        isIff(PTRef tr) const;// { return isIff(getPterm(tr).symb()); }
 

--- a/src/tsolvers/egraph/EnodeStore.h
+++ b/src/tsolvers/egraph/EnodeStore.h
@@ -83,8 +83,7 @@ class EnodeStore {
     vec<PTRef>     index_to_dist;                    // Table distinction index --> proper term
     vec<ERef>      termEnodes;
 
-    ERef  addTerm(PTRef pt);
-    ERef  addAnonTerm(PTRef pt);
+    ERef  addTerm(PTRef pt, bool ignoreChildren = false);
 
 public:
     EnodeStore(Logic& l);


### PR DESCRIPTION
I wanted to do a small refactoring of symbols in OpenSMT and the `anon` symbol was causing some trouble for that.
The Egraph solver can work without this artificial symbol, so it should safe to remove it.

Previously, it was used to create special Enodes that do not need to represent the children of the corresponding Pterm.
However, it seems to be that these special Enodes can use the symbol of the Pterm without losing any effect on the program.