### PR TITLE
664 explicitly divide debug and release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ src/PySMT/opensmt.py
 .ycm_extra_conf.py
 .ycm_extra_conf.pyc
 authors.txt
-build/
+build*/
 delta/parser/__pycache__/
 examples/_opensmt.so
 examples/opensmt.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Makefile.in
 .idea
 .DS_Store
 cmake-build-*
-Makefile
 .*.swp
 INSTALL
 aclocal.m4

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,16 @@ BUILD_DIR_BASE = build
 RELEASE_BUILD_DIR = $(BUILD_DIR_BASE)
 DEBUG_BUILD_DIR = $(BUILD_DIR_BASE)-debug
 
-CMAKE_FLAGS =
+INSTALL_DIR = /usr/local
+
+CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
 DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
 
-.PHONY: default all release debug _dir-release _dir-debug _build-release _build-debug clean clean-all clean-release clean-debug
+################################################################
+
+.PHONY: default all release debug
+.PHONY: _dir-release _dir-debug _build-release _build-debug
 
 default: release
 
@@ -32,6 +37,10 @@ _build-debug: | $(DEBUG_BUILD_DIR)
 $(DEBUG_BUILD_DIR):
 	cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
 
+################################
+
+.PHONY: clean clean-all clean-release clean-debug
+
 clean: clean-release
 
 clean-all: clean-release clean-debug
@@ -41,3 +50,15 @@ clean-release:
 
 clean-debug:
 	rm -fr $(DEBUG_BUILD_DIR)
+
+################################
+
+.PHONY: install install-release install-debug
+
+install: install-release
+
+install-release: release
+	$(MAKE) -C $(RELEASE_BUILD_DIR) install
+
+install-debug: debug
+	$(MAKE) -C $(DEBUG_BUILD_DIR) install

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,34 @@
 BUILD_DIR_BASE = build
+## These can be customized via command line
 RELEASE_BUILD_DIR = $(BUILD_DIR_BASE)
 DEBUG_BUILD_DIR = $(BUILD_DIR_BASE)-debug
 
 DEFAULT_INSTALL_DIR := /usr/local
 USER_INSTALL_DIR := $(INSTALL_DIR)
+## This can be customized via command line,
+## it takes effect within both `cmake --build` and `cmake --install`
 INSTALL_DIR = $(DEFAULT_INSTALL_DIR)
 
+## These can be customized via command line
+## Arguments for `cmake -B <build_dir>`
 CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
-RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
-DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
+RELEASE_CMAKE_FLAGS += $(CMAKE_FLAGS)
+DEBUG_CMAKE_FLAGS += $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
 
+## These can be customized via command line
+## Arguments for `cmake --build <build_dir>`
 CMAKE_BUILD_FLAGS +=
-RELEASE_CMAKE_BUILD_FLAGS = $(CMAKE_BUILD_FLAGS)
-DEBUG_CMAKE_BUILD_FLAGS = $(CMAKE_BUILD_FLAGS)
+RELEASE_CMAKE_BUILD_FLAGS += $(CMAKE_BUILD_FLAGS)
+DEBUG_CMAKE_BUILD_FLAGS += $(CMAKE_BUILD_FLAGS)
 
+## These can be customized via command line
+## Arguments for `cmake --install <build_dir>`
 CMAKE_INSTALL_FLAGS +=
 ifneq ($(USER_INSTALL_DIR),)
   CMAKE_INSTALL_FLAGS += --prefix=$(USER_INSTALL_DIR)
 endif
-RELEASE_CMAKE_INSTALL_FLAGS = $(CMAKE_INSTALL_FLAGS)
-DEBUG_CMAKE_INSTALL_FLAGS = $(CMAKE_INSTALL_FLAGS)
+RELEASE_CMAKE_INSTALL_FLAGS += $(CMAKE_INSTALL_FLAGS)
+DEBUG_CMAKE_INSTALL_FLAGS += $(CMAKE_INSTALL_FLAGS)
 
 ################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,31 @@ CMAKE_FLAGS =
 RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
 DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
 
-.PHONY: default all release debug clean clean-all clean-release clean-debug
+.PHONY: default all release debug _dir-release _dir-debug _build-release _build-debug clean clean-all clean-release clean-debug
 
 default: release
 
 all: release debug
 
-release: $(RELEASE_BUILD_DIR)
+release: _dir-release _build-release
 
-debug: $(DEBUG_BUILD_DIR)
+_dir-release: $(RELEASE_BUILD_DIR)
+
+_build-release: | $(RELEASE_BUILD_DIR)
+	cmake --build $(RELEASE_BUILD_DIR)
 
 $(RELEASE_BUILD_DIR):
 	cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
