### PR TITLE
Symbols: Use interfaces with explicit return sort

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -693,7 +693,7 @@ PTRef Logic::mkConst(const char* name)
 
 
 PTRef Logic::mkVar(SRef s, const char* name, bool isInterpreted) {
-    SymRef sr = sym_store.newSymb(name, {s}, isInterpreted ? SymConf::Interpreted : SymConf::Default);
+    SymRef sr = sym_store.newSymb(name, s, {}, isInterpreted ? SymConf::Interpreted : SymConf::Default);
     assert(sr != SymRef_Undef);
     if (sr == SymRef_Undef) {
         std::cerr << "Unexpected situation in  Logic::mkVar for " << name << std::endl;
@@ -807,19 +807,11 @@ PTRef Logic::mkSelect(vec<PTRef> && args) {
     return mkFun(sortToSelect[arraySort], std::move(args));
 }
 
-SymRef Logic::declareFun(std::string const & fname, SRef rsort, const vec<SRef> & args, SymbolConfig const & symbolConfig)
-{
-    vec<SRef> comb_args;
-
+SymRef Logic::declareFun(std::string const & fname, SRef rsort, vec<SRef> const & args, SymbolConfig const & symbolConfig) {
     assert(rsort != SRef_Undef);
+    assert(std::find(args.begin(), args.end(), SRef_Undef) == args.end());
 
-    comb_args.push(rsort);
-
-    for (SRef sr : args) {
-        assert(sr != SRef_Undef);
-        comb_args.push(sr);
-    }
-    SymRef sr = sym_store.newSymb(fname.c_str(), comb_args, symbolConfig);
+    SymRef sr = sym_store.newSymb(fname.c_str(), rsort, args, symbolConfig);
     return sr;
 }
 

--- a/src/symbols/SymStore.h
+++ b/src/symbols/SymStore.h
@@ -35,19 +35,17 @@ class SymStore {
     VecMap<const char*,SymRef,StringHash,Equal<const char*> >  symbolTable;
     vec<SymRef>                                 symbols;
     SymbolAllocator                             ta{1024};
-  public:
     vec<char*>                                  idToName;
 
+  public:
     ~SymStore();
-    // Construct a new symbol.  The first argument in args is the return
-    // sort of the symbol
+    // Constructs a new symbol.
     SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args, SymbolConfig const & symConfig);
     SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args) { return newSymb(fname, rsort, args, SymConf::Default); }
     bool contains(const char* fname)            const { return symbolTable.has(fname); }
     const vec<SymRef>& nameToRef(const char* s) const { return symbolTable[s]; }
     vec<SymRef>& nameToRef(const char* s)             { return symbolTable[s]; }
 
-    // Replace with std::optional if C++17 will be required
     const vec<SymRef>* getRefOrNull(const char* s) const { return symbolTable.getOrNull(s); }
 
     Symbol& operator [] (SymRef sr)                   { return ta[sr]; }

--- a/src/symbols/SymStore.h
+++ b/src/symbols/SymStore.h
@@ -41,8 +41,8 @@ class SymStore {
     ~SymStore();
     // Construct a new symbol.  The first argument in args is the return
     // sort of the symbol
-    SymRef newSymb(const char *fname, vec<SRef> const & args, SymbolConfig const & symConfig);
-    SymRef newSymb(const char *fname, vec<SRef> const & args) { return newSymb(fname, args, SymConf::Default); }
+    SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args, SymbolConfig const & symConfig);
+    SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args) { return newSymb(fname, rsort, args, SymConf::Default); }
     bool contains(const char* fname)            const { return symbolTable.has(fname); }
     const vec<SymRef>& nameToRef(const char* s) const { return symbolTable[s]; }
     vec<SymRef>& nameToRef(const char* s)             { return symbolTable[s]; }

--- a/src/symbols/Symbol.h
+++ b/src/symbols/Symbol.h
@@ -151,13 +151,10 @@ class SymbolAllocator : public RegionAllocator<uint32_t>
     static int symWord32Size(int size){
         return (sizeof(Symbol) + (sizeof(SRef) * size )) / sizeof(uint32_t); }
  public:
-    bool extra_term_field;
-
-    SymbolAllocator(uint32_t start_cap) : RegionAllocator<uint32_t>(start_cap), extra_term_field(false){}
-    SymbolAllocator() : extra_term_field(false){}
+    SymbolAllocator(uint32_t start_cap) : RegionAllocator<uint32_t>(start_cap) {}
+    SymbolAllocator() = default;
 
     void moveTo(SymbolAllocator& to){
-        to.extra_term_field = extra_term_field;
         RegionAllocator<uint32_t>::moveTo(to); }
 
     SymRef alloc(SRef rsort, vec<SRef> const & argSorts, SymbolConfig const & sc)

--- a/src/symbols/Symbol.h
+++ b/src/symbols/Symbol.h
@@ -94,12 +94,14 @@ class Symbol {
     friend class SymStore;
     // Note: do not use directly (no memory allocation for args)
 
-    Symbol(vec<SRef> const & ps, SymbolConfig const & config)
-        : header(ps.size(), config)
+    Symbol(SRef rsort, vec<SRef> const & argSorts, SymbolConfig const & config)
+        : header(argSorts.size_() + 1, config)
     {
         assert(config.prop != SymbolProperty::LeftAssoc or nargs() == 2);
         assert(config.prop != SymbolProperty::RightAssoc or nargs() == 2);
-        for (int i = 0; i < ps.size(); i++) args[i].sort = ps[i];
+
+        args[0].sort = rsort;
+        for (int i = 0; i < argSorts.size(); ++i) args[i+1].sort = argSorts[i];
     }
 
   public:
@@ -158,16 +160,16 @@ class SymbolAllocator : public RegionAllocator<uint32_t>
         to.extra_term_field = extra_term_field;
         RegionAllocator<uint32_t>::moveTo(to); }
 
-    SymRef alloc(vec<SRef> const & ps, SymbolConfig const & sc)
+    SymRef alloc(SRef rsort, vec<SRef> const & argSorts, SymbolConfig const & sc)
     {
         assert(sizeof(SRef)     == sizeof(uint32_t));
         assert(sizeof(float)    == sizeof(uint32_t));
 
-        uint32_t v = RegionAllocator<uint32_t>::alloc(symWord32Size(ps.size()));
+        uint32_t v = RegionAllocator<uint32_t>::alloc(symWord32Size(argSorts.size() + 1));
         SymRef symid;
         symid.x = v;
 
-        new (lea(symid)) Symbol(ps, sc);
+        new (lea(symid)) Symbol(rsort, argSorts, sc);
         return symid;
     }
 


### PR DESCRIPTION
Previously, the implementation detail that stores the return sort in the same array as arguments sort leaked out up to Logic's creation of new function declaration.
It seems more natural and cleaner to keep the return sort explicitly separated from arguments' sorts up until the last moment.

This also avoids some unnecessary memory allocations.