### PR TITLE
move the built exec. into bin directory

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(OpenSMT-bin opensmt.cc)
 set_target_properties(OpenSMT-bin PROPERTIES
     NO_SYSTEM_FROM_IMPORTED true # For some reason on MAC OS build in travis, the .cc files from this target were compiled with -isystem /usr/include and that was messing up the search order of include paths; This seems to fix it
     OUTPUT_NAME opensmt
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 if (ENABLE_LINE_EDITING)
     if (NOT USE_READLINE)


### PR DESCRIPTION
Resolves #671 

In case someone prefers having the executable also in `build` instead of `build/bin`, a symlink can be added. But I have not figured out how to do it easily in CMake..