### PR TITLE
LASolver: Make debug print clearer

### DIFF
--- a/src/tsolvers/lasolver/Simplex.cc
+++ b/src/tsolvers/lasolver/Simplex.cc
@@ -377,12 +377,12 @@ bool Simplex::invariantHolds() const
         if (isModelOutOfBounds(var)) {
             rval = false;
             if (isModelOutOfUpperBound(var)) {
-                printf("Non-basic (column) LRA var %s has value %s <= %s \n",
+                printf("Non-basic (column) LRA var %s has value %s > %s (upper bound)\n",
                        printVar(var), model->read(var).printValue(), model->Ub(var).printValue());
             }
             if (isModelOutOfLowerBound(var)) {
-                printf("Non-basic (column) LRA var %s has value %s <= %s \n",
-                       printVar(var), model->Lb(var).printValue(), model->read(var).printValue());
+                printf("Non-basic (column) LRA var %s has value %s < %s (lower bound)\n",
+                       printVar(var), model->read(var).printValue(), model->Lb(var).printValue());
             }
             assert(false);
         }


### PR DESCRIPTION
If the current value of a variable is above upper bound, the message should say exactly that.
Similarly if the current value is below lower bound.