### PR TITLE
Added missing const modifiers in `Logic` and `ArithLogic` functions

### DIFF
--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -1331,7 +1331,7 @@ PTRef ArithLogic::sumToNormalizedEquality(PTRef sum) {
     return Logic::mkBinaryEq(mkConst(getSortRef(sum), lhsVal), rhs);
 }
 
-PTRef ArithLogic::getConstantFromLeq(PTRef leq) {
+PTRef ArithLogic::getConstantFromLeq(PTRef leq) const {
     Pterm const & term = getPterm(leq);
     if (not isLeq(term.symb())) {
         throw ApiException("LALogic::getConstantFromLeq called on a term that is not less-or-equal inequality");
@@ -1339,7 +1339,7 @@ PTRef ArithLogic::getConstantFromLeq(PTRef leq) {
     return term[0];
 }
 
-PTRef ArithLogic::getTermFromLeq(PTRef leq) {
+PTRef ArithLogic::getTermFromLeq(PTRef leq) const {
     Pterm const & term = getPterm(leq);
     if (not isLeq(term.symb())) {
         throw ApiException("LALogic::getConstantFromLeq called on a term that is not less-or-equal inequality");
@@ -1347,7 +1347,7 @@ PTRef ArithLogic::getTermFromLeq(PTRef leq) {
     return term[1];
 }
 
-std::pair<PTRef, PTRef> ArithLogic::leqToConstantAndTerm(PTRef leq) {
+std::pair<PTRef, PTRef> ArithLogic::leqToConstantAndTerm(PTRef leq) const {
     Pterm const & term = getPterm(leq);
     assert(isLeq(term.symb()));
     return std::make_pair(term[0], term[1]);

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -253,16 +253,16 @@ public:
     PTRef getTerm_IntMinusOne() const { return term_Int_MINUSONE; }
     PTRef getTerm_RealMinusOne() const { return term_Real_MINUSONE; }
 
-    void checkSortInt(PTRef tr) {
+    void checkSortInt(PTRef tr) const {
         if (getSortRef(tr) != getSort_int()) throw ApiException("Expected integral sort");
     }
-    void checkSortReal(PTRef tr) {
+    void checkSortReal(PTRef tr) const {
         if (getSortRef(tr) != getSort_real()) throw ApiException("Expected real sort");
     }
-    void checkSortInt(vec<PTRef> const & args) {
+    void checkSortInt(vec<PTRef> const & args) const {
         if (args.size() > 0) checkSortInt(args[0]);
     }
-    void checkSortReal(vec<PTRef> const & args) {
+    void checkSortReal(vec<PTRef> const & args) const {
         if (args.size() > 0) checkSortReal(args[0]);
     }
 
@@ -363,12 +363,12 @@ public:
     // Helper methods
 
     // Given an inequality 'c <= t', return the constant c; checked version
-    PTRef getConstantFromLeq(PTRef);
+    PTRef getConstantFromLeq(PTRef) const;
     // Given an inequality 'c <= t', return the term t; checked version
-    PTRef getTermFromLeq(PTRef);
+    PTRef getTermFromLeq(PTRef) const;
     // Given an inequality 'c <= t', return the pair <c,t> for a constant c and term t; unchecked version, for
     // internal use
-    std::pair<PTRef, PTRef> leqToConstantAndTerm(PTRef);
+    std::pair<PTRef, PTRef> leqToConstantAndTerm(PTRef) const;
 
     // MB: In pure LA, there are never nested boolean terms
     vec<PTRef> getNestedBoolRoots(PTRef) const override { return vec<PTRef>(); }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -266,7 +266,7 @@ vec<PTRef> Logic::getNestedBoolRoots(PTRef root) const {
     return nestedBoolRoots;
 }
 
-bool Logic::hasSortSymbol(SortSymbol const & symbol) {
+bool Logic::hasSortSymbol(SortSymbol const & symbol) const {
     SSymRef unused;
     return sort_store.peek(symbol, unused);
 }
@@ -1044,7 +1044,7 @@ bool Logic::getNewFacts(PTRef root, MapWithKeys<PTRef, lbool, PTRefHash> & facts
 //
 // Does term contain var?  (works even if var is a term...)
 //
-bool Logic::contains(PTRef term, PTRef var) {
+bool Logic::contains(PTRef term, PTRef var) const {
     Map<PTRef, bool, PTRefHash> proc;
     vec<PTRef> queue;
     queue.push(term);
@@ -1057,7 +1057,7 @@ bool Logic::contains(PTRef term, PTRef var) {
             continue;
         }
         bool unprocessed_children = false;
-        Pterm & t = getPterm(tr);
+        Pterm const & t = getPterm(tr);
         for (int i = 0; i < t.size(); i++)
             if (!proc.has(t[i])) {
                 queue.push(t[i]);

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -209,7 +209,7 @@ public:
     void instantiateFunctions(SRef);
     void instantiateArrayFunctions(SRef);
 
-    bool hasSortSymbol(SortSymbol const &);
+    bool hasSortSymbol(SortSymbol const &) const;
     bool peekSortSymbol(SortSymbol const &, SSymRef &) const;
     SSymRef declareSortSymbol(SortSymbol symbol);
     SRef getSort(SSymRef, vec<SRef> && args);
@@ -331,7 +331,7 @@ public:
 
     void substitutionsTransitiveClosure(SubstMap & substs);
 
-    bool contains(PTRef x, PTRef y); // term x contains an occurrence of y
+    bool contains(PTRef x, PTRef y) const; // term x contains an occurrence of y
 
     PTRef learnEqTransitivity(PTRef); // Learn limited transitivity information
 


### PR DESCRIPTION
I believe that in none of the cases it is reasonable to have the functions as non-const.