### PR TITLE
CMake: Update minimal version and how googletest is fetched

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 set(OPENSMT_VERSION_MAJOR 2)
 set(OPENSMT_VERSION_MINOR 7)

--- a/parallel-test/CMakeLists.txt
+++ b/parallel-test/CMakeLists.txt
@@ -3,14 +3,11 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.11.0
+    GIT_TAG v1.15.2
+    EXCLUDE_FROM_ALL
 )
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+FetchContent_MakeAvailable(googletest)
 
 add_subdirectory(unit)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,14 +3,11 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.14.0
+    GIT_TAG v1.15.2
+    EXCLUDE_FROM_ALL
 )
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+FetchContent_MakeAvailable(googletest)
 
 add_subdirectory(unit)
 


### PR DESCRIPTION
We update googletest to v1.15.2. As part of that we use `FetchContent_MakeAvailable` to fetch it, because our previous way is now deprecated in CMake 3.30.
In order to use the new command, we need to bump minimal CMake version to `3.14`