### PR TITLE
`MainSolver` API for assertion levels of the assertion stack

### DIFF
--- a/src/parallel/MainSplitter.cc
+++ b/src/parallel/MainSplitter.cc
@@ -125,7 +125,8 @@ bool MainSplitter::verifyPartitions(vec<PTRef> const & partitions) const {
             ok = false;
         } else {
             // Removing the models of the partial partitions from the root instance must yield unsat
-            if (not verifier.impliesInternal(logic.mkAnd(partitionCoverageQuery), logic.mkNot(currentRootInstance()))) {
+            PTRef currentRootInstance = logic.mkAnd(getCurrentAssertions());
+            if (not verifier.impliesInternal(logic.mkAnd(partitionCoverageQuery), logic.mkNot(currentRootInstance))) {
                 error += "[Non-covering partial partitioning: partial partitions do not contain all models of original instance] ";
                 ok = false;
             }


### PR DESCRIPTION
Consistently referring to "assertion stack" (from SMT-LIB 2.6) within the API of `MainSolver` instead of "frames" which is not known outside of OpenSMT community.
I also added methods to access assertions of the assertion stack. The API offers both a copy of all the assertions and also just a view to the assertions, which is more suitable when one wants to just iterate over the assertions of get their count. However, the view is not implemented yet.