### PR TITLE
CI: check that the static Linux build is indeed static

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,9 @@ jobs:
             - checkout
             - run:
                 name: Release static build gcc in Fedora
-                command: ./ci/build_maximally_static.sh
+                command: |
+                  ./ci/build_maximally_static.sh
+                  ! ldd ./build/opensmt
 
     build-macos:
         macos:


### PR DESCRIPTION
We require that the linkage of the produced binary contains no dynamic libraries. For that, we use the exit status of `ldd` (since it is Linux), which fails if no dynamic libraries are present. Hence we negate the exit status with `!`.