### PR TITLE
Provided move semantics for `Opensmt`

### DIFF
--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -200,6 +200,10 @@ class MainSolver
     }
 
     virtual ~MainSolver() = default;
+    MainSolver             (const MainSolver&) = delete;
+    MainSolver& operator = (const MainSolver&) = delete;
+    MainSolver             (MainSolver&&) = default;
+    MainSolver& operator = (MainSolver&&) = delete;
 
     SMTConfig& getConfig() { return config; }
     SimpSMTSolver& getSMTSolver() { return *smt_solver; }

--- a/src/api/Opensmt.h
+++ b/src/api/Opensmt.h
@@ -33,6 +33,13 @@ typedef enum
 class Opensmt
 {
 public:
+    Opensmt             (const Opensmt&) = delete;
+    Opensmt& operator = (const Opensmt&) = delete;
+    Opensmt             (Opensmt&&) = default;
+    Opensmt& operator = (Opensmt&&) = default;
+
+    ~Opensmt() = default;
+
     Opensmt(opensmt_logic _logic, const char* name);
 
     /**

--- a/src/cnfizers/Cnfizer.h
+++ b/src/cnfizers/Cnfizer.h
@@ -75,6 +75,10 @@ public:
 
 
     virtual ~Cnfizer() = default;
+    Cnfizer             (const Cnfizer&) = delete;
+    Cnfizer& operator = (const Cnfizer&) = delete;
+    Cnfizer             (Cnfizer&&) = default;
+    Cnfizer& operator = (Cnfizer&&) = delete;
 
     lbool cnfizeAndGiveToSolver (PTRef, FrameId frame_id); // Main routine
 

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -105,6 +105,11 @@ protected:
 public:
     ArithLogic(opensmt::Logic_t type);
     ~ArithLogic() { for (auto number : numbers) { delete number; } }
+    ArithLogic            (const ArithLogic&) = delete;
+    ArithLogic& operator =(const ArithLogic&) = delete;
+    ArithLogic            (ArithLogic&&) = default;
+    ArithLogic& operator =(ArithLogic&&) = delete;
+
     bool             isBuiltinFunction(SymRef sr) const override;
     PTRef            insertTerm       (SymRef sym, vec<PTRef> && terms) override;
     SRef             getSort_real     () const { return sort_REAL; }

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -128,6 +128,10 @@ class Logic {
 
     Logic(opensmt::Logic_t type);
     virtual ~Logic() = default;
+    Logic            (const Logic&) = delete;
+    Logic& operator =(const Logic&) = delete;
+    Logic            (Logic&&) = default;
+    Logic& operator =(Logic&&) = delete;
 
     virtual PTRef conjoinExtras(PTRef root);
 

--- a/src/minisat/mtl/Map.h
+++ b/src/minisat/mtl/Map.h
@@ -278,8 +278,8 @@ public:
     int        size;
 
     // Don't allow copying (error prone):
-    VecMap<K,D,H,E>&  operator = (VecMap<K,D,H,E>& ) = delete;
-                   VecMap        (VecMap<K,D,H,E>& ) = delete;
+    VecMap&  operator = (VecMap&) = delete;
+    VecMap              (VecMap&) = delete;
 
     bool    checkCap(int new_size) const { return new_size > cap; }
 
@@ -317,6 +317,8 @@ public:
     VecMap () : table(NULL), cap(0), size(0) {}
     VecMap (const H& h, const E& e) : hash(h), equals(e), table(NULL), cap(0), size(0){}
     ~VecMap () { delete [] table; }
+    VecMap&  operator = (VecMap&&) = default;
+    VecMap              (VecMap&&) = default;
 
     // PRECONDITION: the key must already exist in the map.
     const vec<D>& operator [] (const K& k) const

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -407,6 +407,11 @@ public:
         free(info_names[i]);
   }
 
+  SMTConfig             (const SMTConfig&) = delete;
+  SMTConfig& operator = (const SMTConfig&) = delete;
+  SMTConfig             (SMTConfig&&) = default;
+  SMTConfig& operator = (SMTConfig&&) = default;
+
   bool             setOption(const char* name, const SMTOption& value, const char*& msg);
   const SMTOption& getOption(const char* name) const;
 
@@ -443,7 +448,7 @@ public:
   inline void setReductionLoops(int r) { insertOption(o_proof_red_trans, new SMTOption(r)); }
 
   // Set interpolation algorithms
-  inline void setBooleanInterpolationAlgorithm( ItpAlgorithm i ) { 
+  inline void setBooleanInterpolationAlgorithm( ItpAlgorithm i ) {
       insertOption(o_itp_bool_alg, new SMTOption(i.x)); }
 
   inline void setEUFInterpolationAlgorithm( ItpAlgorithm i ) { insertOption(o_itp_euf_alg, new SMTOption(i.x)); }

--- a/src/symbols/SymStore.h
+++ b/src/symbols/SymStore.h
@@ -38,7 +38,12 @@ class SymStore {
     vec<char*>                                  idToName;
 
   public:
+    SymStore() = default;
     ~SymStore();
+    SymStore            (const SymStore&) = delete;
+    SymStore& operator =(const SymStore&) = delete;
+    SymStore            (SymStore&&) = default;
+    SymStore& operator =(SymStore&&) = default;
     // Constructs a new symbol.
     SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args, SymbolConfig const & symConfig);
     SymRef newSymb(const char *fname, SRef rsort, vec<SRef> const & args) { return newSymb(fname, rsort, args, SymConf::Default); }


### PR DESCRIPTION
Allows to move the main solver in applications that require it (e.g. if they use `std::unique_ptr<Opensmt>` and do stuff with it). This required to provide move semantics in several nested/used classes, using the rule of five.