### PR TITLE
Add include <algorithm> to fix building with gcc 14

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -21,6 +21,7 @@
 #include <queue>
 #include <set>
 #include <sstream>
+#include <algorithm>
 
 using namespace std;
 

--- a/src/pterms/PtStore.cc
+++ b/src/pterms/PtStore.cc
@@ -29,6 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "OsmtApiException.h"
 
 #include <sstream>
+#include <algorithm>
 
 const int PtStore::ptstore_vec_idx = 1;
 const int PtStore::ptstore_buf_idx = 2;

--- a/src/simplifiers/BoolRewriting.cc
+++ b/src/simplifiers/BoolRewriting.cc
@@ -5,6 +5,7 @@
 #include "BoolRewriting.h"
 #include "Logic.h"
 #include <unordered_set>
+#include <algorithm>
 
 // Replace subtrees consisting only of ands / ors with a single and / or term.
 // Search a maximal section of the tree consisting solely of ands / ors.  The

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -28,6 +28,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Symbol.h"
 #include "Logic.h"
 
+#include <algorithm>
+
 EnodeStore::EnodeStore(Logic& l)
       : logic(l)
       , ea(1024*1024)


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. In opensmt's case it is the `<algorithm>` header.

[Downstream Gentoo bug](https://bugs.gentoo.org/916855)


[GCC 14 porting guide](https://gcc.gnu.org/gcc-14/porting_to.html)