### PR TITLE
Pterm: Return arguments by value

### DIFF
--- a/src/pterms/Pterm.h
+++ b/src/pterms/Pterm.h
@@ -94,8 +94,7 @@ class Pterm {
 
     int      size        ()          const   { return static_cast<int>(header.size); }
 
-    const PTRef& operator [] (int i) const   { assert(i < size()); return args[i]; }
-    PTRef&       operator [] (int i)         { assert(i < size()); return args[i]; }
+    PTRef operator [] (int i) const   { assert(i < size()); return args[i]; }
 
     SymRef   symb        ()         const   { return sym; }
     bool     has_extra   ()         const   { return false; }


### PR DESCRIPTION
Pterm's arguments should never be changed once the term is created. Hence, it does not make sense to return an argument by reference. Additionally, PTRefs are small enough to be returned by value instead of by const reference.