### PR TITLE
Replaced `Logic::isBuiltinSort` by `isInternalSort`

### DIFF
--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -63,13 +63,6 @@ public:
         return mkVar(sort_REAL, name, false);
     }
 
-    bool isBuiltinSort(SRef sr) const override {
-        return sr == getSort_int() || sr == getSort_real() || Logic::isBuiltinSort(sr);
-    }
-    bool isBuiltinSortSym(SSymRef ssr) const override {
-        return ssr == sort_store.getSortSym(getSort_int()) || ssr == sort_store.getSortSym(getSort_real()) ||
-               Logic::isBuiltinSortSym(ssr);
-    }
     bool isBuiltinConstant(SymRef sr) const override {
         return (isIntConst(sr) || isRealConst(sr) || Logic::isBuiltinConstant(sr));
     }

--- a/src/logics/BVLogic.h
+++ b/src/logics/BVLogic.h
@@ -96,8 +96,6 @@ class BVLogic: public Logic
     PTRef         mkBVConst   (const int c) { char* num; wordToBinary(c, num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the int c to binary
     PTRef         mkBVConst   (const char* c) { char* num; wordToBinary(Integer(c), num, getBitWidth()); PTRef tr = Logic::mkConst(sort_BVNUM, num); free(num); return tr; } // Convert the string c to binary
     virtual PTRef         mkBVNumVar  (const char* name) { return mkVar(sort_BVNUM, name); }
-    virtual bool          isBuiltinSortSym(SSymRef ssr) const override { return (ssr == sort_store.getSortSym(sort_BVNUM)); }
-    virtual bool          isBuiltinSort(SRef sr) const override { return (sr == sort_BVNUM); }
     virtual bool          isBuiltinConstant(SymRef sr) const override { return isBVNUMConst(sr); }
 
 //    virtual void conjoinExtras(PTRef root, PTRef& root_out) { root_out = root; }

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -285,7 +285,7 @@ SRef Logic::getSort(SSymRef symbolRef, vec<SRef> && args) {
     auto [sr, created] = sort_store.getOrCreateSort(symbolRef, std::move(args));
     if (created) {
         instantiateFunctions(sr);
-        if (not isInternalSort(sr)) {
+        if (not isBuiltinSort(sr)) {
             newUninterpretedSortHandler(sr);
         } else if (isArraySort(sr)) {
             instantiateArrayFunctions(sr);
@@ -299,12 +299,6 @@ void Logic::newUninterpretedSortHandler(SRef sref) {
     ss << Logic::s_abstract_value_prefix << 'd' << sort_store.numSorts();
     defaultValueForSort.insert(sref, mkConst(sref, ss.str().c_str()));
     ufsorts.insert(sref, true);
-}
-
-bool Logic::isInternalSort(SRef sref) const {
-    Sort const & sort = sort_store[sref];
-    SSymRef sortSymbol = sort.getSymRef();
-    return sort_store[sortSymbol].isInternal();
 }
 
 SRef Logic::declareUninterpretedSort(std::string const & name) {
@@ -1438,11 +1432,13 @@ bool Logic::isIte(PTRef tr) const {
 bool Logic::isBooleanOperator(PTRef tr) const {
     return isBooleanOperator(term_store[tr].symb());
 }
-bool Logic::isBuiltinSort(SRef const sr) const {
-    return sr == sort_BOOL;
+bool Logic::isBuiltinSort(SRef sr) const {
+    Sort const & sort = sort_store[sr];
+    SSymRef sortSymbol = sort.getSymRef();
+    return isBuiltinSortSym(sortSymbol);
 }
-bool Logic::isBuiltinSortSym(SSymRef const ssr) const {
-    return ssr == sort_store.getSortSym(sort_BOOL);
+bool Logic::isBuiltinSortSym(SSymRef ssr) const {
+    return sort_store[ssr].isInternal();
 }
 bool Logic::isBuiltinConstant(SymRef const sr) const {
     return isConstant(sr) && (sr == sym_TRUE || sr == sym_FALSE);

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -262,9 +262,9 @@ public:
     // terms should be declared to the theory solver
     bool isTheoryTerm(PTRef tr) const;
     bool isBooleanOperator(SymRef tr) const;
-    bool isBooleanOperator(PTRef tr) const;          // { return isBooleanOperator(term_store[tr].symb()); }
-    virtual bool isBuiltinSort(SRef const sr) const; // { return sr == sort_BOOL; }
-    virtual bool isBuiltinSortSym(SSymRef const ssr) const;
+    bool isBooleanOperator(PTRef tr) const;
+    bool isBuiltinSort(SRef const) const;
+    bool isBuiltinSortSym(SSymRef const) const;
     virtual bool
     isBuiltinConstant(SymRef const sr) const;     // { return isConstant(sr) && (sr == sym_TRUE || sr == sym_FALSE); }
     bool isBuiltinConstant(PTRef const tr) const; // { return isBuiltinConstant(getPterm(tr).symb()); }
@@ -406,7 +406,6 @@ protected:
     void markConstant(SymId sid);
 
     virtual PTRef mkBinaryEq(PTRef lhs, PTRef rhs);
-    bool isInternalSort(SRef) const;
     void newUninterpretedSortHandler(SRef);
 
     static char const * e_argnum_mismatch;


### PR DESCRIPTION
Current implementation of virtual `Logic::isBuiltinSort` is useless and more importantly error-prone if something is missed, but it is sufficient to observe if the sort symbol was created as `INTERNAL`.
This way, for example, the auxiliary array sort is missed by the current `isBuiltinSort`.
It is probably less performant but probably negligible.

I would BTW also recommend a similar general approach for all other internal symbols, instead of enumerating all possibilities in virtual methods.