### PR TITLE
Got rid of useless (actually possibly harmful) default destructors

### DIFF
--- a/src/api/Opensmt.cc
+++ b/src/api/Opensmt.cc
@@ -62,8 +62,3 @@ Opensmt::Opensmt(opensmt_logic logic_, const char* name, std::unique_ptr<SMTConf
     mainSolver = std::unique_ptr<MainSolver>(new MainSolver(*logic, *this->config, name));
     mainSolver->initialize();
 }
-
-Opensmt::~Opensmt()
-{
-
-}

--- a/src/api/Opensmt.h
+++ b/src/api/Opensmt.h
@@ -45,7 +45,6 @@ public:
      * @param config Configuration for the OpenSMT instance
      */
     Opensmt(opensmt_logic _logic, const char* name, std::unique_ptr<SMTConfig> config);
-    ~Opensmt();
 
     SMTConfig& getConfig() { return *config; }
     Logic& getLogic() { return *logic; }

--- a/src/cnfizers/Tseitin.h
+++ b/src/cnfizers/Tseitin.h
@@ -48,9 +48,6 @@ public:
         , alreadyCnfized(logic_.getTerm_true())
       {}
 
-    ~Tseitin( ) { }
-
-
 private:
 
     // Cache of already cnfized terms. Note that this is different from Cnfizer cache of already processed top-level flas

--- a/src/logics/ArrayTheory.h
+++ b/src/logics/ArrayTheory.h
@@ -21,7 +21,6 @@ public:
     , tshandler(c, logic)
     { }
 
-    ~ArrayTheory() {}
     virtual Logic&            getLogic() override { return logic; }
     virtual const Logic&      getLogic() const override { return logic; }
     virtual ArrayTHandler&       getTSolverHandler() override  { return tshandler; }

--- a/src/logics/BVLogic.cc
+++ b/src/logics/BVLogic.cc
@@ -80,9 +80,6 @@ BVLogic::BVLogic(opensmt::Logic_t type, int width) :
     equalities.insert(sym_BV_EQ, true);
 }
 
-BVLogic::~BVLogic()
-{}
-
 PTRef
 BVLogic::mkBVEq(PTRef a1, PTRef a2)
 {

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -85,7 +85,6 @@ class BVLogic: public Logic
 
   public:
     BVLogic(opensmt::Logic_t type, int width = i_default_bitwidth);
-    ~BVLogic();
     virtual int          getBitWidth() const { return bitwidth; }
     virtual std::string const getName() const override { return "QF_BV"; }
 
@@ -284,7 +283,3 @@ class BVLogic: public Logic
 
 };
 #endif
-
-
-
-

--- a/src/logics/LATheory.h
+++ b/src/logics/LATheory.h
@@ -22,7 +22,6 @@ public:
             , lalogic(logic)
             , latshandler(c, lalogic)
     { }
-    ~LATheory() {};
     virtual LinAlgLogic&          getLogic() override { return lalogic; }
     virtual const LinAlgLogic&    getLogic() const override { return lalogic; }
     virtual LinAlgTHandler&       getTSolverHandler() override { return latshandler; }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -84,8 +84,6 @@ Logic::Logic(opensmt::Logic_t _logicType) :
     sym_ArraySort = sort_store.newSortSymbol(SortSymbol("Array", 2, SortSymbol::INTERNAL));
 }
 
-Logic::~Logic() = default;
-
 bool Logic::isBuiltinFunction(const SymRef sr) const
 {
     if (sr == sym_TRUE || sr == sym_FALSE || sr == sym_AND || sr == sym_OR || sr == sym_XOR || sr == sym_NOT || sr == sym_EQ || sr == sym_IMPLIES || sr == sym_DISTINCT || sr == sym_ITE) return true;

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -127,7 +127,7 @@ class Logic {
     static const char*  s_abstract_value_prefix;
 
     Logic(opensmt::Logic_t type);
-    virtual ~Logic();
+    virtual ~Logic() = default;
 
     virtual PTRef conjoinExtras(PTRef root);
 
@@ -418,4 +418,3 @@ public:
 };
 
 #endif // LOGIC_H
-

--- a/src/logics/Theory.h
+++ b/src/logics/Theory.h
@@ -171,7 +171,7 @@ class Theory
     SubstitutionResult      computeSubstitutions(PTRef fla);
     void                    printFramesAsQuery(const vec<PFRef> & frames, std::ostream & s) const;
     virtual bool            okToPartition(PTRef) const { return true; }
-    virtual                ~Theory() {};
+    virtual                ~Theory() = default;
 };
 
 class UFTheory : public Theory
