### PR TITLE
Extended test_LRALogicMkTerms:ConstantSimplification of 1/3

### DIFF
--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -185,6 +185,9 @@ TEST_F(LRALogicMkTermsTest, test_ConstantSimplification)
     PTRef two = logic.mkConst("2");
     EXPECT_EQ(logic.mkConst("1/2"), logic.mkRealDiv(logic.getTerm_RealOne(), two));
     EXPECT_EQ(two, logic.mkRealDiv(logic.mkConst("4"), two));
+
+    PTRef three = logic.mkConst("3");
+    EXPECT_EQ(logic.mkConst("1/3"), logic.mkRealDiv(logic.getTerm_RealOne(), three));
 }
 
 TEST_F(LRALogicMkTermsTest, test_Inequality_Constant)


### PR DESCRIPTION
Added additional test that checks the case of creating "1/3" instead of just "1/2".
This can catch errors if the implementation of rationals is changed since 1/3 does not have finite representation if the numerator and denominator are not separated (such as with floats).