### PR TITLE
Replaced non-const `getTermNames` by `tryAddNamedAssertion`/`tryAddTermNameFor`

### DIFF
--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -531,14 +531,14 @@ PTRef Interpret::parseTerm(const ASTNode& term, LetRecords& letRecords) {
         if (tr == PTRef_Undef) return tr;
 
         if (strcmp(name_attr.getValue(), ":named") == 0) {
-            auto & termNames = main_solver->getTermNames();
             ASTNode& sym = **(name_attr.children->begin());
             assert(sym.getType() == SYM_T or sym.getType() == QSYM_T);
-            if (termNames.contains(sym.getValue())) {
-                notify_formatted(true, "name %s already exists", sym.getValue());
+            char const * str = sym.getValue();
+            bool const success = main_solver->tryAddTermNameFor(tr, str);
+            if (not success) {
+                notify_formatted(true, "name %s already exists", str);
                 return PTRef_Undef;
             }
-            termNames.insert(sym.getValue(), tr);
         }
         return tr;
     }

--- a/src/api/Interpret.h
+++ b/src/api/Interpret.h
@@ -173,8 +173,8 @@ class Interpret {
     void                        getInterpolants(const ASTNode& n);
     void                        interp (ASTNode& n);
 
-    void                        notify_formatted(bool error, const char* s, ...);
-    void                        notify_success();
+    void                        notify_formatted(bool error, const char* s, ...) const;
+    void                        notify_success() const;
     void                        comment_formatted(const char* s, ...) const;
 
     bool                        addLetFrame(ASTNode const & bindingsNode, LetRecords& letRecords);
@@ -199,15 +199,16 @@ class Interpret {
     void    execute(const ASTNode* n);
     bool    gotExit() const { return f_exit; }
 
-    bool    getAssignment  ();
+    bool    getAssignment  () const;
 
-    void    reportError(char const * msg) { notify_formatted(true, msg); }
+    void    reportError(char const * msg) const { notify_formatted(true, msg); }
 
     PTRef getParsedFormula();
     vec<PTRef>& getAssertions() { return assertions; }
     bool is_top_level_assertion(PTRef ref);
     int get_assertion_index(PTRef ref);
-    MainSolver&     getMainSolver() { return *main_solver; }
+    MainSolver&        getMainSolver() { return *main_solver; }
+    MainSolver const & getMainSolver() const { return *main_solver; }
 };
 
 }

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -128,6 +128,18 @@ void MainSolver::insertFormula(PTRef fla) {
     firstNotSimplifiedFrame = std::min(firstNotSimplifiedFrame, frames.frameCount() - 1);
 }
 
+bool MainSolver::tryAddNamedAssertion(PTRef fla, std::string const & name) {
+    bool const success = tryAddTermNameFor(fla, name);
+    if (not success) { return false; }
+
+    addAssertion(fla);
+    return true;
+}
+
+bool MainSolver::tryAddTermNameFor(PTRef fla, std::string const & name) {
+    return termNames.tryInsert(name, fla);
+}
+
 sstat MainSolver::simplifyFormulas() {
     status = s_Undef;
     for (std::size_t i = firstNotSimplifiedFrame; i < frames.frameCount() && status != s_False; i++) {

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -87,7 +87,16 @@ public:
     std::size_t getAssertionLevel() const;
 
     void insertFormula(PTRef fla);
+    // Alias for `insertFormula`, reserved for future use
+    void addAssertion(PTRef fla) { return insertFormula(fla); }
     std::size_t getInsertedFormulasCount() const { return insertedFormulasCount; }
+    // Alias for `getInsertedFormulasCount`, reserved for future use
+    std::size_t getAssertionsCount() const { return getInsertedFormulasCount(); }
+
+    // Uses tryAddTermName and inserts the formula only on success
+    bool tryAddNamedAssertion(PTRef, std::string const & name);
+    // Try add a unique name for a term already included in the assertions
+    bool tryAddTermNameFor(PTRef, std::string const & name);
 
     void initialize();
 
@@ -130,7 +139,10 @@ public:
     // Returns interpolation context for the last query (must be in UNSAT state)
     std::unique_ptr<InterpolationContext> getInterpolationContext();
 
-    TermNames & getTermNames() { return termNames; }
+    [[deprecated("Use tryAddNamedAssertion or tryAddTermName")]]
+    TermNames & getTermNames() {
+        return termNames;
+    }
     TermNames const & getTermNames() const { return termNames; }
 
     void stop() { smt_solver->stop = true; }

--- a/src/common/TermNames.h
+++ b/src/common/TermNames.h
@@ -26,11 +26,20 @@ public:
     bool contains(TermName const & name) const { return nameToTerm.contains(name); }
     bool contains(PTRef term) const { return termToNames.contains(term); }
 
+    [[deprecated("Use tryInsert")]]
     void insert(TermName const & name, PTRef term) {
         assert(not contains(name));
-        nameToTerm.emplace(name, term);
+        [[maybe_unused]] bool const success = tryInsert(name, term);
+        assert(success);
+    }
+
+    bool tryInsert(TermName const & name, PTRef term) {
+        auto const [_, inserted] = nameToTerm.try_emplace(name, term);
+        if (not inserted) { return false; }
+
         termToNames[term].push_back(name);
         scopedNamesAndTerms.push({name, term});
+        return true;
     }
 
     PTRef termByName(TermName const & name) const {

--- a/test/unit/test_UnsatCore.cc
+++ b/test/unit/test_UnsatCore.cc
@@ -123,13 +123,9 @@ using MinFullUFUnsatCoreTest = UFUnsatCoreTestTp<MinFullUnsatCoreTestBase>;
 
 TEST_F(UFUnsatCoreTest, Bool_Simple) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a2", b2);
-    termNames.insert("a3", nb1);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -141,13 +137,9 @@ TEST_F(UFUnsatCoreTest, Bool_Simple) {
 
 TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a2", b2);
-    termNames.insert("a3", nb1);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -159,12 +151,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple) {
 
 TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed1) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a2", b2);
-    termNames.insert("a3", nb1);
+    solver.addAssertion(b1);
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -176,12 +165,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed1) {
 
 TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed2) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a3", nb1);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.addAssertion(b2);
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -193,12 +179,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed2) {
 
 TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed3) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a2", b2);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.addAssertion(nb1);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -210,9 +193,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Unnamed3) {
 
 TEST_F(FullUFUnsatCoreTest, Full_Bool_Simple) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
+    solver.addAssertion(b1);
+    solver.addAssertion(b2);
+    solver.addAssertion(nb1);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -224,9 +207,9 @@ TEST_F(FullUFUnsatCoreTest, Full_Bool_Simple) {
 
 TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
+    solver.addAssertion(b1);
+    solver.addAssertion(b2);
+    solver.addAssertion(nb1);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -238,12 +221,9 @@ TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple) {
 
 TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed1) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a2", b2);
-    termNames.insert("a3", nb1);
+    solver.addAssertion(b1);
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -255,12 +235,9 @@ TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed1) {
 
 TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed2) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a3", nb1);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.addAssertion(b2);
+    solver.tryAddNamedAssertion(nb1, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -272,12 +249,9 @@ TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed2) {
 
 TEST_F(MinFullUFUnsatCoreTest, Min_Full_Bool_Simple_Unnamed3) {
     MainSolver solver = makeSolver();
-    solver.insertFormula(b1);
-    solver.insertFormula(b2);
-    solver.insertFormula(nb1);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", b1);
-    termNames.insert("a2", b2);
+    solver.tryAddNamedAssertion(b1, "a1");
+    solver.tryAddNamedAssertion(b2, "a2");
+    solver.addAssertion(nb1);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -300,13 +274,9 @@ TEST_F(UFUnsatCoreTest, Bool_ReuseProofChain) {
     PTRef c4 = logic.mkOr(nb1, nb3);
     PTRef a1 = logic.mkAnd(c1,c2);
     PTRef a2 = logic.mkAnd(c3,c4);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(b4);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", b4);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(b4, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -330,13 +300,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_ReuseProofChain) {
     PTRef c4 = logic.mkOr(nb1, nb3);
     PTRef a1 = logic.mkAnd(c1,c2);
     PTRef a2 = logic.mkAnd(c3,c4);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(b4);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", b4);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(b4, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -360,9 +326,9 @@ TEST_F(FullUFUnsatCoreTest, Full_Bool_ReuseProofChain) {
     PTRef c4 = logic.mkOr(nb1, nb3);
     PTRef a1 = logic.mkAnd(c1,c2);
     PTRef a2 = logic.mkAnd(c3,c4);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(b4);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(b4);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -381,13 +347,9 @@ TEST_F(UFUnsatCoreTest, UF_Simple) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -406,13 +368,9 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -431,12 +389,9 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed1) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.addAssertion(a1);
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -455,12 +410,9 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed2) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.addAssertion(a2);
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -479,12 +431,9 @@ TEST_F(MinUFUnsatCoreTest, Min_UF_Simple_Unnamed3) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.addAssertion(a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -503,9 +452,9 @@ TEST_F(FullUFUnsatCoreTest, Full_UF_Simple) {
     PTRef a1 = logic.mkEq(x,y);
     PTRef a2 = logic.mkEq(logic.mkUninterpFun(g,{x,y}), logic.mkUninterpFun(g,{y,x}));
     PTRef a3 = logic.mkNot(logic.mkEq(logic.mkUninterpFun(f,{x}), logic.mkUninterpFun(f,{y})));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -521,13 +470,9 @@ TEST_F(UFUnsatCoreTest, Bool_Simple_Overlap) {
     PTRef a1 = b1;
     PTRef a2 = logic.mkAnd(b1, b2);
     PTRef a3 = logic.mkOr(logic.mkNot(b1), logic.mkNot(b2));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -543,13 +488,9 @@ TEST_F(MinUFUnsatCoreTest, Min_Bool_Simple_Overlap) {
     PTRef a1 = b1;
     PTRef a2 = logic.mkAnd(b1, b2);
     PTRef a3 = logic.mkOr(logic.mkNot(b1), logic.mkNot(b2));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -565,9 +506,9 @@ TEST_F(FullUFUnsatCoreTest, Full_Bool_Simple_Overlap) {
     PTRef a1 = b1;
     PTRef a2 = logic.mkAnd(b1, b2);
     PTRef a3 = logic.mkOr(logic.mkNot(b1), logic.mkNot(b2));
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -614,13 +555,9 @@ TEST_F(AXUnsatCoreTest, AX_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(i,j));
     PTRef a2 = logic.mkNot(logic.mkEq(logic.mkSelect({a,j}), logic.mkSelect({logic.mkStore({a,i,e}),j})));
     PTRef a3 = logic.mkEq(logic.mkSelect({a,k}), e);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -639,13 +576,9 @@ TEST_F(AXUnsatCoreTest, Min_AX_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(i,j));
     PTRef a2 = logic.mkNot(logic.mkEq(logic.mkSelect({a,j}), logic.mkSelect({logic.mkStore({a,i,e}),j})));
     PTRef a3 = logic.mkEq(logic.mkSelect({a,k}), e);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -664,9 +597,9 @@ TEST_F(FullAXUnsatCoreTest, Full_AX_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(i,j));
     PTRef a2 = logic.mkNot(logic.mkEq(logic.mkSelect({a,j}), logic.mkSelect({logic.mkStore({a,i,e}),j})));
     PTRef a3 = logic.mkEq(logic.mkSelect({a,k}), e);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -719,15 +652,10 @@ TEST_F(LIAUnsatCoreTest, LIA_Simple) {
     PTRef a2 = logic.mkGeq(y,z);
     PTRef a3 = logic.mkLt(logic.mkPlus(vec<PTRef>{x,y,z}), logic.getTerm_IntZero());
     PTRef a4 = logic.mkLt(x,z);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    solver.insertFormula(a4);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
-    termNames.insert("a4", a4);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
+    solver.tryAddNamedAssertion(a4, "a4");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -749,15 +677,10 @@ TEST_F(LIAUnsatCoreTest, Min_LIA_Simple) {
     PTRef a2 = logic.mkGeq(y,z);
     PTRef a3 = logic.mkLt(logic.mkPlus(vec<PTRef>{x,y,z}), logic.getTerm_IntZero());
     PTRef a4 = logic.mkLt(x,z);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    solver.insertFormula(a4);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
-    termNames.insert("a4", a4);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
+    solver.tryAddNamedAssertion(a4, "a4");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -779,10 +702,10 @@ TEST_F(FullLIAUnsatCoreTest, Full_LIA_Simple) {
     PTRef a2 = logic.mkGeq(y,z);
     PTRef a3 = logic.mkLt(logic.mkPlus(vec<PTRef>{x,y,z}), logic.getTerm_IntZero());
     PTRef a4 = logic.mkLt(x,z);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    solver.insertFormula(a4);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(a3);
+    solver.addAssertion(a4);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -838,13 +761,9 @@ TEST_F(ALIAUnsatCoreTest, ALIA_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(logic.mkSelect({arr1, x}), logic.mkSelect({arr1,y})));
     PTRef a2 = logic.mkEq(logic.mkSelect({arr1,x}), logic.getTerm_IntZero());
     PTRef a3 = logic.mkEq(x,y);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -863,13 +782,9 @@ TEST_F(ALIAUnsatCoreTest, Min_ALIA_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(logic.mkSelect({arr1, x}), logic.mkSelect({arr1,y})));
     PTRef a2 = logic.mkEq(logic.mkSelect({arr1,x}), logic.getTerm_IntZero());
     PTRef a3 = logic.mkEq(x,y);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
-    auto & termNames = solver.getTermNames();
-    termNames.insert("a1", a1);
-    termNames.insert("a2", a2);
-    termNames.insert("a3", a3);
+    solver.tryAddNamedAssertion(a1, "a1");
+    solver.tryAddNamedAssertion(a2, "a2");
+    solver.tryAddNamedAssertion(a3, "a3");
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();
@@ -888,9 +803,9 @@ TEST_F(FullALIAUnsatCoreTest, Full_ALIA_Simple) {
     PTRef a1 = logic.mkNot(logic.mkEq(logic.mkSelect({arr1, x}), logic.mkSelect({arr1,y})));
     PTRef a2 = logic.mkEq(logic.mkSelect({arr1,x}), logic.getTerm_IntZero());
     PTRef a3 = logic.mkEq(x,y);
-    solver.insertFormula(a1);
-    solver.insertFormula(a2);
-    solver.insertFormula(a3);
+    solver.addAssertion(a1);
+    solver.addAssertion(a2);
+    solver.addAssertion(a3);
     auto res = solver.check();
     ASSERT_EQ(res, s_False);
     auto core = solver.getUnsatCore();


### PR DESCRIPTION
Non-const getter `getTermNames` seems necessary only for consecutive `insert` after `insertFormula`.
I consider it clearer to use a function such as `insertNamedFormula` directly, similar to what is done in the SMT-LIB2 format.
This way it is also clearer that the user is *not* responsible for removing the names in incremental queries, this is what `pop` implicitly does.

Instead of directly removing `getTermNames`, I used a deprecated attribute since we changed the API.
However, it causes a lot of warnings because the compiler still favors the non-const getter in many situations, even when the const is sufficient - one would have to use e.g. `std::as_const` to avoid the warning.
Here I am not sure, maybe we should remove the non-const getter right away. It may break existing code after the update but only if someone used it for `insert`.