### PR TITLE
ArithLogic: Fix normalization of equality

### DIFF
--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -392,6 +392,8 @@ protected:
     opensmt::pair<FastRational, PTRef> sumToNormalizedPair(PTRef sum);
     opensmt::pair<FastRational, PTRef> sumToNormalizedIntPair(PTRef sum);
     opensmt::pair<FastRational, PTRef> sumToNormalizedRealPair(PTRef sum);
+
+    bool hasNegativeLeadingVariable(PTRef poly) const;
 };
 
 // Determine for two multiplicative terms (* k1 v1) and (* k2 v2), v1 !=

--- a/test/unit/test_LIALogicMkTerms.cc
+++ b/test/unit/test_LIALogicMkTerms.cc
@@ -130,6 +130,13 @@ TEST_F(LIALogicMkTermsTest, test_Inequality_Simplification)
     );
 }
 
+TEST_F(LIALogicMkTermsTest, test_EqualityNormalization_Commutativity) {
+    PTRef two = logic.mkIntConst(2);
+    PTRef eq1 = logic.mkEq(x, two);
+    PTRef eq2 = logic.mkEq(two, x);
+    ASSERT_EQ(eq1, eq2);
+}
+
 TEST_F(LIALogicMkTermsTest, test_EqualityNormalization) {
     PTRef two = logic.mkIntConst(2);
     PTRef eq1 = logic.mkEq(x, y);
@@ -153,6 +160,15 @@ TEST_F(LIALogicMkTermsTest, test_EqualityNormalization_AlreadyNormalized) {
     PTRef eq1 = logic.mkEq(logic.mkPlus(logic.mkTimes(x, two), logic.mkTimes(y, three)), logic.getTerm_IntOne());
     ASSERT_NE(eq1, logic.getTerm_false());
     EXPECT_EQ(logic.getSymRef(eq1), logic.get_sym_Int_EQ());
+}
+
+TEST_F(LIALogicMkTermsTest, test_EqualityNormalization_EqualityToConstant) {
+    PTRef two = logic.mkIntConst(2);
+    PTRef eq = logic.mkEq(x, two);
+    PTRef lhs = logic.getPterm(eq)[0];
+    PTRef rhs = logic.getPterm(eq)[1];
+    EXPECT_NE(logic.getSymRef(lhs), logic.get_sym_Int_TIMES());
+    EXPECT_NE(logic.getSymRef(rhs), logic.get_sym_Int_TIMES());
 }
 
 TEST_F(LIALogicMkTermsTest, test_ReverseAuxRewrite) {

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -244,6 +244,13 @@ TEST_F(LRALogicMkTermsTest, test_ChainableInequality) {
     EXPECT_EQ(multiArgsGt, expandedGt);
 }
 
+TEST_F(LRALogicMkTermsTest, test_EqualityNormalization_Commutativity) {
+    PTRef two = logic.mkRealConst(2);
+    PTRef eq1 = logic.mkEq(x, two);
+    PTRef eq2 = logic.mkEq(two, x);
+    ASSERT_EQ(eq1, eq2);
+}
+
 TEST_F(LRALogicMkTermsTest, test_EqualityNormalization) {
     PTRef two = logic.mkRealConst(2);
     PTRef eq1 = logic.mkEq(x, y);


### PR DESCRIPTION
Previously we were normalizing equality (almost) the same way as inequality. However, while for inequality it is possible that the right-hand-side can have both positive and negative leading term, for equality this meant that the same equality can be normalized to two different terms.
For example "x = 2" got normalized to "-2 = -x", while "2 = x" got normalized to "2 = x".

The proposed fix here is to ensure that the equalities always have positive leading term on the right-hand-side. Thus now even "x = 2" is normalized to "2 = x".