### PR TITLE
Interpret: Reduce size of call stack's activation record for parseTerm

### DIFF
--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -178,7 +178,7 @@ class Interpret {
     void                        notify_success();
     void                        comment_formatted(const char* s, ...) const;
 
-    bool                        addLetFrame(std::vector<opensmt::pair<PTRef, std::string>> const & bindings, LetRecords& letRecords);
+    bool                        addLetFrame(ASTNode const & bindingsNode, LetRecords& letRecords);
     PTRef                       letNameResolve(const char* s, const LetRecords& letRecords) const;
     PTRef                       resolveQualifiedIdentifier(const char * name, ASTNode const & sort, bool isQuoted);
 


### PR DESCRIPTION
Last changes in parseTerm (a838804c) led to increased size of activation record and this resulted in more stack overflows on SMT-LIB benchmarks with huge nested lets.
Even though according to my intuition, the abovementioned changes should have decreased the memory footprint on the stack, it seems the opposite happened. My guess is that the changes allowed compiler to inline something that was not inlined previously, but this required more stack space to accomodate the inlined code.

The changes in this PR move more work (and data structure) to another method, which is then not inlined anymore (my guess). This not only reverts the size increase, but actually leads to further decrease of the activation record's size.

Proper solution would be to reimplement parsing in a non-recursive way, but this patch significantly helps in the meantime.