### PR TITLE
CircleCI: used latest Arch Linux for clang-format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
     formatter:
         docker:
-            - image: usiverify/verify-env:ubuntu
+            - image: usiverify/verify-env:archlinux
               auth:
                   username: mydockerhub-user
                   password: $DOCKERHUB_PASSWORD

--- a/src/tsolvers/stpsolver/IDLSolver.h
+++ b/src/tsolvers/stpsolver/IDLSolver.h
@@ -8,7 +8,7 @@
 
 class IDLSolver : public STPSolver<SafeInt> {
 public:
-    IDLSolver(SMTConfig & c, ArithLogic & l) : STPSolver(c, l){};
+    IDLSolver(SMTConfig & c, ArithLogic & l) : STPSolver(c, l) {};
 };
 
 template<>

--- a/src/tsolvers/stpsolver/RDLSolver.h
+++ b/src/tsolvers/stpsolver/RDLSolver.h
@@ -8,7 +8,7 @@
 
 class RDLSolver : public STPSolver<Delta> {
 public:
-    RDLSolver(SMTConfig & c, ArithLogic & l) : STPSolver(c, l){};
+    RDLSolver(SMTConfig & c, ArithLogic & l) : STPSolver(c, l) {};
 };
 
 template<>


### PR DESCRIPTION
The latest Ubuntu image was still not enough for `clang-format` (#744)

See this [PR](https://github.com/usi-verification-and-security/verify-env/pull/6) on `verify-env`.