### PR TITLE
Treat named and full unsat cores separately but with common interface

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -1284,22 +1284,7 @@ void Interpret::getProof()
 
 void Interpret::getUnsatCore() {
     auto const unsatCore = main_solver->getUnsatCore();
-    std::cout << "(\n";
-    auto const & termNames = main_solver->getTermNames();
-    if (not config.print_cores_full()) {
-        // this is the default: we care only about ':named' terms and their names
-        for (PTRef fla : unsatCore->getNamedTerms()) {
-            assert(termNames.contains(fla));
-            auto const & name = termNames.nameForTerm(fla);
-            std::cout << name << '\n';
-        }
-    } else {
-        // we explicitly asked to include all terms and to ignore ':named' terms at all
-        for (PTRef fla : unsatCore->getTerms()) {
-            std::cout << logic->printTerm(fla) << '\n';
-        }
-    }
-    std::cout << ')' << std::endl;
+    unsatCore->print();
 }
 
 void Interpret::getInterpolants(const ASTNode& n)

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -272,8 +272,7 @@ std::unique_ptr<UnsatCore> MainSolver::getUnsatCore() const {
     if (not config.produce_unsat_cores()) { throw ApiException("Producing unsat cores is not enabled"); }
     if (status != s_False) { throw ApiException("Unsat core cannot be extracted if solver is not in UNSAT state"); }
 
-    auto & proof = smt_solver->getResolutionProof();
-    UnsatCoreBuilder unsatCoreBuilder{config, logic, proof, pmanager, termNames};
+    UnsatCoreBuilder unsatCoreBuilder{*this};
 
     return unsatCoreBuilder.build();
 }

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -138,6 +138,8 @@ public:
     static std::unique_ptr<Theory> createTheory(Logic & logic, SMTConfig & config);
 
 protected:
