### PR TITLE
Removed problematic use of `move_iterator`s

### DIFF
--- a/src/tsolvers/lasolver/Polynomial.h
+++ b/src/tsolvers/lasolver/Polynomial.h
@@ -100,9 +100,9 @@ void PolynomialT<VarType>::merge(PolynomialT<VarType> const & other, Real const 
         tmp_storage.resize(this->poly.size() + other.poly.size(), Term(VarType::Undef, 0));
     }
     std::size_t storageIndex = 0;
-    auto myIt = std::make_move_iterator(poly.begin());
+    auto myIt = poly.begin();
     auto otherIt = other.poly.cbegin();
-    auto myEnd = std::make_move_iterator(poly.end());
+    auto myEnd = poly.end();
     auto otherEnd = other.poly.cend();
     TermCmp cmp;
     Real tmp;
@@ -122,7 +122,7 @@ void PolynomialT<VarType>::merge(PolynomialT<VarType> const & other, Real const 
             break;
         }
         if (cmp(*myIt, *otherIt)) {
-            tmp_storage[storageIndex] = *myIt;
+            tmp_storage[storageIndex] = std::move(*myIt);
             ++storageIndex;
             ++myIt;
         }
@@ -141,7 +141,7 @@ void PolynomialT<VarType>::merge(PolynomialT<VarType> const & other, Real const 
                 informRemoved(myIt->var);
             }
             else {
-                tmp_storage[storageIndex] = *myIt;
+                tmp_storage[storageIndex] = std::move(*myIt);
                 ++storageIndex;
             }
             ++myIt;


### PR DESCRIPTION
`std::move` does not require that the argument iterators are `move_iterator`s.
(It would be necessary only if `std::copy` was used: [example](https://stackoverflow.com/questions/26432990/are-stdmove-and-stdcopy-identical)).
Furthermore, `move_iterator` should not be dereferenced more than once: [cppreference](https://en.cppreference.com/w/cpp/iterator/move_iterator/operator*).