### PR TITLE
Add Github action for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release Workflow
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-builds-osx:
+    strategy:
+      matrix:
+        include:
+          - os: macos-14
+            suffix: arm-osx
+          - os: macos-13
+            suffix: x64-osx
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up build environment
+        run: |
+          brew install bison
+          brew install flex
+          echo "/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/opt/flex/bin:/usr/local/opt/bison/bin" >> "$GITHUB_PATH"
+
+      - name: Build project
+        run: |
+          ./ci/build_for_release.sh
+          mv ./build/opensmt.tar.bz2 ./opensmt-${{ matrix.suffix }}.tar.bz2
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./opensmt-${{ matrix.suffix }}.tar.bz2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bison cmake flex libgmp-dev
+
+      - name: Build project
+        run: |
+          ./ci/build_for_release.sh
+          mv ./build/opensmt.tar.bz2 ./opensmt-x64-linux.tar.bz2
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./opensmt-x64-linux.tar.bz2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/build_for_release.sh
+++ b/ci/build_for_release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set environment variables
+export CMAKE_BUILD_TYPE="Release"
+export PARALLEL="OFF"
+export ENABLE_LINE_EDITING="FALSE"
+
+# Delegate to appropriate script with environment variables correctly set
+"$SCRIPT_DIR/build_maximally_static.sh"


### PR DESCRIPTION
This adds a GitHub action that we can use to automatically build and upload binaries once a release is published.
The drafting of the release and its publication is still manual, but that is OK since we want to have control over that process.