+    friend class UnsatCoreBuilderBase;
+
     using FrameId = uint32_t;
 
     struct PushFrame {

--- a/src/common/TermNames.h
+++ b/src/common/TermNames.h
@@ -2,9 +2,12 @@
 #define OPENSMT_TERMNAMES_H
 
 #include "ScopedVector.h"
+#include "TypeUtils.h"
 
+#include <options/SMTConfig.h>
 #include <pterms/PTRef.h>
 
+#include <algorithm>
 #include <optional>
 #include <string>
 #include <type_traits>

--- a/src/unsatcores/CMakeLists.txt
+++ b/src/unsatcores/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(unsatcores
 PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/UnsatCore.h"
 PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/UnsatCore.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/UnsatCoreBuilder.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/UnsatCoreBuilder.cc"
 )

--- a/src/unsatcores/UnsatCore.cc
+++ b/src/unsatcores/UnsatCore.cc
@@ -1,0 +1,44 @@
+#include "UnsatCore.h"
+
+#include <common/TermNames.h>
+#include <logics/Logic.h>
+
+#include <iostream>
+
+namespace opensmt {
+
+void UnsatCore::print() const {
+    print(std::cout);
+}
+
+void UnsatCore::print(std::ostream & os) const {
+    printBegin(os);
+    printBody(os);
+    printEnd(os);
+}
+
+void UnsatCore::printBegin(std::ostream & os) const {
+    os << "(\n";
+}
+
+void UnsatCore::printBody(std::ostream & os) const {
+    for (PTRef term : getTerms()) {
+        printTerm(os, term);
+        os << '\n';
+    }
+}
+
+void UnsatCore::printEnd(std::ostream & os) const {
+    os << ')' << std::endl;
+}
+
+void NamedUnsatCore::printTerm(std::ostream & os, PTRef term) const {
+    assert(termNames.contains(term));
+    os << termNames.nameForTerm(term);
+}
+
+void FullUnsatCore::printTerm(std::ostream & os, PTRef term) const {
+    os << logic.printTerm(term);
+}
+
+} // namespace opensmt

--- a/src/unsatcores/UnsatCore.h
+++ b/src/unsatcores/UnsatCore.h
@@ -4,25 +4,77 @@
 #include <minisat/mtl/Vec.h>
 #include <pterms/PTRef.h>
 
+#include <iosfwd>
+
 namespace opensmt {
+
+class Logic;
+class TermNames;
 
 class UnsatCore {
 public:
-    friend class UnsatCoreBuilder;
+    virtual ~UnsatCore() = default;
 
-    vec<PTRef> const & getTerms() const { return terms; }
-    vec<PTRef> const & getNamedTerms() const { return namedTerms; }
+    virtual vec<PTRef> const & getTerms() const = 0;
+
+    void print() const;
+    void print(std::ostream &) const;
 
 protected:
-    inline UnsatCore(vec<PTRef> && terms_, vec<PTRef> && namedTerms_);
+    UnsatCore() = default;
 
-    vec<PTRef> terms;
-    vec<PTRef> namedTerms;
+    void printBegin(std::ostream &) const;
+    void printBody(std::ostream &) const;
+    void printEnd(std::ostream &) const;
+
+    virtual void printTerm(std::ostream &, PTRef) const = 0;
 };
 
-UnsatCore::UnsatCore(vec<PTRef> && terms_, vec<PTRef> && namedTerms_)
-    : terms{std::move(terms_)},
-      namedTerms{std::move(namedTerms_)} {
+class NamedUnsatCore : public UnsatCore {
+public:
+    vec<PTRef> const & getTerms() const override { return namedTerms; }
+
+    vec<PTRef> const & getHiddenTerms() const { return hiddenTerms; }
+
+protected:
+    friend class UnsatCoreBuilder;
+
+    inline NamedUnsatCore(TermNames const &, vec<PTRef> && namedTerms_, vec<PTRef> && hiddenTerms_);
+
+    void printTerm(std::ostream &, PTRef) const override;
+
+    TermNames const & termNames;
+
+    vec<PTRef> namedTerms;
+    vec<PTRef> hiddenTerms;
+};
+
+class FullUnsatCore : public UnsatCore {
+public:
+    vec<PTRef> const & getTerms() const override { return terms; }
+
+protected:
+    friend class UnsatCoreBuilder;
+
+    inline FullUnsatCore(Logic const &, vec<PTRef> && terms_);
+
+    void printTerm(std::ostream &, PTRef) const override;
+
+    Logic const & logic;
+
+    vec<PTRef> terms;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+NamedUnsatCore::NamedUnsatCore(TermNames const & termNames_, vec<PTRef> && namedTerms_, vec<PTRef> && hiddenTerms_)
+    : termNames{termNames_},
+      namedTerms{std::move(namedTerms_)},
+      hiddenTerms{std::move(hiddenTerms_)} {
+    assert(namedTerms.size() > 0 || hiddenTerms.size() > 0);
+}
+
+FullUnsatCore::FullUnsatCore(Logic const & logic_, vec<PTRef> && terms_) : logic{logic_}, terms{std::move(terms_)} {
     assert(terms.size() > 0);
 }
 

--- a/test/unit/test_UnsatCore.cc
+++ b/test/unit/test_UnsatCore.cc
@@ -51,6 +51,39 @@ protected:
     }
 };
 
+template <typename LogicT>
+class FullUnsatCoreTestBase {
+protected:
+    FullUnsatCoreTestBase(Logic_t type) : logic{type} {}
+
+    LogicT logic;
+    SMTConfig config;
+
+    MainSolver makeSolver() {
+        const char* msg = "ok";
+        config.setOption(SMTConfig::o_produce_unsat_cores, SMTOption(true), msg);
+        config.setOption(SMTConfig::o_print_cores_full, SMTOption(true), msg);
+        return {logic, config, "unsat_core"};
+    }
+};
+
+template <typename LogicT>
+class MinFullUnsatCoreTestBase {
+protected:
+    MinFullUnsatCoreTestBase(Logic_t type) : logic{type} {}
+
+    LogicT logic;
+    SMTConfig config;
+
+    MainSolver makeSolver() {
+        const char* msg = "ok";
+        config.setOption(SMTConfig::o_produce_unsat_cores, SMTOption(true), msg);
+        config.setOption(SMTConfig::o_print_cores_full, SMTOption(true), msg);
+        config.setOption(SMTConfig::o_minimal_unsat_cores, SMTOption(true), msg);
+        return {logic, config, "unsat_core"};
+    }
+};
+
 /// Pure propositional and uninterpreted functions
 template <template<typename> typename TestBaseT>
 class UFUnsatCoreTestTp : public ::testing::Test, public TestBaseT<Logic> {
@@ -85,12 +118,18 @@ protected:
 
 using UFUnsatCoreTest = UFUnsatCoreTestTp<UnsatCoreTestBase>;
 using MinUFUnsatCoreTest = UFUnsatCoreTestTp<MinUnsatCoreTestBase>;
+using FullUFUnsatCoreTest = UFUnsatCoreTestTp<FullUnsatCoreTestBase>;
+using MinFullUFUnsatCoreTest = UFUnsatCoreTestTp<MinFullUnsatCoreTestBase>;
 
 TEST_F(UFUnsatCoreTest, Bool_Simple) {
     MainSolver solver = makeSolver();
     solver.insertFormula(b1);
     solver.insertFormula(b2);
     solver.insertFormula(nb1);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", b1);
+    termNames.insert("a2", b2);
+    termNames.insert("a3", nb1);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -112,7 +151,7 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(b1, coreTerms));
     EXPECT_TRUE(isInCore(nb1, coreTerms));
@@ -129,7 +168,7 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed1) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 1);
     EXPECT_FALSE(isInCore(b1, coreTerms));
     EXPECT_TRUE(isInCore(nb1, coreTerms));
@@ -146,7 +185,7 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed2) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(b1, coreTerms));
     EXPECT_TRUE(isInCore(nb1, coreTerms));
