### PR TITLE
Included `cassert` in standalone headers

### DIFF
--- a/src/common/Random.h
+++ b/src/common/Random.h
@@ -8,6 +8,8 @@
 #ifndef OPENSMT_RANDOM_H
 #define OPENSMT_RANDOM_H
 
+#include <cassert>
+
 namespace opensmt {
 // Returns a random float 0 <= x < 1. Seed must never be 0.
 static inline double drand(double & seed) {

--- a/src/common/ScopedVector.h
+++ b/src/common/ScopedVector.h
@@ -8,6 +8,7 @@
 #ifndef OPENSMT_SCOPEDVECTOR_H
 #define OPENSMT_SCOPEDVECTOR_H
 
+#include <cassert>
 #include <vector>
 
 namespace opensmt {

--- a/src/common/SplayTree.h
+++ b/src/common/SplayTree.h
@@ -35,6 +35,8 @@ stored and the comparison function C
 #ifndef SPLAY_TREE_H
 #define SPLAY_TREE_H
 
+#include <cassert>
+
 template <class T, class C >
 class SplayTree
 {

--- a/src/common/numbers/NumberUtils.h
+++ b/src/common/numbers/NumberUtils.h
@@ -8,6 +8,8 @@
 #ifndef OPENSMT_NUMBERUTILS_H
 #define OPENSMT_NUMBERUTILS_H
 
+#include <cassert>
+
 #include <gmp.h>
 #include <gmpxx.h>
 


### PR DESCRIPTION
I failed to build OpenSMT as an external library when I swapped the order of `StringConv.h` and `NumberUtils.h`. The reason is that some headers use assertions but do not include `<cassert>`, even indirectly via other headers.