### PR TITLE
ArithLogic: Remove method isNumVarOrIte

### DIFF
--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -266,9 +266,7 @@ public:
 
     bool isNumVar(SymRef sr) const { return isVar(sr) and (yieldsSortInt(sr) or yieldsSortReal(sr)); }
     bool isNumVar(PTRef tr) const { return isNumVar(getPterm(tr).symb()); }
-    bool isNumVarOrIte(SymRef sr) const { return isNumVar(sr) || isIte(sr); }
-    bool isNumVarOrIte(PTRef tr) const { return isNumVarOrIte(getPterm(tr).symb()); }
-    bool isNumVarLike(SymRef tr) const { return isNumVarOrIte(tr) || isIntDiv(tr) || isMod(tr) || (hasUFs() and isUF(tr)); }
+    bool isNumVarLike(SymRef sr) const { return isNumVar(sr) or isIte(sr) or isIntDiv(sr) or isMod(sr) or (hasUFs() and isUF(sr)); }
     bool isNumVarLike(PTRef tr) const { return isNumVarLike(getPterm(tr).symb()); }
 
     bool isZero(SymRef sr) const { return isIntZero(sr) or isRealZero(sr); }

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -89,9 +89,9 @@ void LASolver::isProperLeq(PTRef tr)
     assert(logic.isLeq(tr));
     auto [cons, sum] = logic.leqToConstantAndTerm(tr);
     assert(logic.isConstant(cons));
-    assert(logic.isNumVarOrIte(sum) || logic.isPlus(sum) || logic.isTimes(sum));
-    assert(!logic.isTimes(sum) || ((logic.isNumVarOrIte(logic.getPterm(sum)[0]) && logic.isOne(logic.mkNeg(logic.getPterm(sum)[1]))) ||
-                                   (logic.isNumVarOrIte(logic.getPterm(sum)[1]) && logic.isOne(logic.mkNeg(logic.getPterm(sum)[0])))));
+    assert(logic.isNumVar(sum) || logic.isPlus(sum) || logic.isTimes(sum));
+    assert(!logic.isTimes(sum) || ((logic.isNumVar(logic.getPterm(sum)[0]) && logic.isOne(logic.mkNeg(logic.getPterm(sum)[1]))) ||
+                                   (logic.isNumVar(logic.getPterm(sum)[1]) && logic.isOne(logic.mkNeg(logic.getPterm(sum)[0])))));
     (void) cons; (void)sum;
 }
 
@@ -222,7 +222,7 @@ opensmt::Number LASolver::getNum(PTRef r) {
 }
 
 void LASolver::notifyVar(LVRef v) {
-    assert(logic.isNumVarOrIte(getVarPTRef(v)));
+    assert(logic.isNumVar(getVarPTRef(v)));
     if (logic.yieldsSortInt(getVarPTRef(v))) {
         markVarAsInt(v);
     }
@@ -300,10 +300,10 @@ LVRef LASolver::registerArithmeticTerm(PTRef expr) {
         }
     }
 
-    if (logic.isNumVarOrIte(expr) || logic.isTimes(expr)) {
+    if (logic.isNumVar(expr) || logic.isTimes(expr)) {
         // Case (1), (2a), and (2b)
         auto [v,c] = logic.splitTermToVarAndConst(expr);
-        assert(logic.isNumVarOrIte(v) || (laVarMapper.isNegated(v) && logic.isNumVarOrIte(logic.mkNeg(v))));
+        assert(logic.isNumVar(v) || (laVarMapper.isNegated(v) && logic.isNumVar(logic.mkNeg(v))));
         x = getLAVar_single(v);
         simplex.newNonbasicVar(x);
         notifyVar(x);


### PR DESCRIPTION
This method is a relict from the time when we tried to keep ITEs around and let the theory solver deal with them. That did not work and we now eliminate ITEs from the formulas before they are internalized. Thus LASolver should never encounter an ITE.