### PR TITLE
Efficient iterating and views on `TermNames`

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -625,8 +625,7 @@ bool Interpret::getAssignment() {
     std::ostringstream ss;
     auto const & termNames = main_solver->getTermNames();
     ss << '(';
-    for (auto const & name : termNames) {
-        PTRef term = termNames.termByName(name);
+    for (auto const & [name, term] : termNames) {
         lbool val = main_solver->getTermValue(term);
         ss << '(' << name << ' ' << (val == l_True ? "true" : (val == l_False ? "false" : "unknown")) << ')' << " ";
     }
@@ -1303,8 +1302,7 @@ void Interpret::getInterpolants(const ASTNode& n)
     LetRecords letRecords;
     letRecords.pushFrame();
     auto const & termNames = main_solver->getTermNames();
-    for (auto const & name : termNames) {
-        PTRef term = termNames.termByName(name);
+    for (auto const & [name, term] : termNames) {
         letRecords.addBinding(name, term);
     }
     for (auto e : exps) {

--- a/src/common/ScopedVector.h
+++ b/src/common/ScopedVector.h
@@ -17,6 +17,9 @@ class ScopedVector {
     std::vector<unsigned> limits;
 
 public:
+    using iterator = typename decltype(elements)::iterator;
+    using const_iterator = typename decltype(elements)::const_iterator;
+
     void push(T const & element) { return elements.push_back(element); }
 
     void pushScope() { limits.push_back(elements.size()); }
@@ -26,6 +29,7 @@ public:
     template<typename TFun>
     void popScope(TFun callback);
 
+    [[nodiscard]] bool empty() const { return elements.empty(); }
     [[nodiscard]] std::size_t size() const { return elements.size(); }
 
     [[nodiscard]] T * data() { return elements.data(); }


### PR DESCRIPTION
It is often necessary to iterate over all pairs of names and terms of `TermNames`. Previously this was done by looking up the term for each name, which is inefficient. The proposed method has just linear complexity of such iterations.

Furthermore, the PR offers to also iterate only over names or only over terms, which, if the pairs are not desired, is even more efficient.