### PR TITLE
Logic: Make API for getting array sort more robust

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -1543,6 +1543,7 @@ bool        Logic::isArrayStore(SymRef sr) const { return stores.has(sr); }
 bool        Logic::isArrayStore(PTRef tr) const { return isArrayStore(getPterm(tr).symb()); }
 
 SRef Logic::getArraySort(SRef domain, SRef codomain) {
+    if (not hasArrays()) { throw OsmtApiException("Selected logic does not support arrays"); }
     return getSort(sym_ArraySort, {domain, codomain});
 }
 


### PR DESCRIPTION
Creating array sorts should be allowed only for logics that support arrays.