### PR TITLE
CMake: Remove workaround and fix order of GMP libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,16 +92,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/itehandler
     ${CMAKE_SOURCE_DIR}/interpolation
     ${CMAKE_SOURCE_DIR}/parallel
+    ${GMP_INCLUDE_DIR}
 )
-
-#######################################################################################################
-# workaround for older versions of CMake where we cannot use target_link_libraries for object libraries
-get_property(GMP_INCLUDE_DIRS TARGET GMP::GMP PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-if (NOT GMP_INCLUDE_DIRS)
-    message(FATAL_ERROR "GMP includes not found")
-endif()
-include_directories(${GMP_INCLUDE_DIRS})
-#######################################################################################################
 
 
 if (BUILD_EXECUTABLES AND NOT BUILD_STATIC_LIBS)

--- a/cmake_modules/FindGMP.cmake
+++ b/cmake_modules/FindGMP.cmake
@@ -41,12 +41,5 @@ if(GMP_FOUND AND NOT TARGET GMP::GMP)
     )
 
     add_library(GMP::GMP INTERFACE IMPORTED)
-    set_property(TARGET GMP::GMP APPEND PROPERTY
-        INTERFACE_LINK_LIBRARIES GMP::GMP_C GMP::GMP_CXX
-    )
-    set_property(TARGET GMP::GMP APPEND PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
-    )
-    # the above command is for compatibillity with old versions of CMAKE, the version below is simpler, but works only from CMake 3.11 
-    #target_link_libraries(GMP::GMP INTERFACE GMP::GMP_C GMP::GMP_CXX)
+    target_link_libraries(GMP::GMP INTERFACE GMP::GMP_CXX GMP::GMP_C)
 endif()


### PR DESCRIPTION
Apparently, order of static libraries when linking into executable can matter, and for GMP the C++ version gmpxx must come before the C version gmp.
On some systems (like Fedora, ArchLinux), this was not the cases, most likely because when creating the wrapper target GMP::GMP, we specified the libraries in the wrong order.