### PR TITLE
Ignore files related to ccls language server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ regression/log-*
 src/PySMT/opensmt.py
 .ycm_extra_conf.py
 .ycm_extra_conf.pyc
-.ccls-cache/
+.ccls*
 authors.txt
 build*/
 delta/parser/__pycache__/


### PR DESCRIPTION
I use for example in VS Codium. It is an alternative to for example clang server.
It is possible that someone do not want to use GCC... We can either ignore this, or add the conf. file and at the same time add it to .gitignore so anyone can freely update the file on local machine.