### PR TITLE
FastRational: Eliminate potential UB

### DIFF
--- a/src/common/FastRational.cc
+++ b/src/common/FastRational.cc
@@ -115,8 +115,8 @@ FastRational gcd(FastRational const & a, FastRational const & b)
         return FastRational(gcd(a.num, b.num));
     }
     else {
-        a.force_ensure_mpq_valid();
-        b.force_ensure_mpq_valid();
+        a.ensure_mpq_valid();
+        b.ensure_mpq_valid();
         mpz_gcd(FastRational::mpz(), mpq_numref(a.mpq), mpq_numref(b.mpq));
         return FastRational(FastRational::mpz());
     }
@@ -129,8 +129,8 @@ FastRational lcm(FastRational const & a, FastRational const & b)
         return lcm(a.num, b.num);
     }
     else {
-        a.force_ensure_mpq_valid();
-        b.force_ensure_mpq_valid();
+        a.ensure_mpq_valid();
+        b.ensure_mpq_valid();
         mpz_lcm(FastRational::mpz(), mpq_numref(a.mpq), mpq_numref(b.mpq));
         return FastRational(FastRational::mpz());
     }
@@ -160,8 +160,8 @@ FastRational fastrat_fdiv_q(FastRational const & n, FastRational const & d) {
         return quo;
     }
 overflow:
-    n.force_ensure_mpq_valid();
-    d.force_ensure_mpq_valid();
+    n.ensure_mpq_valid();
+    d.ensure_mpq_valid();
     mpz_fdiv_q(FastRational::mpz(), mpq_numref(n.mpq), mpq_numref(d.mpq));
     return FastRational(FastRational::mpz());
 }
@@ -185,8 +185,8 @@ FastRational divexact(FastRational const & n, FastRational const & d) {
         }
     } else {
         assert(n.mpqPartValid() || d.mpqPartValid());
-        n.force_ensure_mpq_valid();
-        d.force_ensure_mpq_valid();
+        n.ensure_mpq_valid();
+        d.ensure_mpq_valid();
         mpz_divexact(FastRational::mpz(), mpq_numref(n.mpq), mpq_numref(d.mpq));
         return FastRational(FastRational::mpz());
     }


### PR DESCRIPTION
Casting away const and then modifying the object is UB if the original object was const.
From [cppreference](https://en.cppreference.com/w/cpp/language/const_cast):
"Modifying a const object through a non-const access path results in undefined behavior."

We fix the problem by making `mpq` and `state` mutable, as we can change the inner representaton in certain circumstances without changing the rational value represented by the object.

Fixes #662.