@@ -163,10 +202,89 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed3) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 1);
     EXPECT_TRUE(isInCore(b1, coreTerms));
     EXPECT_FALSE(isInCore(nb1, coreTerms));
+}
+
+TEST_F(FullUFUnsatCoreTest, Full_Bool_Simple) {
+    MainSolver solver = makeSolver();
+    solver.insertFormula(b1);
+    solver.insertFormula(b2);
+    solver.insertFormula(nb1);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(b1, coreTerms));
+    EXPECT_TRUE(isInCore(nb1, coreTerms));
+}
+
+TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple) {
+    MainSolver solver = makeSolver();
+    solver.insertFormula(b1);
+    solver.insertFormula(b2);
+    solver.insertFormula(nb1);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(b1, coreTerms));
+    EXPECT_TRUE(isInCore(nb1, coreTerms));
+}
+
+TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed1) {
+    MainSolver solver = makeSolver();
+    solver.insertFormula(b1);
+    solver.insertFormula(b2);
+    solver.insertFormula(nb1);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a2", b2);
+    termNames.insert("a3", nb1);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(b1, coreTerms));
+    EXPECT_TRUE(isInCore(nb1, coreTerms));
+}
+
+TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed2) {
+    MainSolver solver = makeSolver();
+    solver.insertFormula(b1);
+    solver.insertFormula(b2);
+    solver.insertFormula(nb1);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", b1);
+    termNames.insert("a3", nb1);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(b1, coreTerms));
+    EXPECT_TRUE(isInCore(nb1, coreTerms));
+}
+
+TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed3) {
+    MainSolver solver = makeSolver();
+    solver.insertFormula(b1);
+    solver.insertFormula(b2);
+    solver.insertFormula(nb1);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", b1);
+    termNames.insert("a2", b2);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(b1, coreTerms));
+    EXPECT_TRUE(isInCore(nb1, coreTerms));
 }
 
 TEST_F(UFUnsatCoreTest, Bool_ReuseProofChain) {
@@ -185,6 +303,10 @@ TEST_F(UFUnsatCoreTest, Bool_ReuseProofChain) {
     solver.insertFormula(a1);
     solver.insertFormula(a2);
     solver.insertFormula(b4);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", b4);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -218,7 +340,33 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_ReuseProofChain) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
+    EXPECT_TRUE(isInCore(a2, coreTerms));
+    EXPECT_FALSE(isInCore(b4, coreTerms));
+}
+
+TEST_F(FullUFUnsatCoreTest, Full_Bool_ReuseProofChain) {
+    // We add three assertions
+    // a1 := (b1 or b2) and (b1 or ~b2)
+    // a2 := (~b1 or b3) and (~b1 or ~b3)
+    // a3 := b4
+    // The first two assertions form the unsat core.
+    MainSolver solver = makeSolver();
+    PTRef c1 = logic.mkOr(b1, b2);
+    PTRef c2 = logic.mkOr(b1, nb2);
+    PTRef c3 = logic.mkOr(nb1, b3);
+    PTRef c4 = logic.mkOr(nb1, nb3);
+    PTRef a1 = logic.mkAnd(c1,c2);
+    PTRef a2 = logic.mkAnd(c3,c4);
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(b4);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_TRUE(isInCore(a2, coreTerms));
@@ -236,6 +384,10 @@ TEST_F(UFUnsatCoreTest, UF_Simple) {
     solver.insertFormula(a1);
     solver.insertFormula(a2);
     solver.insertFormula(a3);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -264,7 +416,7 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_FALSE(isInCore(a2, coreTerms));
@@ -288,7 +440,7 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed1) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 1);
     EXPECT_FALSE(isInCore(a1, coreTerms));
     EXPECT_FALSE(isInCore(a2, coreTerms));
@@ -312,7 +464,7 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed2) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_FALSE(isInCore(a2, coreTerms));
@@ -336,11 +488,32 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed3) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 1);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_FALSE(isInCore(a2, coreTerms));
     EXPECT_FALSE(isInCore(a3, coreTerms));
