### PR TITLE
Add support for unsat core computation for theory combination

### DIFF
--- a/src/logics/ArrayTheory.cc
+++ b/src/logics/ArrayTheory.cc
@@ -9,8 +9,7 @@
 #include "ArrayHelpers.h"
 #include "DistinctRewriter.h"
 
-PTRef ArrayTheory::preprocessAfterSubstitutions(PTRef fla, PreprocessingContext const & context) {
-    if (context.perPartition) { throw OsmtInternalException("Interpolation not supported for logics with arrays yet"); }
+PTRef ArrayTheory::preprocessAfterSubstitutions(PTRef fla, PreprocessingContext const &) {
     // TODO: simplify select over store on the same index
     fla = rewriteDistincts(getLogic(), fla);
     fla = instantiateReadOverStore(getLogic(), fla);

--- a/src/logics/UFLATheory.cc
+++ b/src/logics/UFLATheory.cc
@@ -8,8 +8,7 @@
 #include "Substitutor.h"
 #include "TreeOps.h"
 
-PTRef UFLATheory::preprocessAfterSubstitutions(PTRef fla, PreprocessingContext const & context) {
-    if (context.perPartition) { throw OsmtInternalException("Mode not supported for QF_UFLRA yet"); }
+PTRef UFLATheory::preprocessAfterSubstitutions(PTRef fla, PreprocessingContext const &) {
     fla = rewriteDistincts(getLogic(), fla);
     fla = rewriteDivMod<ArithLogic>(logic, fla);
     PTRef purified = purify(fla);

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -491,6 +491,11 @@ protected:
     void finalizeResolutionProof(CRef finalConflict);
     std::unique_ptr<ResolutionProof> resolutionProof;                 // (Pointer to) ResolutionProof store
     vec< CRef >         pleaves;                  // Store clauses that are still involved in the proof
+
+    /// Given a clause that is unit under assigment at level 0, creates the actual unit clause and logs its derivation
+    /// @returns CRef of the newly created unit clause
+    /// Assumes that literal at index 0 is unassigned and all other literals are falsified by current assignment
+    CRef logUnitClauseDerivationAtLevelZero(CRef);
     // End of proof production
 
     //

--- a/src/smtsolvers/TheoryIF.cc
+++ b/src/smtsolvers/TheoryIF.cc
@@ -120,9 +120,13 @@ TPropRes CoreSMTSolver::handleNewSplitClauses(SplitClauses & splitClauses) {
             std::swap(splitClause[0],splitClause[impliedIndex]);
             CRef cr = processNewClause(splitClause);
             propData.push_back(PropagationData{.lit = implied, .reason = cr});
+            if (decisionLevel() == 0 and logsResolutionProof()) {
+                CRef unitClause = logUnitClauseDerivationAtLevelZero(cr);
+                propData.back().reason = unitClause;
+            }
             res = TPropRes::Propagate;
         } else {
-            // MB: ensure that that the first literal is not falsified
+            // MB: ensure that the first literal is not falsified
             if (value(splitClause[0]) == l_False and impliedIndex != -1) {
                 std::swap(splitClause[0],splitClause[impliedIndex]);
             }


### PR DESCRIPTION
This PR enables computation of unsat cores for theory combination by supporting computation of resolution proof for theory combination.
This builds on top of changes in #706, which enables per-partition preprocessing.
Besides preprocessing changes, the only missing feature seemed to be handling unit clauses at level 0 computed from splits (theory combination lemmas for interface variables), which is added in this PR (see the corresponding commit message for details).