### PR TITLE
Fix mod corner cases

### DIFF
--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -809,7 +809,7 @@ PTRef ArithLogic::mkMod(vec<PTRef> && args) {
 
     if (not isNumConst(divisor)) { throw OsmtApiException("Divisor must be constant in linear logic"); }
     if (isZero(divisor)) { throw ArithDivisionByZeroException(); }
-
+    if (isOne(divisor) or isMinusOne(divisor)) { return getTerm_IntZero(); }
     if (isConstant(dividend)) {
         auto const& dividendValue = getNumConst(dividend);
         auto const& divisorValue = getNumConst(divisor);
@@ -831,6 +831,8 @@ PTRef ArithLogic::mkIntDiv(vec<PTRef> && args) {
     PTRef divisor = args[1];
     if (not isConstant(divisor) and not isConstant(dividend)) { throw LANonLinearException("Divisor or dividend must be constant in linear logic"); }
     if (isZero(divisor)) { throw ArithDivisionByZeroException(); }
+    if (isOne(divisor)) { return dividend; }
+    if (isMinusOne(divisor)) { return mkNeg(dividend); }
 
     if (isConstant(divisor) and isConstant(dividend)) {
         auto const& dividendValue = getNumConst(dividend);

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -278,7 +278,10 @@ public:
 
     bool isOne(PTRef tr) const { return isIntOne(tr) or isRealOne(tr); }
     bool isIntOne(PTRef tr) const { return tr == getTerm_IntOne(); }
+    bool isMinusOne(PTRef tr) const { return isIntMinusOne(tr) or isRealMinusOne(tr); }
+    bool isIntMinusOne(PTRef tr) const { return tr == getTerm_IntMinusOne(); }
     bool isRealOne(PTRef tr) const { return tr == getTerm_RealOne(); }
+    bool isRealMinusOne(PTRef tr) const { return tr == getTerm_RealMinusOne(); }
     bool isIntOne(SymRef sr) const { return sr == sym_Int_ONE; }
     bool isRealOne(SymRef sr) const { return sr == sym_Real_ONE; }
 

--- a/test/unit/test_LIALogicMkTerms.cc
+++ b/test/unit/test_LIALogicMkTerms.cc
@@ -81,6 +81,16 @@ TEST_F(LIALogicMkTermsTest, testMod_Leq) {
     EXPECT_EQ(logic.getSymRef(leq), logic.get_sym_Int_LEQ());
 }
 
+TEST_F(LIALogicMkTermsTest, testMod_One) {
+    PTRef one = logic.getTerm_IntOne();
+    PTRef zero = logic.getTerm_IntZero();
+    PTRef mod = logic.mkMod(x, one);
+    EXPECT_EQ(mod, zero);
+    PTRef minusOne = logic.getTerm_IntMinusOne();
+    mod = logic.mkMod(x, minusOne);
+    EXPECT_EQ(mod, zero);
+}
+
 TEST_F(LIALogicMkTermsTest, testDiv_Constants_PosPos) {
     PTRef two = logic.mkIntConst(2);
     PTRef three = logic.mkIntConst(3);
@@ -117,6 +127,16 @@ TEST_F(LIALogicMkTermsTest, testDiv_Constants_NegNeg) {
     EXPECT_EQ(div, logic.getTerm_IntOne());
     EXPECT_EQ(mod, logic.getTerm_IntOne());
 }
+
+TEST_F(LIALogicMkTermsTest, testDiv_One) {
+    PTRef one = logic.getTerm_IntOne();
+    PTRef div = logic.mkIntDiv(x, one);
+    EXPECT_EQ(div, x);
+    PTRef minusOne = logic.getTerm_IntMinusOne();
+    div = logic.mkIntDiv(x, minusOne);
+    EXPECT_EQ(div, logic.mkNeg(x));
+}
+
 
 TEST_F(LIALogicMkTermsTest, test_Inequality_Simplification)
 {


### PR DESCRIPTION
OpenSMT computes incorrectly `(mod x 1)`, `(mod x -1)`, `(div x 1)` and
`(div x -1)` because the special handling for these is missing.  This
PR adds the simplifications directly to `ArithLogic`.

There's also unit tests for the above cases. 

Fixes #628 