### PR TITLE
Fixed CMake definition of the executable regarding the version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,12 +125,6 @@ endif()
 
 add_subdirectory(${CMAKE_SOURCE_DIR})
 
-
-target_compile_definitions(OpenSMT-bin PRIVATE
-        OPENSMT_GIT_DESCRIPTION="${OPENSMT_GIT_DESCRIPTION}"
-)
-
-
 ################# TESTING #############################################
 if(PACKAGE_TESTS)
     if (NOT BUILD_SHARED_LIBS)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -10,6 +10,10 @@ if (ENABLE_LINE_EDITING)
     target_link_libraries(OpenSMT-bin PUBLIC LibEdit::LibEdit)
 endif()
 
+target_compile_definitions(OpenSMT-bin PRIVATE
+    OPENSMT_GIT_DESCRIPTION="${OPENSMT_GIT_DESCRIPTION}"
+)
+
 target_link_libraries(OpenSMT-bin PUBLIC OpenSMT-static)
 
 


### PR DESCRIPTION
The build fails with `cmake -DBUILD_EXECUTABLES=OFF ..` because the definition of `OPENSMT_GIT_DESCRIPTION` is not conditioned by `BUILD_EXECUTABLES` and rule `OpenSMT-bin` does not exist without the parameter.
Hence I moved the definition into the `CMakeLists.txt` that concerns the binary specifically and is already conditioned.