### PR TITLE
Arrays: Add helper methods for querying array terms

### DIFF
--- a/src/logics/ArrayTheory.cc
+++ b/src/logics/ArrayTheory.cc
@@ -18,7 +18,7 @@ vec<PTRef> collectStores(Logic const & logic, PTRef fla) {
         CollectStoresConfig(Logic const & logic) : logic(logic) {}
 
         void visit(PTRef term) override {
-            if (logic.isArrayStore(logic.getSymRef(term))) {
+            if (logic.isArrayStore(term)) {
                 stores.push(term);
             }
         }
@@ -36,7 +36,7 @@ PTRef instantiateReadOverStore(Logic & logic, PTRef fla) {
     for (PTRef store : stores) {
         PTRef index = logic.getPterm(store)[1];
         PTRef value = logic.getPterm(store)[2];
-        assert(logic.isArrayStore(logic.getSymRef(store)));
+        assert(logic.isArrayStore(store));
         instantiatedAxioms.push(logic.mkEq(logic.mkSelect({store, index}), value));
     }
     instantiatedAxioms.push(fla);

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1580,7 +1580,9 @@ bool        Logic::hasSortBool(PTRef tr) const { return sym_store[getPterm(tr).s
 bool        Logic::hasSortBool(SymRef sr) const { return sym_store[sr].rsort() == sort_BOOL; }
 
 bool        Logic::isArraySelect(SymRef sr) const { return selects.has(sr); }
+bool        Logic::isArraySelect(PTRef tr) const { return isArraySelect(getPterm(tr).symb()); }
 bool        Logic::isArrayStore(SymRef sr) const { return stores.has(sr); }
+bool        Logic::isArrayStore(PTRef tr) const { return isArrayStore(getPterm(tr).symb()); }
 
 void Logic::termSort(vec<PTRef>& v) const { sort(v, std::less<PTRef>{}); }
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -153,7 +153,9 @@ class Logic {
     bool isArraySort(SRef sref) const { return sort_store[sref].getSymRef() == sym_ArraySort; }
     bool hasArrays() const { return opensmt::QFLogicToProperties.at(logicType).ufProperty.hasArrays; }
     bool isArrayStore(SymRef) const;
+    bool isArrayStore(PTRef) const;
     bool isArraySelect(SymRef) const;
+    bool isArraySelect(PTRef) const;
     PTRef mkStore(vec<PTRef> &&);
     PTRef mkSelect(vec<PTRef> &&);
 

--- a/src/tsolvers/axdiffsolver/ArraySolver.cc
+++ b/src/tsolvers/axdiffsolver/ArraySolver.cc
@@ -141,10 +141,10 @@ void ArraySolver::declareAtom(PTRef tr) {
             if (logic.isArraySort(logic.getSortRef(term))) {
                 ERef eref = egraph.termToERef(term);
                 arrayTerms.insert(eref);
-                if (logic.isArrayStore(logic.getSymRef(term))) {
+                if (logic.isArrayStore(term)) {
                     storeTerms.insert(eref);
                 }
-            } else if (logic.isArraySelect(logic.getSymRef(term))) {
+            } else if (logic.isArraySelect(term)) {
                 ERef eref = egraph.termToERef(term);
                 selectTerms.insert(eref);
             }
@@ -212,7 +212,7 @@ void ArraySolver::makeWeakRepresentative(NodeRef nodeRef) {
 }
 
 void ArraySolver::merge(ERef storeTerm) {
-    assert(logic.isArrayStore(logic.getSymRef(egraph.ERefToTerm(storeTerm))));
+    assert(logic.isArrayStore(egraph.ERefToTerm(storeTerm)));
     ERef arrayTerm = getArrayFromStore(storeTerm);
     ERef indexTerm = getRoot(getIndexFromStore(storeTerm));
     NodeRef arrayNode = getNodeRef(getRoot(arrayTerm));
@@ -522,8 +522,8 @@ ArraySolver::ExplanationCollection ArraySolver::readOverWeakEquivalenceConflict(
     assert(logic.isEquality(equality));
     PTRef lhs = logic.getPterm(equality)[0];
     PTRef rhs = logic.getPterm(equality)[1];
-    assert(logic.isArraySelect(logic.getSymRef(lhs)));
-    assert(logic.isArraySelect(logic.getSymRef(rhs)));
+    assert(logic.isArraySelect(lhs));
+    assert(logic.isArraySelect(rhs));
     ERef array1 = egraph.termToERef(logic.getPterm(lhs)[0]);
     ERef array2 = egraph.termToERef(logic.getPterm(rhs)[0]);
     ERef index1 = egraph.termToERef(logic.getPterm(lhs)[1]);

--- a/src/tsolvers/axdiffsolver/ArraySolver.h
+++ b/src/tsolvers/axdiffsolver/ArraySolver.h
@@ -258,28 +258,28 @@ private:
 
     ERef getArrayFromStore(ERef storeTerm) const {
         PTRef ptref = egraph.ERefToTerm(storeTerm);
-        assert(logic.isArrayStore(logic.getSymRef(ptref)));
+        assert(logic.isArrayStore(ptref));
         PTRef arrayPTerm = logic.getPterm(ptref)[0];
         return egraph.termToERef(arrayPTerm);
     }
 
     ERef getIndexFromStore(ERef storeTerm) const {
         PTRef ptref = egraph.ERefToTerm(storeTerm);
-        assert(logic.isArrayStore(logic.getSymRef(ptref)));
+        assert(logic.isArrayStore(ptref));
         PTRef indexPTerm = logic.getPterm(ptref)[1];
         return egraph.termToERef(indexPTerm);
     }
 
     ERef getIndexFromSelect(ERef selectTerm) const {
         PTRef ptref = egraph.ERefToTerm(selectTerm);
-        assert(logic.isArraySelect(logic.getSymRef(ptref)));
+        assert(logic.isArraySelect(ptref));
         PTRef indexPTerm = logic.getPterm(ptref)[1];
         return egraph.termToERef(indexPTerm);
     }
 
     ERef getArrayFromSelect(ERef selectTerm) const {
         PTRef ptref = egraph.ERefToTerm(selectTerm);
-        assert(logic.isArraySelect(logic.getSymRef(ptref)));
+        assert(logic.isArraySelect(ptref));
         PTRef arrayPTerm = logic.getPterm(ptref)[0];
         return egraph.termToERef(arrayPTerm);
     }


### PR DESCRIPTION
Methods isArrayStore and isArraySelect were missing the overloads taking PTRef as argument. This adds these overloads  to accompany the existing methods taking SymRef as argument.