### PR TITLE
Included SMT-LIB unsat-core options into command-line options

### DIFF
--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -219,10 +219,12 @@ void printHelp()
           "where OPTION can be\n"
           "  --help [-h]                     prints this help message and exits\n"
           "  --version                       prints opensmt version and exits\n"
+          "  --verbose [-v]                  verbose run of the solver\n"
           "  --dry-run [-d]                  executes dry run\n"
           "  --random-seed [-r] <seed>       sets random seed to specific number\n"
+          "  --minimal-unsat-cores           produced unsat cores must be irreducible\n"
+          "  --print-cores-full              produced unsat cores are agnostic to the smt2 attribute ':named'\n"
           "  --produce-interpolants [-i]     enables interpolant computation\n"
-          "  --verbose [-v]                  verbose run of the solver\n"
           "  --pipe [-p]                     for execution within a pipe\n";
     std::cerr << help_string;
 }
@@ -232,6 +234,8 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
     SMTConfig res;
     int selectedLongOpt = 0;
     constexpr int versionLongOpt = 1;
+    constexpr int minUcoreLongOpt = 2;
+    constexpr int fullUcoreLongOpt = 3;
 
     struct option long_options[] =
         {
@@ -239,12 +243,15 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
             {"version", no_argument, &selectedLongOpt, versionLongOpt},
             {"verbose", no_argument, nullptr, 'v'},
             {"dry-run", no_argument, nullptr, 'd'},
+            {"random-seed", required_argument, nullptr, 'r'},
+            {"minimal-unsat-cores", no_argument, &selectedLongOpt, minUcoreLongOpt},
+            {"print-cores-full", no_argument, &selectedLongOpt, fullUcoreLongOpt},
             {"produce-interpolants", no_argument, nullptr, 'i'},
             {"pipe", no_argument, nullptr, 'p'},
-            {"random-seed", required_argument, nullptr, 'r'},
             {0, 0, 0, 0}
         };
 
+    const char* msg;
     while (true) {
         int option_index = 0;
         int c = getopt_long(argc, argv, "r:hdivp", long_options, &option_index);
@@ -252,14 +259,25 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
 
         switch (c) {
             case 0:
-                assert(*long_options[option_index].flag == versionLongOpt);
-                printVersion();
-                exit(0);
+                switch (*long_options[option_index].flag) {
+                    case versionLongOpt:
+                        printVersion();
+                        exit(0);
+                    case minUcoreLongOpt:
+                        res.setOption(SMTConfig::o_minimal_unsat_cores, SMTOption(true), msg);
+                        break;
+                    case fullUcoreLongOpt:
+                        res.setOption(SMTConfig::o_print_cores_full, SMTOption(true), msg);
+                        break;
+                }
+                break;
             case 'h':
                 printHelp();
                 exit(0);
+            case 'v':
+                res.setOption(SMTConfig::o_verbosity, SMTOption(true), msg);
+                break;
             case 'd':
-                const char* msg;
                 res.setOption(SMTConfig::o_dryrun, SMTOption(true), msg);
                 break;
             case 'r':
@@ -270,9 +288,6 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
                 break;
             case 'i':
                 res.setOption(SMTConfig::o_produce_inter, SMTOption(true), msg);
-                break;
-            case 'v':
-                res.setOption(SMTConfig::o_verbosity, SMTOption(true), msg);
                 break;
             case 'p':
                 pipeExecution = true;


### PR DESCRIPTION
Similarly to how option `--produce-interpolants` works, we also include SMT-LIB options `:minimal-unsat-cores` and `:print-cores-full` into the command line options.
We do not include `:produce-unsat-cores` because it does not seem to be useful (as discussed below). An alternative is suggested in #845.