+}
+
+TEST_F(FullUFUnsatCoreTest, Full_UF_Simple) {
+    // a1 := x = y
+    // a2 := g(x,y) = g(y,x)
+    // a3 := f(x) != f(y)
+    MainSolver solver = makeSolver();
+    PTRef a1 = logic.mkEq(x,y);
+    PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
+    PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(a3);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
+    EXPECT_FALSE(isInCore(a2, coreTerms));
+    EXPECT_TRUE(isInCore(a3, coreTerms));
 }
 
 TEST_F(UFUnsatCoreTest, Bool_Simple_Overlap) {
@@ -351,6 +524,10 @@ TEST_F(UFUnsatCoreTest, Bool_Simple_Overlap) {
     solver.insertFormula(a1);
     solver.insertFormula(a2);
     solver.insertFormula(a3);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -376,9 +553,27 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Overlap) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_FALSE(isInCore(a1, coreTerms));
+    EXPECT_TRUE(isInCore(a2, coreTerms));
+    EXPECT_TRUE(isInCore(a3, coreTerms));
+}
+
+TEST_F(FullUFUnsatCoreTest, Full_Bool_Simple_Overlap) {
+    MainSolver solver = makeSolver();
+    PTRef a1 = b1;
+    PTRef a2 = logic.mkAnd(b1, b2);
+    PTRef a3 = logic.mkOr(logic.mkNot(b1), logic.mkNot(b2));
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(a3);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 3);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_TRUE(isInCore(a2, coreTerms));
     EXPECT_TRUE(isInCore(a3, coreTerms));
 }
@@ -409,6 +604,7 @@ protected:
 
 using AXUnsatCoreTest = AXUnsatCoreTestTp<UnsatCoreTestBase>;
 using MinAXUnsatCoreTest = AXUnsatCoreTestTp<MinUnsatCoreTestBase>;