-	cmake --build $(RELEASE_BUILD_DIR)
+
+debug: _dir-debug _build-debug
+
+_dir-debug: $(DEBUG_BUILD_DIR)
+
+_build-debug: | $(DEBUG_BUILD_DIR)
+	cmake --build $(DEBUG_BUILD_DIR)
 
 $(DEBUG_BUILD_DIR):
 	cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
-	cmake --build $(DEBUG_BUILD_DIR)
 
 clean: clean-release
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ clean-debug:
 
 install: install-release
 
-install-release: _dir-release
+install-release: release
 	cmake --install $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_INSTALL_FLAGS)
 
-install-debug: _dir-debug
+install-debug: debug
 	cmake --install $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_INSTALL_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,21 @@ CMAKE_FLAGS =
 RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
 DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
 
+.PHONY: default all release debug clean clean-all clean-release clean-debug
+
 default: release
 
 all: release debug
 
-release:
+release: $(RELEASE_BUILD_DIR)
+
+debug: $(DEBUG_BUILD_DIR)
+
+$(RELEASE_BUILD_DIR):
 	@cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
 	@cmake --build $(RELEASE_BUILD_DIR)
 
-debug:
+$(DEBUG_BUILD_DIR):
 	@cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
 	@cmake --build $(DEBUG_BUILD_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,24 @@ BUILD_DIR_BASE = build
 RELEASE_BUILD_DIR = $(BUILD_DIR_BASE)
 DEBUG_BUILD_DIR = $(BUILD_DIR_BASE)-debug
 
-INSTALL_DIR = /usr/local
+DEFAULT_INSTALL_DIR := /usr/local
+USER_INSTALL_DIR := $(INSTALL_DIR)
+INSTALL_DIR = $(DEFAULT_INSTALL_DIR)
 
 CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
 DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
+
+CMAKE_BUILD_FLAGS +=
+RELEASE_CMAKE_BUILD_FLAGS = $(CMAKE_BUILD_FLAGS)
+DEBUG_CMAKE_BUILD_FLAGS = $(CMAKE_BUILD_FLAGS)
+
+CMAKE_INSTALL_FLAGS +=
+ifneq ($(USER_INSTALL_DIR),)
+  CMAKE_INSTALL_FLAGS += --prefix=$(USER_INSTALL_DIR)
+endif
+RELEASE_CMAKE_INSTALL_FLAGS = $(CMAKE_INSTALL_FLAGS)
+DEBUG_CMAKE_INSTALL_FLAGS = $(CMAKE_INSTALL_FLAGS)
 
 ################################################################
 
@@ -21,8 +34,8 @@ release: _dir-release _build-release
 
 _dir-release: $(RELEASE_BUILD_DIR)
 
-_build-release: | $(RELEASE_BUILD_DIR)
-	cmake --build $(RELEASE_BUILD_DIR)
+_build-release: _dir-release
+	cmake --build $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_BUILD_FLAGS)
 
 $(RELEASE_BUILD_DIR):
 	cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
@@ -31,8 +44,8 @@ debug: _dir-debug _build-debug
 
 _dir-debug: $(DEBUG_BUILD_DIR)
 
-_build-debug: | $(DEBUG_BUILD_DIR)
-	cmake --build $(DEBUG_BUILD_DIR)
+_build-debug: _dir-debug
+	cmake --build $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_BUILD_FLAGS)
 
 $(DEBUG_BUILD_DIR):
 	cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
@@ -57,8 +70,8 @@ clean-debug:
 
 install: install-release
 
-install-release: release
-	$(MAKE) -C $(RELEASE_BUILD_DIR) install
+install-release: _dir-release
+	cmake --install $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_INSTALL_FLAGS)
 
-install-debug: debug
-	$(MAKE) -C $(DEBUG_BUILD_DIR) install
+install-debug: _dir-debug
+	cmake --install $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_INSTALL_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,19 @@ release: $(RELEASE_BUILD_DIR)
 debug: $(DEBUG_BUILD_DIR)
 
 $(RELEASE_BUILD_DIR):
-	@cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
-	@cmake --build $(RELEASE_BUILD_DIR)
+	cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
+	cmake --build $(RELEASE_BUILD_DIR)
 
 $(DEBUG_BUILD_DIR):
-	@cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
-	@cmake --build $(DEBUG_BUILD_DIR)
+	cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
+	cmake --build $(DEBUG_BUILD_DIR)
 
 clean: clean-release
 
 clean-all: clean-release clean-debug
 
 clean-release:
