### PR TITLE
Improve Handling of Empty Name in Logic::mkConst

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -648,12 +648,6 @@ PTRef Logic::mkNot(PTRef arg) {
 
 PTRef Logic::mkConst(const char* name)
 {
-    //assert(0);
-    // return PTRef_Undef;
-    if (strlen(name) == 0) {
-        std::cerr << "Error in Logic::mkConst: empty name" << std::endl;
-        return PTRef_Undef;
-    }
     return resolveTerm(name, {});
 }
 

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -649,8 +649,11 @@ PTRef Logic::mkNot(PTRef arg) {
 PTRef Logic::mkConst(const char* name)
 {
     //assert(0);
-    //return PTRef_Undef;
-    assert(strlen(name) > 0);
+    // return PTRef_Undef;
+    if (strlen(name) == 0) {
+        std::cerr << "Error in Logic::mkConst: empty name" << std::endl;
+        return PTRef_Undef;
+    }
     return resolveTerm(name, {});
 }
 


### PR DESCRIPTION
Fixes #694.

When opensmt processes assertions involving empty name, it triggers an assertion failure in `Logic::mkConst`.

To resolve this issue, I propose a modification to the `Logic::mkConst` to check for empty name explicitly. If an empty name is encountered, the function will now print an error message and return `PTRef_Undef`.