### PR TITLE
ArithLogic: Avoid redundant work when computing substitutions

### DIFF
--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -384,7 +384,7 @@ lbool ArithLogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Subs
     auto toPoly = [&logic](PTRef eq) {
         assert(logic.isEquality(eq));
         poly_t poly;
-        PTRef polyTerm = logic.mkMinus(logic.getPterm(eq)[0], logic.getPterm(eq)[1]);
+        PTRef polyTerm = logic.mkMinus(logic.getPterm(eq)[1], logic.getPterm(eq)[0]);
         assert(logic.isLinearTerm(polyTerm));
         if (logic.isLinearFactor(polyTerm)) {
             auto [var,c] = logic.splitTermToVarAndConst(polyTerm);

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -384,7 +384,9 @@ lbool ArithLogic::arithmeticElimination(const vec<PTRef> & top_level_arith, Subs
     auto toPoly = [&logic](PTRef eq) {
         assert(logic.isEquality(eq));
         poly_t poly;
-        PTRef polyTerm = logic.mkMinus(logic.getPterm(eq)[1], logic.getPterm(eq)[0]);
+        PTRef lhs = logic.getPterm(eq)[0];
+        PTRef rhs = logic.getPterm(eq)[1];
+        PTRef polyTerm = lhs == logic.getZeroForSort(logic.getSortRef(lhs)) ? rhs : logic.mkMinus(rhs, lhs);
         assert(logic.isLinearTerm(polyTerm));
         if (logic.isLinearFactor(polyTerm)) {
             auto [var,c] = logic.splitTermToVarAndConst(polyTerm);


### PR DESCRIPTION
Equalities are currently normalized to form c = t where c is a constant and t is a term.
When computing polynomial from the equality, we compute the term t - c.
However, mkMinus currently works by negating the SECOND argument and passing them to mkPlus.
It is better to negate the constant rather than the term, thus we should pass FIRST argument of the equality as the SECOND argument to mkMinus.

Additionally, we can avoid the whole operation if the constant is 0.