### PR TITLE
CI: Update macos environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
 
     build-macos:
         macos:
-            xcode: 14.2.0
+            xcode: 15.4.0
         resource_class: macos.m1.medium.gen1
         steps:
             - run:


### PR DESCRIPTION
It is important to keep updating the environment, otherwise, homebrew may not have ready-to-pour packages any more (e.g. CMake).