### PR TITLE
CMake: Bump required version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
-
-if (POLICY CMP0074) # Policy 0074 has been introduced in CMake 3.12, so we need a check, otherwise older version would give an error
-cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_minimum_required(VERSION 3.12)
 
 set(OPENSMT_VERSION_MAJOR 2)
 set(OPENSMT_VERSION_MINOR 7)
@@ -159,25 +155,17 @@ if(PACKAGE_TESTS)
     if (NOT BUILD_SHARED_LIBS)
       message(FATAL_ERROR "Building tests requires shared libraries")
     endif()
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-        MESSAGE(WARNING "Minimum CMAKE version for building tests is 3.11")
-    else(CMAKE_VERSION VERSION_LESS 3.11)
-        enable_testing()
-        add_subdirectory(${PROJECT_SOURCE_DIR}/test)
-        if (PARALLEL)
-            add_subdirectory(${PROJECT_SOURCE_DIR}/parallel-test)
-        endif()
-    endif(CMAKE_VERSION VERSION_LESS 3.11)
+    enable_testing()
+    add_subdirectory(${PROJECT_SOURCE_DIR}/test)
+    if (PARALLEL)
+        add_subdirectory(${PROJECT_SOURCE_DIR}/parallel-test)
+    endif()
 endif()
 #########################################################################
 ################# BENCHMARKING ##########################################
 
 if (PACKAGE_BENCHMARKS)
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-        MESSAGE(WARNING "Minimum CMAKE version for building benchmarking is 3.11")
-    else()
-        add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
-    endif()
+    add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
 endif()
 
 #########################################################################

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,7 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12)
 project(opensmt-examples)
 
 set(CMAKE_CXX_STANDARD 17)
-
-if (POLICY CMP0074) # Policy 0074 has been introduced in CMake 3.12, so we need a check, otherwise older version would give an error
-cmake_policy(SET CMP0074 NEW)
-endif()
 
 set(OpenSMT_DIR CACHE PATH "Path to OpenSMT installation directory")
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -65,7 +65,7 @@ if (BUILD_SHARED_LIBS)
     include(CMakePackageConfigHelpers)
     write_basic_package_version_file( "${CMAKE_CURRENT_BINARY_DIR}/OpenSMTConfigVersion.cmake"
         VERSION ${OPENSMT_VERSION}
-        COMPATIBILITY SameMajorVersion # SameMinorVersion available only from CMake 3.11 
+        COMPATIBILITY SameMinorVersion
     )
 
     configure_package_config_file(OpenSMTConfig.cmake.in


### PR DESCRIPTION
The latest version of CMake at the time of writing is 3.30 and it warns that

"Compatibility with CMake < 3.5 will be removed from a future version of
 CMake."

We need to bump the required CMake version at least to 3.5. However, we have at a few places some configuration that requires CMake >= 3.12. I think it reasonable to bump the required version to that version and simplify our scripts a bit.