### PR TITLE
Sorting xor-args in ascending order (same as others)

### DIFF
--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -467,7 +467,7 @@ PTRef Logic::mkXor(vec<PTRef> && args) {
     else if (args[0] == getTerm_false() || args[1] == getTerm_false())
         return (args[0] == getTerm_false() ? args[1] : args[0]);
 
-    sort(args, std::greater<PTRef>{});
+    termSort(args);
     tr = mkFun(getSym_xor(), std::move(args));
 
     if (tr == PTRef_Undef) {


### PR DESCRIPTION
I really do not know why it was previously sorted in descending order.
It seems to be an old line of code from the times before versioning using GitHub.

I only found that xors are handled in `Tseitin.cc` and `Logic.cc:getNewFacts`, but it does not seem that the order has any special meaning...

I believe that the fix should be just fine.