@@ -185,7 +185,6 @@ class UFTheory : public Theory
         , uflogic(logic)
         , tshandler(c, uflogic)
     { }
-    ~UFTheory() {}
     virtual Logic&            getLogic() override { return uflogic; }
     virtual const Logic&      getLogic() const override { return uflogic; }
     virtual UFTHandler&       getTSolverHandler() override  { return tshandler; }

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -991,4 +991,3 @@ void InterpolationContext::ensureNoLiteralsWithoutPartition() {
         proof_graph->eliminateNoPartitionTheoryVars(noPartitionVars);
     }
 }
-

--- a/src/proof/PG.h
+++ b/src/proof/PG.h
@@ -72,8 +72,6 @@ public:
 , cv  ( -1 )
 { }
 
-	~RuleContext ( ) { }
-
 	inline void reset( )
 	{
 		type = rNO;

--- a/src/smtsolvers/Proof.h
+++ b/src/smtsolvers/Proof.h
@@ -61,8 +61,6 @@ struct ProofDer
     ProofDer() : ref {0}, type{clause_type::CLA_ORIG} {}
     ProofDer(clause_type type) : ref {0}, type{type} {}
 
-    ~ProofDer( ) = default;
-
     std::vector< CRef >  chain_cla;               // Clauses chain
     std::vector< Var >   chain_var;               // Pivot chain
     int                  ref;                     // Reference counter
@@ -93,7 +91,6 @@ class Proof
 public:
 
     Proof ( ClauseAllocator& cl );
-    ~Proof( ) = default;
 
     // Notifies the proof about a new original clause.
     void newOriginalClause(CRef c) { newLeafClause(c, clause_type::CLA_ORIG); }

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -77,10 +77,6 @@ SimpSMTSolver::SimpSMTSolver(SMTConfig & c, THandler & t) :
     remove_satisfied      = false;
 }
 