+using FullAXUnsatCoreTest = AXUnsatCoreTestTp<FullUnsatCoreTestBase>;
 
 TEST_F(AXUnsatCoreTest, AX_Simple) {
     // a1 := i != j
@@ -421,6 +617,10 @@ TEST_F(AXUnsatCoreTest, AX_Simple) {
     solver.insertFormula(a1);
     solver.insertFormula(a2);
     solver.insertFormula(a3);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -449,7 +649,28 @@ TEST_F(AXUnsatCoreTest, Min_AX_Simple) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
+    EXPECT_TRUE(isInCore(a2, coreTerms));
+    EXPECT_FALSE(isInCore(a3, coreTerms));
+}
+
+TEST_F(FullAXUnsatCoreTest, Full_AX_Simple) {
+    // a1 := i != j
+    // a2 := a[j] != a<i -> e>[j]
+    // a3 := a[k] = e
+    MainSolver solver = makeSolver();
+    PTRef a1 = logic.mkNot(logic.mkEq(i,j));
+    PTRef a2 = logic.mkNot(logic.mkEq(logic.mkSelect({a,j}), logic.mkSelect({logic.mkStore({a,i,e}),j})));
+    PTRef a3 = logic.mkEq(logic.mkSelect({a,k}), e);
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(a3);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_TRUE(isInCore(a2, coreTerms));
@@ -486,6 +707,7 @@ protected:
 
 using LIAUnsatCoreTest = LIAUnsatCoreTestTp<UnsatCoreTestBase>;
 using MinLIAUnsatCoreTest = LIAUnsatCoreTestTp<MinUnsatCoreTestBase>;
+using FullLIAUnsatCoreTest = LIAUnsatCoreTestTp<FullUnsatCoreTestBase>;
 
 TEST_F(LIAUnsatCoreTest, LIA_Simple) {
     // a1 := x >= y
@@ -501,6 +723,11 @@ TEST_F(LIAUnsatCoreTest, LIA_Simple) {
     solver.insertFormula(a2);
     solver.insertFormula(a3);
     solver.insertFormula(a4);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", a3);
+    termNames.insert("a4", a4);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -534,7 +761,32 @@ TEST_F(LIAUnsatCoreTest, Min_LIA_Simple) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 3);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
+    EXPECT_TRUE(isInCore(a2, coreTerms));
+    EXPECT_FALSE(isInCore(a3, coreTerms));
+    EXPECT_TRUE(isInCore(a4, coreTerms));
+}
+
+TEST_F(FullLIAUnsatCoreTest, Full_LIA_Simple) {
+    // a1 := x >= y
+    // a2 := y >= z
+    // a3 := x + y + z < 0
+    // a4 := x < z
+    MainSolver solver = makeSolver();
+    PTRef a1 = logic.mkGeq(x,y);
+    PTRef a2 = logic.mkGeq(y,z);
+    PTRef a3 = logic.mkLt(logic.mkPlus(vec<PTRef>{x,y,z}), logic.getTerm_IntZero());
+    PTRef a4 = logic.mkLt(x,z);
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(a3);
+    solver.insertFormula(a4);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 3);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_TRUE(isInCore(a2, coreTerms));
@@ -576,6 +828,7 @@ protected:
 
 using ALIAUnsatCoreTest = ALIAUnsatCoreTestTp<UnsatCoreTestBase>;
 using MinALIAUnsatCoreTest = ALIAUnsatCoreTestTp<MinUnsatCoreTestBase>;
+using FullALIAUnsatCoreTest = ALIAUnsatCoreTestTp<FullUnsatCoreTestBase>;
 
 TEST_F(ALIAUnsatCoreTest, ALIA_Simple) {
     // a1 := select(arr1, x) != select(arr1,y)
@@ -588,6 +841,10 @@ TEST_F(ALIAUnsatCoreTest, ALIA_Simple) {
     solver.insertFormula(a1);
     solver.insertFormula(a2);
     solver.insertFormula(a3);
+    auto & termNames = solver.getTermNames();
+    termNames.insert("a1", a1);
+    termNames.insert("a2", a2);
+    termNames.insert("a3", a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -616,7 +873,28 @@ TEST_F(ALIAUnsatCoreTest, Min_ALIA_Simple) {
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
-    auto & coreTerms = core->getNamedTerms();
+    auto & coreTerms = core->getTerms();
+    ASSERT_EQ(coreTerms.size(), 2);
+    EXPECT_TRUE(isInCore(a1, coreTerms));
+    EXPECT_FALSE(isInCore(a2, coreTerms));
+    EXPECT_TRUE(isInCore(a3, coreTerms));
+}
+
+TEST_F(FullALIAUnsatCoreTest, Full_ALIA_Simple) {
+    // a1 := select(arr1, x) != select(arr1,y)
+    // a2 := select(arr1, x) == 0
+    // a3 := x == y
+    MainSolver solver = makeSolver();
+    PTRef a1 = logic.mkNot(logic.mkEq(logic.mkSelect({arr1, x}), logic.mkSelect({arr1,y})));
+    PTRef a2 = logic.mkEq(logic.mkSelect({arr1,x}), logic.getTerm_IntZero());
+    PTRef a3 = logic.mkEq(x,y);
+    solver.insertFormula(a1);
+    solver.insertFormula(a2);
+    solver.insertFormula(a3);
+    auto res = solver.check();
+    ASSERT_EQ(res, s_False);
+    auto core = solver.getUnsatCore();
+    auto & coreTerms = core->getTerms();
     ASSERT_EQ(coreTerms.size(), 2);
     EXPECT_TRUE(isInCore(a1, coreTerms));
     EXPECT_FALSE(isInCore(a2, coreTerms));


### PR DESCRIPTION
Also moved printing from `Interpret` to `UnsatCore` and divided minimization into a separate class `Minimize`.