### PR TITLE
Model: Add a simple method to extend a model with value for a new variable

### DIFF
--- a/src/models/Model.h
+++ b/src/models/Model.h
@@ -1,16 +1,20 @@
-//
-// Created by Martin Blicha on 12.06.20.
-//
+/*
+ * Copyright (c) 2020-2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+#ifndef OPENSMT_MODEL_H
+#define OPENSMT_MODEL_H
 
 #include <logics/Logic.h>
 #include <pterms/PTRef.h>
 
-#include <algorithm>
 #include <cassert>
+#include <memory>
+#include <span>
 #include <unordered_map>
-
-#ifndef OPENSMT_MODEL_H
-#define OPENSMT_MODEL_H
 
 namespace opensmt {
 class Model {
@@ -25,6 +29,9 @@ public:
     static std::string getFormalArgBaseNameForSymbol(
         Logic const & logic, SymRef sr,
         std::string const & formalArgDefaultPrefix); // Return a string that is not equal to the argument
+
+    [[nodiscard]] std::unique_ptr<Model> extend(std::span<std::pair<PTRef, PTRef>> extension) const;
+    [[nodiscard]] std::unique_ptr<Model> extend(PTRef var, PTRef val) const;
 
 private:
     bool isCorrect(SymbolDefinition const & defs) const;

--- a/test/unit/test_Model.cc
+++ b/test/unit/test_Model.cc
@@ -1,6 +1,9 @@
-//
-// Created by Martin Blicha on 14.06.20.
-//
+/*
+ * Copyright (c) 2020-2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
 
 #include <gtest/gtest.h>
 #include <logics/ArithLogic.h>
@@ -227,7 +230,7 @@ protected:
                 std::make_pair(a, logic.getTerm_true()),
                 std::make_pair(b, logic.getTerm_false())
         };
-        return std::unique_ptr<Model>(new Model(logic, eval));
+        return std::make_unique<Model>(logic, eval);
     }
 };
 
@@ -301,7 +304,18 @@ TEST_F(LAModelTest, test_distinctOperator) {
 
     PTRef distinct = logic.mkDistinct({logic.getTerm_RealZero(), logic.getTerm_RealMinusOne(), x});
     EXPECT_EQ(model->evaluate(distinct), tval);
+}
 
+TEST_F(LAModelTest, test_extendModel) {
+    auto model = getModel();
+    PTRef fresh = logic.mkRealVar("fresh");
+    PTRef five = logic.mkRealConst(5);
+    auto extended = model->extend(fresh, five);
+    EXPECT_EQ(extended->evaluate(x), model->evaluate(x));
+    EXPECT_EQ(extended->evaluate(y), model->evaluate(y));
+    EXPECT_EQ(extended->evaluate(z), model->evaluate(z));
+    EXPECT_NE(model->evaluate(fresh), five);
+    EXPECT_EQ(extended->evaluate(fresh), five);
 }
 
 


### PR DESCRIPTION
This functionality is helpful for Golem and could be interesting for others as well. By adding the possibility of extension, we do not need to expose ModelBuilder to the outside world.