-
-SimpSMTSolver::~SimpSMTSolver( )
-{ }
-
 void SimpSMTSolver::initialize( )
 {
     CoreSMTSolver::initialize( );

--- a/src/smtsolvers/SimpSMTSolver.h
+++ b/src/smtsolvers/SimpSMTSolver.h
@@ -55,7 +55,6 @@ class SimpSMTSolver : public CoreSMTSolver
     // Constructor/Destructor:
     //
     SimpSMTSolver (SMTConfig &, THandler&);
-    ~SimpSMTSolver( );
 
     void         initialize           ( );
 
@@ -69,7 +68,7 @@ public:
     bool    substitute(Var v, Lit x);  // Replace all occurences of v with x (may cause a contradiction).
 
     // Variable mode:
-    // 
+    //
     void    setFrozen (Var v, bool b); // If a variable is frozen it will not be eliminated.
     bool    isEliminated(Var v) const;
 
@@ -81,7 +80,7 @@ public:
     lbool    solve       (Lit p       ,        bool do_simp = true, bool turn_off_simp = false);
     lbool    solve       (Lit p, Lit q,        bool do_simp = true, bool turn_off_simp = false);
     lbool    solve       (Lit p, Lit q, Lit r, bool do_simp = true, bool turn_off_simp = false);
-    bool    eliminate   (bool turn_off_elim = false);  // Perform variable elimination based simplification. 
+    bool    eliminate   (bool turn_off_elim = false);  // Perform variable elimination based simplification.
 
     // Memory managment:
     //
@@ -200,7 +199,7 @@ inline lbool SimpSMTSolver::solve        (                     bool do_simp, boo
 inline lbool SimpSMTSolver::solve        (Lit p       ,        bool do_simp, bool turn_off_simp)  { return solve(vec<Lit>{p}, do_simp, turn_off_simp); }
 inline lbool SimpSMTSolver::solve        (Lit p, Lit q,        bool do_simp, bool turn_off_simp)  { return solve(vec<Lit>{p,q}, do_simp, turn_off_simp); }
 inline lbool SimpSMTSolver::solve        (Lit p, Lit q, Lit r, bool do_simp, bool turn_off_simp)  { return solve(vec<Lit>{p,q,r}, do_simp, turn_off_simp); }
-inline lbool SimpSMTSolver::solve        (const vec<Lit>& assumps, bool do_simp, bool turn_off_simp){ 
+inline lbool SimpSMTSolver::solve        (const vec<Lit>& assumps, bool do_simp, bool turn_off_simp){
     budgetOff(); setAssumptions(assumps); return solve_(do_simp, turn_off_simp); }
 inline lbool SimpSMTSolver::solveLimited (const vec<Lit>& assumps, bool do_simp, bool turn_off_simp){
     setAssumptions(assumps); return solve_(do_simp, turn_off_simp); }

--- a/src/sorts/SStore.h
+++ b/src/sorts/SStore.h
@@ -58,7 +58,6 @@ class SStore
   public:
 
     SStore() = default;
-    ~SStore() = default;
 
     //===========================================================================
     // Public APIs for sort construction/destruction

--- a/src/tsolvers/ArrayTHandler.h
+++ b/src/tsolvers/ArrayTHandler.h
@@ -17,8 +17,6 @@ class ArrayTHandler : public TSolverHandler {
 public:
     ArrayTHandler(SMTConfig & c, Logic & l);
 
-    ~ArrayTHandler() override = default;
-
     Logic & getLogic() override { return logic; };
 
     Logic const & getLogic() const override { return logic; }

--- a/src/tsolvers/THandler.h
+++ b/src/tsolvers/THandler.h
@@ -49,8 +49,6 @@ public:
     , checked_trail_size (0)
     { }
 
-    ~THandler() = default;
-
     void clear();  // Clear the solvers from their states
 
     bool isDeclared (Var v) { return v < declared.size() and declared[v]; } // Has v been declared to the theory solvers?

--- a/src/tsolvers/UFLATHandler.h
+++ b/src/tsolvers/UFLATHandler.h
@@ -47,7 +47,6 @@ class UFLATHandler : public TSolverHandler
     std::unordered_set<PTRef, PTRefHash> knownEqualities;
   public:
     UFLATHandler(SMTConfig & c, ArithLogic & l);
-    ~UFLATHandler() override = default;
     Logic & getLogic() override { return logic; }
     Logic const & getLogic() const override { return logic; }
 

--- a/src/tsolvers/UFTHandler.cc
+++ b/src/tsolvers/UFTHandler.cc
@@ -12,8 +12,6 @@ UFTHandler::UFTHandler(SMTConfig & c, Logic & l)
     setSolverSchedule({egraph});
 }
 
-UFTHandler::~UFTHandler() { }
-
 Logic &UFTHandler::getLogic()
 {
     return logic;
@@ -35,4 +33,3 @@ PTRef UFTHandler::getInterpolant(const ipartitions_t& mask, ItpColorMap * labels
     assert(iegraph);
     return iegraph->getInterpolant(mask, labels, pmanager);
 }
-

--- a/src/tsolvers/UFTHandler.h
+++ b/src/tsolvers/UFTHandler.h
@@ -42,7 +42,6 @@ class UFTHandler : public TSolverHandler
     Egraph*    egraph;
   public:
     UFTHandler(SMTConfig & c, Logic & l);
-    virtual ~UFTHandler();
     // This is for simplification, needed to run the theory solver code
     // as if it were running inside a SAT solver.
     virtual       Logic& getLogic() override;

--- a/src/tsolvers/axdiffsolver/ArraySolver.h
+++ b/src/tsolvers/axdiffsolver/ArraySolver.h
@@ -105,8 +105,6 @@ class ArraySolver : public TSolver {
 public:
     ArraySolver(Logic & logic, Egraph & egraph, SMTConfig & config);
 
-    ~ArraySolver() = default;
-
     void clearSolver() override;
 
     bool assertLit(PtAsgn asgn) override;

--- a/src/tsolvers/bvsolver/BVSolver.cc
+++ b/src/tsolvers/bvsolver/BVSolver.cc
@@ -33,8 +33,6 @@ BVSolver::BVSolver(SMTConfig & c, MainSolver & s, BVLogic & l)
  , B(id, c, mainSolver, l, explanation, suggestions)
 { }
 
-BVSolver::~BVSolver () { }
-
 //
 // The solver is informed of the existence of
 // atom e. It might be useful for initializing

--- a/src/tsolvers/bvsolver/BVSolver.h
+++ b/src/tsolvers/bvsolver/BVSolver.h
@@ -34,7 +34,6 @@ class BVSolver : public TSolver
 {
 public:
     BVSolver(SMTConfig & c, MainSolver & s, BVLogic & l);
-    ~BVSolver ( );
 
     bool            assertLit          ( PtAsgn ) override;
     void            pushBacktrackPoint ( )        override;

--- a/src/tsolvers/stpsolver/STPSolver.h
+++ b/src/tsolvers/stpsolver/STPSolver.h
@@ -44,8 +44,6 @@ private:
 public:
     STPSolver(SMTConfig &c, ArithLogic &l);
 
-    ~STPSolver() override;
-
     void clearSolver() override;
 
     bool assertLit(PtAsgn asgn) override;

--- a/src/tsolvers/stpsolver/STPSolver_implementations.hpp
+++ b/src/tsolvers/stpsolver/STPSolver_implementations.hpp
@@ -17,9 +17,6 @@ STPSolver<T>::STPSolver(SMTConfig &c, ArithLogic &l)
         , inv_bpoint(-1), inv_asgn(PtAsgn_Undef) {}
 
 template<class T>
-STPSolver<T>::~STPSolver() = default;
-
-template<class T>
 typename STPSolver<T>::ParsedPTRef STPSolver<T>::parseRef(PTRef ref) const {
     // inequalities are in the form (c <= (x + (-1 * y)))
     // due to how LALogic creates terms, we won't ever encounter <, >, or >= inequalities


### PR DESCRIPTION
I experienced in my project that some classes in OpenSMT have implicitly deleted move semantics. I found out that because my class forbids copying and requires moving, but class `Opensmt` was not able to.

I observed that this is caused by a user-defined destructor, referring to [rule of five](https://en.cppreference.com/w/cpp/language/rule_of_three): "the presence of a user-defined (or = default or = delete declared) destructor, ... prevents implicit definition of the move constructor and the move assignment operator". This also means that wherever move semantics are desired (e.g. using `std::move`), the object is actually still copied because move constructor is not available. Therefore, performance can be possibly improved: "failing to provide move constructor and move assignment is usually not an error, but a missed optimization opportunity".

I found a lot of user-defined destructors that are empty, i.e. that do the same thing as would the implicitly defined destructor, but which would not prevent implicit def. of move constructor. I got rid of such destructors, but only in cases where it did not break semantics of the code. For example, destructors should be defined as `virtual` in virtual base classes.

In cases where I did not delete the destructor, I did not fix the possible problem by providing the missing move constructor and `operator=`, because I was lazy, and also since I do not know all the classes and I am not sure if move semantics should be allowed in all cases.

As a last comment, there are a lot of classes with user-defined destructor but with no explicit definitions of copy semantics. This is almost always a bad practice, as discussed in the [rule of three](https://en.cppreference.com/w/cpp/language/rule_of_three). If these classes are not intended to be copied (which I did not investigate), the copy semantics should be explicitly deleted. Otherwise, copying will usually result in a mess.