### PR TITLE
EGraph: Remove redundant mapping

### DIFF
--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -71,9 +71,8 @@ ERef EnodeStore::addTerm(PTRef term, bool ignoreChildren) {
     }();
     ERef newEnode = ea.alloc(symref, argSpan, term);
 
+    assert(not termToERef.has(term));
     termToERef.insert(term, newEnode);
-    assert(not ERefToTerm.has(newEnode));
-    ERefToTerm.insert(newEnode, term);
     termEnodes.push(newEnode);
     return newEnode;
 }

--- a/src/tsolvers/egraph/EnodeStore.h
+++ b/src/tsolvers/egraph/EnodeStore.h
@@ -78,7 +78,6 @@ class EnodeStore {
     uint32_t       dist_idx;
 
     Map<PTRef,ERef,PTRefHash,Equal<PTRef> >    termToERef;
-    Map<ERef,PTRef,ERefHash,Equal<ERef> >      ERefToTerm;
 
     vec<PTRef>     index_to_dist;                    // Table distinction index --> proper term
     vec<ERef>      termEnodes;
@@ -108,7 +107,7 @@ public:
      * @return true if tr is in the store, false if not.
      */
     bool         peekERef(PTRef tr, ERef& er)  const { return termToERef.peek(tr, er); }
-    PTRef        getPTRef(ERef er)     const { return ERefToTerm[er]; }
+    PTRef        getPTRef(ERef er)     const { return ea[er].getTerm(); }
 
     vec<PTRefERefPair> constructTerm(PTRef tr);
 


### PR DESCRIPTION
A map from `ERef` to `PTRef` is redundant since `Enode` itself remembers its corresponding `PTRef` a `Egraph` can access this information given `ERef`.