### PR TITLE
Remove functionality to dump solver state

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -314,21 +314,6 @@ void Interpret::interp(ASTNode& n) {
                 }
                 break;
             }
-
-            case t_writestate: {
-                if (not isInitialized()) {
-                    notify_formatted(true, "Illegal command before set-logic: write-state");
-                } else {
-                    if (main_solver->solverEmpty()) {
-                        sstat status = main_solver->simplifyFormulas();
-                        if (status == s_Error)
-                            notify_formatted(true, "write-state");
-                    } else {
-                        writeState((**(n.children->begin())).getValue());
-                    }
-                }
-                break;
-            }
             case t_echo: {
                 const char *str = (**(n.children->begin())).getValue();
                 notify_formatted(false, "%s", str);
@@ -572,15 +557,6 @@ sstat Interpret::checkSat() {
         else if ((statusString.compare("unsat") == 0) && (res == s_True)) {
             notify_formatted(false, "(error \"check status which says unsat\")");
         }
-    }
-
-    if (res == s_Undef) {
-        const SMTOption& o_dump_state = config.getOption(":dump-state");
-        const SpType o_split = config.sat_split_type();
-        char* name = config.dump_state();
-        if (!o_dump_state.isEmpty() && o_split == spt_none)
-            writeState(name);
-        free(name);
     }
 
     return res;
@@ -875,18 +851,6 @@ std::string Interpret::printDefinitionSmtlib(TemplateFunction const & templateFu
     ss << ")" << " " << logic->printSort(templateFun.getRetSort()) << "\n";
     ss << "    " << logic->printTerm(templateFun.getBody()) << ")\n";
     return ss.str();
-}
-
-void Interpret::writeState(const char* filename)
-{
-    char* msg;
-    bool rval;
-
-    rval = main_solver->writeSolverState_smtlib2(filename, &msg);
-
-    if (!rval) {
-        notify_formatted("%s", msg);
-    }
 }
 
 bool Interpret::declareFun(ASTNode const & n) // (const char* fname, const vec<SRef>& args)

--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -154,7 +154,6 @@ class Interpret {
     void                        getInfo(ASTNode& n);
     void                        setOption(ASTNode& n);
     void                        getOption(ASTNode& n);
-    void                        writeState(const char* fname);
     bool                        declareFun(ASTNode const & n); //(const char* fname, const vec<SRef>& args);
     bool                        declareConst(ASTNode& n); //(const char* fname, const SRef ret_sort);
     bool                        defineFun(const ASTNode& n);

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -218,31 +218,6 @@ std::unique_ptr<InterpolationContext> MainSolver::getInterpolationContext() {
     );
 }
 
-bool MainSolver::writeSolverState_smtlib2(const char* file, char** msg) const
-{
-    char* name;
-    int written = asprintf(&name, "%s.smt2", file);
-    assert(written >= 0);
-    std::ofstream file_s;
-    file_s.open(name);
-    if (file_s.is_open()) {
-        logic.dumpHeaderToFile(file_s);
-        logic.dumpFormulaToFile(file_s, root_instance.getRoot());
-        logic.dumpChecksatToFile(file_s);
-        file_s.close();
-    }
-    else {
-        written = asprintf(msg, "Failed to open file %s\n", name);
-        assert(written >= 0);
-        free(name);
-        return false;
-    }
-    (void)written;
-    free(name);
-    return true;
-}
-
-
 void MainSolver::printFramesAsQuery() const
 {
     char* base_name = config.dump_query_name();

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -225,7 +225,6 @@ class MainSolver
     void  printFramesAsQuery() const;
     sstat getStatus       () const { return status; }
     bool  solverEmpty     () const { return ts.solverEmpty(); }
-    bool  writeSolverState_smtlib2 (const char* file, char** msg) const;
 
     // Values
     lbool   getTermValue   (PTRef tr) const { return ts.getTermValue(tr); }

--- a/src/api/smt2tokens.h
+++ b/src/api/smt2tokens.h
@@ -67,8 +67,6 @@ namespace osmttokens {
         t_setlogic,
         t_getinterpolants,
         t_theory,
-        t_writestate,
-        t_readstate,
         t_simplify,
         t_let,
         t_echo
@@ -144,8 +142,6 @@ namespace osmttokens {
         {t_setlogic, "set-logic"},
         {t_getinterpolants, "get-interpolants"},
         {t_theory, "theory"},
-        {t_writestate, "write-state"},
-        {t_readstate, "read-state"},
         {t_simplify, "simplify"},
         {t_let, "let"},
         {t_echo, "echo"}

--- a/src/parsers/smt2new/smt2newlexer.ll
+++ b/src/parsers/smt2new/smt2newlexer.ll
@@ -95,8 +95,6 @@ using namespace osmttokens;
 "set-option"       { yyget_lval(yyscanner)->tok = { t_setoption }; return TK_SETOPTION;     }
 "get-interpolants" { yyget_lval(yyscanner)->tok = { t_getinterpolants }; return TK_GETITPS;       }
 "theory"           { yyget_lval(yyscanner)->tok = { t_theory }; return TK_THEORY;        }
-"write-state"      { yyget_lval(yyscanner)->tok = { t_writestate }; return TK_WRSTATE;       }
-"read-state"       { yyget_lval(yyscanner)->tok = { t_readstate }; return TK_RDSTATE;       }
 "simplify"         { yyget_lval(yyscanner)->tok = { t_simplify }; return TK_SIMPLIFY;      }
 "echo"             { yyget_lval(yyscanner)->tok = { t_echo }; return TK_ECHO; }
 


### PR DESCRIPTION
I believe this functionality is no longer needed.
I did not find the corresponding read state functionality. Maybe we removed that already some time ago? 