### PR TITLE
Do not expose ModelBuilder

### DIFF
--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(models OBJECT Model.cc ModelBuilder.cc)
 
-install(FILES Model.h ModelBuilder.h
+install(FILES Model.h 
     DESTINATION ${INSTALL_HEADERS_DIR}/models)


### PR DESCRIPTION
ModelBuilder is an internal detail of how OpenSMT builds SMT models. Users should only have access to the final Model, not to the builder.