-	@rm -fr $(RELEASE_BUILD_DIR)
+	rm -fr $(RELEASE_BUILD_DIR)
 
 clean-debug:
-	@rm -fr $(DEBUG_BUILD_DIR)
+	rm -fr $(DEBUG_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+BUILD_DIR_BASE = build
+RELEASE_BUILD_DIR = $(BUILD_DIR_BASE)
+DEBUG_BUILD_DIR = $(BUILD_DIR_BASE)-debug
+
+CMAKE_FLAGS =
+RELEASE_CMAKE_FLAGS = $(CMAKE_FLAGS)
+DEBUG_CMAKE_FLAGS = $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug
+
+default: release
+
+all: release debug
+
+release:
+	@cmake -B $(RELEASE_BUILD_DIR) $(RELEASE_CMAKE_FLAGS)
+	@cmake --build $(RELEASE_BUILD_DIR)
+
+debug:
+	@cmake -B $(DEBUG_BUILD_DIR) $(DEBUG_CMAKE_FLAGS)
+	@cmake --build $(DEBUG_BUILD_DIR)
+
+clean: clean-release
+
+clean-all: clean-release clean-debug
+
+clean-release:
+	@rm -fr $(RELEASE_BUILD_DIR)
+
+clean-debug:
+	@rm -fr $(DEBUG_BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # OpenSMT2
 Copyright 2024 Tomáš Kolárik <tomaqa@gmail.com>  
+Copyright 2023 Martin Blicha <martin.blicha@gmail.com>  
 Copyright 2019 Antti Hyvarinen <antti.hyvarinen@gmail.com>  
 Copyright 2009 Roberto Bruttomesso <roberto.bruttomesso@gmail.com>
 
@@ -186,4 +187,4 @@ When using OpenSMT as a library, the option needs to be set in `SMTConfig` **bef
 Interpolation is supported for SMT-LIB logics `QF_UF`, `QF_LRA`, and `QF_LIA` in both single-query and incremental mode. An example of how SMT-LIB2 file can be extended to instruct OpenSMT to compute interpolants can be found [here](regression_itp/itp_bug_small.smt2).
 
 ## Contact
-If you have questions, bug reports, or feature requests, please refer to our [GitHub](https://github.com/usi-verification-and-security/opensmt/issues) issue tracker or send us a mail at tomaqa@gmail.com or antti.hyvarinen@gmail.com.
+If you have questions, bug reports, or feature requests, please refer to our [GitHub](https://github.com/usi-verification-and-security/opensmt/issues) issue tracker or send us an email at tomaqa@gmail.com, martin.blicha@gmail.com or antti.hyvarinen@gmail.com.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Build (and configure) with the default values but install into `local_dir`:
 make && make install INSTALL_DIR=local_dir
 ```
 
-Build and configure to by default install into `local_dir` but also install into `local_dir2`:
+Build and configure to install into `local_dir` and install there, but also perform another installation into `local_dir2`:
 ```
 make INSTALL_DIR=local_dir && make install && make install INSTALL_DIR=local_dir2
 ```


### PR DESCRIPTION
Root Makefile that serves only for initial builds.

`make` (or `make default` or `make release`) builds `build` and `make debug` builds `build-test`.
`make all` builds both.
Once the build directory is created, the rule is "up-to-date" and not run anymore. This is not a mistake but my intention.

The build directories can also be removed using `make clean` (or `make clean-release`) and `make clean-debug` (or `make clean-all`). Then it is possible to run e.g. `make` again.

The target build directories can be modified via cmdline, for example: `make RELEASE_BUILD_DIR=build-release`.
But then the option should also be used for `make clean` otherwise it will try to remove the default build directory (it won't fail but won't do anything).

More importantly, CMake options may be modified using `CMAKE_FLAGS` option, for example:
`make CMAKE_FLAGS=-DENABLE_LINE_EDITING:BOOL=ON`
`make debug CMAKE_FLAGS='-DENABLE_LINE_EDITING:BOOL=ON -DUSE_READLINE:BOOL=ON'`

The Makefile is not documented yet, README is not updated.

Resolves #664.

I think that the `install` rules should be handled too, but here I am not sure how to handle the target install directory for the library (`include` is the same for both) - should there also be a separate directory for each build type (e.g. `/usr/local/lib/release/libopensmt.a` and `/usr/local/lib/debug/libopensmt.a`, or `/usr/local/lib/libopensmt.a` and `/usr/local/lib/debug/libopensmt.a`), or should it be just one and always overwrite the previous file? In order to change the build type. I think that on the system level, at least on Linux distros, only one type at a time is usually supported.