### PR TITLE
CMake: Do not install redundant file + small cleanup

### DIFF
--- a/src/tsolvers/egraph/CMakeLists.txt
+++ b/src/tsolvers/egraph/CMakeLists.txt
@@ -1,26 +1,21 @@
 target_sources(tsolvers
+PUBLIC "${CMAKE_CURRENT_LIST_DIR}/CgTypes.h"
 PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Egraph.h"
 PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Enode.h"
 PUBLIC "${CMAKE_CURRENT_LIST_DIR}/EnodeStore.h"
-PUBLIC "${CMAKE_CURRENT_LIST_DIR}/CgTypes.h"
+PUBLIC "${CMAKE_CURRENT_LIST_DIR}/InterpolatingEgraph.h"
+PUBLIC "${CMAKE_CURRENT_LIST_DIR}/UFInterpolator.h"
 
+PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphDebug.cc"
+PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphModelBuilder.cc"
+PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphSolver.cc"
 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Enode.cc"
 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EnodeStore.cc"
-PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphSolver.cc"
-PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphDebug.cc"
 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Explainer.cc"
-PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EgraphModelBuilder.cc"
-)
-
-
-target_sources(tsolvers
-    PUBLIC "${CMAKE_CURRENT_LIST_DIR}/UFInterpolator.h"
-    PRIVATE "${CMAKE_CURRENT_LIST_DIR}/UFInterpolator.cc"
-    PUBLIC "${CMAKE_CURRENT_LIST_DIR}/InterpolatingEgraph.h"
-    PRIVATE "${CMAKE_CURRENT_LIST_DIR}/InterpolatingEgraph.cc"
+PRIVATE "${CMAKE_CURRENT_LIST_DIR}/InterpolatingEgraph.cc"
+PRIVATE "${CMAKE_CURRENT_LIST_DIR}/UFInterpolator.cc"
 )
 
 install(FILES
-    ${CMAKE_CURRENT_LIST_DIR}/UFInterpolator.h
     ${CMAKE_CURRENT_LIST_DIR}/CgTypes.h
-DESTINATION ${INSTALL_HEADERS_DIR}//tsolvers/egraph)
+DESTINATION ${INSTALL_HEADERS_DIR}/tsolvers/egraph)


### PR DESCRIPTION
I am pretty sure we do not need to install UFInterpolator.h, it should not be exposed to consumers.

While removing it, I reorganized the corresponding CMakeLists.txt.