### PR TITLE
Add support for QF_AUFLIRA logic

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -378,6 +378,7 @@ std::unique_ptr<Theory> MainSolver::createTheory(Logic & logic, SMTConfig & conf
         case Logic_t::QF_ALIA:
         case Logic_t::QF_AUFLRA:
         case Logic_t::QF_AUFLIA:
+        case Logic_t::QF_AUFLIRA:
         {
             ArithLogic & laLogic = dynamic_cast<ArithLogic &>(logic);
             theory = new UFLATheory(config, laLogic);

--- a/src/api/Opensmt.cc
+++ b/src/api/Opensmt.cc
@@ -39,8 +39,8 @@ opensmt::Logic_t convert(opensmt_logic logic) {
           return opensmt::Logic_t::QF_AUFLRA;
         case qf_auflia:
           return opensmt::Logic_t::QF_AUFLIA;
-        case qf_ct:
-            return opensmt::Logic_t::QF_CT;
+        case qf_auflira:
+            return opensmt::Logic_t::QF_AUFLIRA;
         default:
             return opensmt::Logic_t::UNDEF;
     }

--- a/src/api/Opensmt.h
+++ b/src/api/Opensmt.h
@@ -27,7 +27,7 @@ typedef enum
   , qf_auflra     // Arrays + UF + LRA
   , qf_auflia     // Arrays + UF + LIA
   , qf_bool       // Only booleans
-  , qf_ct         // Cost 
+  , qf_auflira    // Arrays + UF + (LIA or LRA)
 } opensmt_logic;
 
 class Opensmt

--- a/src/logics/LogicFactory.cc
+++ b/src/logics/LogicFactory.cc
@@ -13,7 +13,7 @@
 std::array<std::string, 23> logicToName = {{"Undef", "Empty", "QF_UF", "QF_CUF", "QF_BV", "QF_RDL", "QF_IDL",
                                            "QF_LRA", "QF_LIA", "QF_UFRDL", "QF_UFIDL", "QF_UFLRA", "QF_UFLIA",
                                            "QF_UFBV", "QF_AX", "QF_AXDIFF", "QF_ALRA", "QF_ALIA", "QF_AUFLRA",
-                                           "QF_AUFLIA", "QF_BOOL", "QF_AUFBV", "QF_CT"}};
+                                           "QF_AUFLIA", "QF_BOOL", "QF_AUFBV", "QF_AUFLIRA"}};
 
 opensmt::Logic_t opensmt::getLogicFromString(const std::string& name) {
     if (name == "QF_UF") return opensmt::Logic_t::QF_UF;
@@ -31,6 +31,7 @@ opensmt::Logic_t opensmt::getLogicFromString(const std::string& name) {
     if (name == "QF_ALIA") return opensmt::Logic_t::QF_ALIA;
     if (name == "QF_AUFLRA") return opensmt::Logic_t::QF_AUFLRA;
     if (name == "QF_AUFLIA") return opensmt::Logic_t::QF_AUFLIA;
+    if (name == "QF_AUFLIRA") return opensmt::Logic_t::QF_AUFLIRA;
     return opensmt::Logic_t::UNDEF;
 }
 
@@ -54,6 +55,7 @@ Logic * opensmt::LogicFactory::getInstance(Logic_t logicType) {
         case Logic_t::QF_UFLIA:
         case Logic_t::QF_ALIA:
         case Logic_t::QF_AUFLIA:
+        case Logic_t::QF_AUFLIRA:
         {
             l = new ArithLogic(logicType);
             break;

--- a/src/logics/LogicFactory.h
+++ b/src/logics/LogicFactory.h
@@ -48,7 +48,7 @@ struct LogicProperty {
 
 enum class Logic_t : int {
     UNDEF, EMPTY, QF_UF, QF_CUF, QF_BV, QF_RDL, QF_IDL, QF_LRA, QF_LIA, QF_NIA, QF_NRA, QF_LIRA, QF_NIRA, QF_UFRDL, QF_UFIDL,
-    QF_UFLRA, QF_UFLIA, QF_UFBV, QF_AX, QF_AXDIFF, QF_ALRA, QF_ALIA, QF_AUFLRA, QF_AUFLIA, QF_BOOL, QF_AUFBV, QF_CT
+    QF_UFLRA, QF_UFLIA, QF_UFBV, QF_AX, QF_AXDIFF, QF_ALRA, QF_ALIA, QF_AUFLRA, QF_AUFLIA, QF_BOOL, QF_AUFBV, QF_AUFLIRA
 };
 
 inline const std::unordered_map<Logic_t, LogicProperty> QFLogicToProperties  {
@@ -156,10 +156,10 @@ inline const std::unordered_map<Logic_t, LogicProperty> QFLogicToProperties  {
                           no_arith,
                           UFProperty{true, true, false},
                           BVProperty{true}}},
-     {Logic_t::QF_CT, {"QF_CT",
-                        no_arith,
-                        no_uf,
-                        no_bv}}
+     {Logic_t::QF_AUFLIRA, {"QF_AUFLIRA",
+                            ArithProperty{true, true, Arithmetic_t::Linear},
+                            UFProperty{true, true, false},
+                            no_bv}}
 };
 
 Logic_t getLogicFromString(const std::string & name);


### PR DESCRIPTION
This currently represents the most general logic OpenSMT can support. Even though we don't support mixing Int and Real terms, with this logic a user can create formulas using either Int or Real terms, in combination with arrays and uninterpreted functions.