### PR TITLE
Disable compilation of BV-related files since we do not support BV solving at the moment anyway

### DIFF
--- a/src/logics/CMakeLists.txt
+++ b/src/logics/CMakeLists.txt
@@ -4,13 +4,13 @@ target_sources(logics
 PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/Logic.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/ArithLogic.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/BVLogic.h"
+    #"${CMAKE_CURRENT_SOURCE_DIR}/BVLogic.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/LogicFactory.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/Theory.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/FunctionTools.h"
 PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/LogicFactory.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/BVLogic.cc"
+    #"${CMAKE_CURRENT_SOURCE_DIR}/BVLogic.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/Logic.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/ArrayTheory.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/ArrayHelpers.cc"
@@ -23,5 +23,5 @@ PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/SubstLoopBreaker.cc"
 )
 
-install(FILES LogicFactory.h Theory.h Logic.h ArithLogic.h BVLogic.h FunctionTools.h
+install(FILES LogicFactory.h Theory.h Logic.h ArithLogic.h FunctionTools.h
 DESTINATION ${INSTALL_HEADERS_DIR}/logics)

--- a/src/logics/Theory.h
+++ b/src/logics/Theory.h
@@ -26,7 +26,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef THEORY_H
 #define THEORY_H
 
-#include "BVLogic.h"
 #include "Logic.h"
 
 #include <api/PartitionManager.h>

--- a/src/tsolvers/CMakeLists.txt
+++ b/src/tsolvers/CMakeLists.txt
@@ -27,7 +27,7 @@ PRIVATE
 
 include(egraph/CMakeLists.txt)
 include(lasolver/CMakeLists.txt)
-include(bvsolver/CMakeLists.txt)
+#include(bvsolver/CMakeLists.txt)
 include(stpsolver/CMakeLists.txt)
 include(arraysolver/CMakeLists.txt)
 


### PR DESCRIPTION
We can revive these files if #601 is successfully finished.
However, currently we do not support any way for the user to use BV solving, so it does not make sense to keep compiling these files.