### PR TITLE
Arrays: Add example of API usage

### DIFF
--- a/examples/test_arrays.cc
+++ b/examples/test_arrays.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <opensmt/opensmt2.h>
+
+void usingWrapper();
+void creatingComponentsDirectly();
+
+int main()
+{
+    // There are now two ways to construct the necessary objects
+    // 1. Using a provided wrapper
+    usingWrapper();
+    // 2. Creating the necessary components directly
+    creatingComponentsDirectly();
+    return 0;
+
+}
+
+void usingWrapper() {
+    Opensmt osmt(qf_alia, "OpenSMT");
+    MainSolver & mainSolver = osmt.getMainSolver();
+    // You can ask the wrapper for the concrete subclass of Logic, but YOU need to make sure it matches the type you
+    // have provided in the constructor
+    ArithLogic & logic = osmt.getLIALogic();
+
+    SRef int2intSort = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    PTRef zero = logic.getTerm_IntZero();
+    PTRef one = logic.getTerm_IntOne();
+    PTRef a = logic.mkVar(int2intSort, "a");
+    // assertion a<0 -> 1>[0] = 1
+    PTRef store = logic.mkStore({a, zero, one});
+    PTRef select = logic.mkSelect({store, zero});
+    PTRef eq = logic.mkEq(select, one);
+    // test if the negation is satisfiable
+    mainSolver.insertFormula(logic.mkNot(eq));
+    sstat r = mainSolver.check();
+    assert(r == s_False);
+
+    if (r == s_True)
+        printf("sat\n");
+    else if (r == s_False)
+    {
+        printf("unsat\n");
+    }
+    else if (r == s_Undef)
+        printf("unknown\n");
+    else
+        printf("error\n");
+}
+
+void creatingComponentsDirectly() {
+    ArithLogic logic{opensmt::Logic_t::QF_ALIA};
+    SMTConfig config;
+    MainSolver mainSolver(logic, config, "ALIA solver");
+
+    SRef int2intSort = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    // check that two arrays can be different
+    PTRef a = logic.mkVar(int2intSort, "a");
+    PTRef b = logic.mkVar(int2intSort, "b");
+    PTRef eq = logic.mkEq(a, b);
+    mainSolver.insertFormula(logic.mkNot(eq));
+    sstat r = mainSolver.check();
+    assert(r == s_True);
+    // TODO: print model
+
+    if (r == s_True)
+        printf("sat\n");
+    else if (r == s_False)
+    {
+        printf("unsat\n");
+    }
+    else if (r == s_Undef)
+        printf("unknown\n");
+    else
+        printf("error\n");
+}
+
+

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -318,7 +318,7 @@ bool Logic::hasSortSymbol(const SortSymbol & symbol) {
     return sort_store.peek(symbol, unused);
 }
 
-bool Logic::peekSortSymbol(SortSymbol const & symbol, SSymRef & out) {
+bool Logic::peekSortSymbol(SortSymbol const & symbol, SSymRef & out) const {
     return sort_store.peek(symbol, out);
 }
 
@@ -1574,6 +1574,10 @@ bool        Logic::isArraySelect(SymRef sr) const { return selects.has(sr); }
 bool        Logic::isArraySelect(PTRef tr) const { return isArraySelect(getPterm(tr).symb()); }
 bool        Logic::isArrayStore(SymRef sr) const { return stores.has(sr); }
 bool        Logic::isArrayStore(PTRef tr) const { return isArrayStore(getPterm(tr).symb()); }
+
+SRef Logic::getArraySort(SRef domain, SRef codomain) {
+    return getSort(sym_ArraySort, {domain, codomain});
+}
 
 void Logic::termSort(vec<PTRef>& v) const { sort(v, std::less<PTRef>{}); }
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -150,7 +150,10 @@ class Logic {
     std::string         printSort  (SRef s)    const;
     std::size_t         getSortSize(SRef s)    const;
     SRef declareUninterpretedSort(std::string const &);
+
     bool isArraySort(SRef sref) const { return sort_store[sref].getSymRef() == sym_ArraySort; }
+    SRef getArraySort(SRef domain, SRef codomain);
+
     bool hasArrays() const { return opensmt::QFLogicToProperties.at(logicType).ufProperty.hasArrays; }
     bool isArrayStore(SymRef) const;
     bool isArrayStore(PTRef) const;
@@ -261,7 +264,7 @@ public:
     void        instantiateArrayFunctions(SRef);
 
     bool        hasSortSymbol(SortSymbol const &);
-    bool        peekSortSymbol(SortSymbol const &, SSymRef&);
+    bool        peekSortSymbol(SortSymbol const &, SSymRef &) const;
     SSymRef     declareSortSymbol(SortSymbol symbol);
     SRef        getSort(SSymRef, vec<SRef> && args);
 

--- a/src/sorts/SStore.cc
+++ b/src/sorts/SStore.cc
@@ -29,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string>
 #include <sstream>
 
-bool SStore::peek(SortSymbol const & symbol, SSymRef & outRef) {
+bool SStore::peek(SortSymbol const & symbol, SSymRef & outRef) const {
     auto it = this->sortSymbolTable.find(symbol.name);
     if (it != sortSymbolTable.end()) {
         outRef = it->second;

--- a/src/sorts/SStore.h
+++ b/src/sorts/SStore.h
@@ -63,7 +63,7 @@ class SStore
     //===========================================================================
     // Public APIs for sort construction/destruction
 
-    bool peek(SortSymbol const & symbol, SSymRef & outRef);
+    bool peek(SortSymbol const & symbol, SSymRef & outRef) const;
     SSymRef newSortSymbol(SortSymbol symbol);
 
     Sort const & operator [](SRef sr)               const { return sa[sr]; }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -245,3 +245,12 @@ PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_SATSolverTypes.cc"
 
 target_link_libraries(SATSolverTypesTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET SATSolverTypesTest)
+
+
+add_executable(ArraysTest)
+target_sources(ArraysTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Arrays.cc"
+        )
+
+target_link_libraries(ArraysTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET ArraysTest)

--- a/test/unit/test_Arrays.cc
+++ b/test/unit/test_Arrays.cc
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
+*
+*  SPDX-License-Identifier: MIT
+*
+*/
+
+#include <gtest/gtest.h>
+#include <ArithLogic.h>
+#include <MainSolver.h>
+
+class ArraysTest: public ::testing::Test {
+public:
+    ArraysTest()
+        : logic(opensmt::Logic_t::QF_ALIA), zero(logic.getTerm_IntZero()), one(logic.getTerm_IntOne())
+    {}
+    ArithLogic logic;
+    PTRef zero;
+    PTRef one;
+};
+
+TEST_F(ArraysTest, test_NoDuplicateSorts) {
+    SRef s1 = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    SRef s2 = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    ASSERT_EQ(s1, s2);
+}
+
+TEST_F(ArraysTest, test_ReadOverWrite) {
+    SRef sref = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    PTRef a = logic.mkVar(sref, "a");
+    PTRef store = logic.mkStore({a, zero, one});
+    PTRef select = logic.mkSelect({store, zero});
+
+    SMTConfig config;
+    MainSolver solver(logic, config, "solver");
+    solver.insertFormula(logic.mkNot(logic.mkEq(select, one)));
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+}
+


### PR DESCRIPTION
This PR adds an example how to create (and check) formula on the theory of arrays. In order to do that, we extend API of `Logic` to provide an easy way to get an array sort with the given domain and codomain.