### PR TITLE
Getters of numerator and denominator for `FastRational`

### DIFF
--- a/src/common/FastRational.h
+++ b/src/common/FastRational.h
@@ -13,6 +13,7 @@ Copyright (c) 2008, 2009 Centre national de la recherche scientifique (CNRS)
 #include "Vec.h"
 #include <stack>
 #include <vector>
+#include <optional>
 
 typedef int32_t  word;
 typedef uint32_t uword;
@@ -165,6 +166,7 @@ private:
     }
     void force_ensure_mpq_valid() const
     {
+        // TK: I am afraid that this is UB
         const_cast<FastRational *>(this)->ensure_mpq_valid();
     }
     void ensure_mpq_memory_allocated()
@@ -243,6 +245,20 @@ public:
         else {
             return FastRational(mpq_numref(mpq));
         }
+    }
+
+    std::optional<std::pair<word, uword>> tryGetNumDen() const {
+        if (!wordPartValid()) return {};
+        return std::make_pair(num, den);
+    }
+
+    mpq_class getMpq() const {
+        if (wordPartValid()) {
+            static_assert(sizeof(long) == 8);
+            return mpq_class{static_cast<long>(num), static_cast<long>(den)};
+        }
+        assert(mpqPartValid());
+        return mpq_class{mpq};
     }
 
     inline int compare(const FastRational& b) const;


### PR DESCRIPTION
I noticed that it may be the first time using `std::optional` in the project but I hope it won't cause any trouble..

- `force_ensure_mpq_valid` is `const`, uses `const_cast`, but may modify non-mutable data members of `FastRational`, which I am afraid results in [undefined behavior](https://en.cppreference.com/w/cpp/language/const_cast)
- I also changed `FastRational` to `opensmt::Number` in `ArithLogic.h` to maintain consistency - the header includes only the abstraction `Number.h` and is using it in the declaration of several functions but not all. I also changed that in most cases in `ArithLogic.cc`, but not in all. I observed that many pieces of code in OpenSMT assume that `FastRational` is being used in the place of `Number`, so changing it to `mpq_class` would break a lot of code. Therefore, I just focused on most parts of `ArithLogic`, at least to avoid confusion for guys who are not that familiar with the internals (for example me :smiling_face_with_tear:).