### PR TITLE
Unified external stops of solvers

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -1,3 +1,5 @@
+./src/api/GlobalStop.cc
+./src/api/GlobalStop.h
 ./src/api/MainSolver.cc
 ./src/api/MainSolver.h
 ./src/api/Opensmt.cc

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -20,12 +20,14 @@ $<TARGET_OBJECTS:unsatcores>
 add_library(api OBJECT)
 
 set(PRIVATE_SOURCES_TO_ADD
+    "${CMAKE_CURRENT_SOURCE_DIR}/GlobalStop.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/MainSolver.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/PartitionManager.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/Interpret.cc"
 )
 
 set(PUBLIC_SOURCES_TO_ADD
+    "${CMAKE_CURRENT_SOURCE_DIR}/GlobalStop.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/MainSolver.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/PartitionManager.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/smt2tokens.h"
@@ -99,6 +101,7 @@ endif()
 install(FILES
     Opensmt.h
     smt2tokens.h
+    GlobalStop.h
     MainSolver.h
     PartitionManager.h
     Interpret.h

--- a/src/api/GlobalStop.cc
+++ b/src/api/GlobalStop.cc
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2025, Tomas Kolarik <tomaqa@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+namespace opensmt {
+
+namespace {
+    bool globalStopFlag{false};
+}
+
+void notifyGlobalStop() {
+    globalStopFlag = true;
+}
+
+bool globallyStopped() {
+    return globalStopFlag;
+}
+
+} // namespace opensmt

--- a/src/api/GlobalStop.h
+++ b/src/api/GlobalStop.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2025, Tomas Kolarik <tomaqa@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+namespace opensmt {
+
+// Notify all solvers in the application to stop
+void notifyGlobalStop();
+// Check if a global stop flag for all solvers has been triggered
+bool globallyStopped();
+
+} // namespace opensmt

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -25,8 +25,6 @@
 
 namespace opensmt {
 
-bool stop;
-
 MainSolver::MainSolver(Logic & logic, SMTConfig & conf, std::string name)
     : theory(createTheory(logic, conf)),
       term_mapper(new TermMapper(logic)),

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -145,7 +145,9 @@ public:
     }
     TermNames const & getTermNames() const { return termNames; }
 
-    void stop() { smt_solver->stop = true; }
+    // Notify this particular solver to stop the computation
+    // For stopping at the global scope, refer to GlobalStop.h
+    void notifyStop() { smt_solver->notifyStop(); }
 
     static std::unique_ptr<Theory> createTheory(Logic & logic, SMTConfig & config);
 

--- a/src/parallel/ScatterSplitter.cc
+++ b/src/parallel/ScatterSplitter.cc
@@ -133,6 +133,8 @@ bool ScatterSplitter::excludeAssumptions(vec<Lit> && neg_constrs) {
 
 bool ScatterSplitter::okContinue() const {
 
+    // ignores SimpSMTSolver::okContinue and hence ignores stopped() and globallyStopped()
+
     if (splitContext.solverLimit() and splitContext.solverLimit() == search_counter and not config.sat_split_mode()) {
         return false;
     } else if (getChannel().shouldStop()) {

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -69,7 +69,6 @@ CoreSMTSolver::CoreSMTSolver(SMTConfig & c, THandler& t )
     : config           (c)
     , theory_handler   (t)
     , verbosity        (c.verbosity())
-    , init             (false)
     , stop             (false)
     // Parameters: (formerly in 'SearchParams')
     , var_decay        (c.sat_var_decay())
@@ -147,8 +146,6 @@ CoreSMTSolver::initialize()
     if (config.produce_proof() && !resolutionProof) {
         resolutionProof = std::make_unique<ResolutionProof>(this->ca);
     }
-
-    init = true;
 }
 
 CoreSMTSolver::~CoreSMTSolver()

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -80,7 +80,6 @@ protected:
     SMTConfig & config;         // Stores Config
     THandler  & theory_handler; // Handles theory
     bool      verbosity;
-    bool      init;
     enum class ConsistencyAction { BacktrackToZero, ReturnUndef, SkipToSearchBegin, NoOp };
     int search_counter;
 public:

--- a/src/smtsolvers/LookaheadSMTSolver.cc
+++ b/src/smtsolvers/LookaheadSMTSolver.cc
@@ -44,7 +44,7 @@ lbool LookaheadSMTSolver::solve_() {
             model[i] = value(i);
         }
     } else {
-        assert(not okContinue() || res == LALoopRes::unsat || this->stop);
+        assert(not okContinue() || res == LALoopRes::unsat);
     }
     switch (res) {
         case LALoopRes::unknown_final:

--- a/src/smtsolvers/SimpSMTSolver.cc
+++ b/src/smtsolvers/SimpSMTSolver.cc
@@ -424,7 +424,7 @@ bool SimpSMTSolver::backwardSubsumptionCheck(bool verbose)
     {
 
         // Empty subsumption queue and return immediately on user-interrupt:
-        if (asynch_interrupt)
+        if (not okContinue())
         {
             subsumption_queue.clear();
             bwdsub_assigns = trail.size();
@@ -709,7 +709,7 @@ bool SimpSMTSolver::eliminate(bool turn_off_elim)
         }
 
         // Empty elim_heap and return immediately on user-interrupt:
-        if (asynch_interrupt)
+        if (not okContinue())
         {
             assert(bwdsub_assigns == trail.size());
             assert(subsumption_queue.size() == 0);
@@ -723,7 +723,7 @@ bool SimpSMTSolver::eliminate(bool turn_off_elim)
         {
             Var elim = elim_heap.removeMin();
 
-            if (asynch_interrupt) break;
+            if (not okContinue()) break;
 
             if (isEliminated(elim) || value(elim) != l_Undef) continue;
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -243,3 +243,11 @@ target_sources(ArraysTest
 
 target_link_libraries(ArraysTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET ArraysTest)
+
+add_executable(StopTest)
+target_sources(StopTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Stop.cc"
+        )
+
+target_link_libraries(StopTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET StopTest)

--- a/test/unit/test_Stop.cc
+++ b/test/unit/test_Stop.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025, Kolarik Tomas <tomaqa@gmail.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <api/GlobalStop.h>
+#include <api/MainSolver.h>
+#include <logics/ArithLogic.h>
+
+#include <array>
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace opensmt {
+
+constexpr auto const sleep_amount = 10ms;
+
+class StopTest : public ::testing::Test {
+protected:
+    static constexpr size_t nSolvers = 2;
+
+    void init() {
+        for (size_t i = 0; i < nSolvers; ++i) {
+            auto & logic = logics[i];
+            auto & solver = solvers[i];
+
+            PTRef x = logic.mkRealVar("x");
+            PTRef y = logic.mkRealVar("y");
+            PTRef z = logic.mkRealVar("z");
+            PTRef w = logic.mkRealVar("w");
+            PTRef v = logic.mkRealVar("v");
+
+            // This at least ensures that it is not solved just during the preprocessing phase
+
+            solver.addAssertion(logic.mkOr(logic.mkEq(x, y), logic.mkEq(x, z)));
+            solver.addAssertion(logic.mkOr(logic.mkEq(y, w), logic.mkEq(y, v)));
+            solver.addAssertion(logic.mkOr(logic.mkEq(z, w), logic.mkEq(z, v)));
+
+            solver.addAssertion(logic.mkLt(x, w));
+            solver.addAssertion(logic.mkLt(x, v));
+        }
+    }
+
+    void solveAllOnBackground() {
+        for (size_t i = 0; i < nSolvers; ++i) {
+            solveOnBackground(i);
+        }
+    }
+
+    void notifyAll() {
+        for (size_t i = 0; i < nSolvers; ++i) {
+            solvers[i].notifyStop();
+        }
+    }
+
+    std::array<sstat, nSolvers> waitAll() {
+        std::array<sstat, nSolvers> results;
+        for (size_t i = 0; i < nSolvers; ++i) {
+            results[i] = wait(i);
+        }
+        return results;
+    }
+
+    SMTConfig config{};
+    std::array<ArithLogic, nSolvers> logics{Logic_t::QF_LRA, Logic_t::QF_LRA};
+    std::array<MainSolver, nSolvers> solvers{MainSolver{logics[0], config, "solver 1"},
+                                             MainSolver{logics[1], config, "solver 2"}};
+
+    std::array<std::thread, nSolvers> threads;
+    std::array<std::future<sstat>, nSolvers> futures;
+
+private:
+    void runOnBackground(size_t idx, auto f) {
+        std::packaged_task task{std::move(f)};
+        futures[idx] = task.get_future();
+        threads[idx] = std::thread{std::move(task)};
+    }
+
+    void solveOnBackground(size_t idx) {
+        runOnBackground(idx, [this, idx] {
+            std::this_thread::sleep_for(sleep_amount);
+            return solvers[idx].check();
+        });
+    }
+
+    sstat wait(size_t idx) {
+        threads[idx].join();
+        return futures[idx].get();
+    }
+};
+
+TEST_F(StopTest, test_NoStop) {
+    init();
+
+    solveAllOnBackground();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_False, s_False}));
+}
+
+TEST_F(StopTest, test_LocalPreStop) {
+    init();
+
+    solvers.front().notifyStop();
+    solveAllOnBackground();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_False}));
+}
+
+TEST_F(StopTest, test_GlobalPreStop) {
+    init();
+
+    notifyGlobalStop();
+    solveAllOnBackground();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+TEST_F(StopTest, test_AllLocalPreStop) {
+    init();
+
+    notifyAll();
+    solveAllOnBackground();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+// Post-stops at least ensure the functionality of returning unknown after the solving is already trigerred
+
+TEST_F(StopTest, test_LocalPostStop) {
+    init();
+
+    solveAllOnBackground();
+    std::this_thread::sleep_for(sleep_amount / 10);
+    solvers.front().notifyStop();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_False}));
+}
+
+TEST_F(StopTest, test_GlobalPostStop) {
+    init();
+
+    solveAllOnBackground();
+    std::this_thread::sleep_for(sleep_amount / 10);
+    notifyGlobalStop();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+TEST_F(StopTest, test_AllLocalPostStop) {
+    init();
+
+    solveAllOnBackground();
+    std::this_thread::sleep_for(sleep_amount / 10);
+    notifyAll();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+TEST_F(StopTest, test_LocalTimeout) {
+    init();
+
+    solveAllOnBackground();
+    if (futures.front().wait_for(sleep_amount / 2) != std::future_status::timeout) { ASSERT_TRUE(false); }
+
+    solvers.front().notifyStop();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_False}));
+}
+
+TEST_F(StopTest, test_GlobalTimeout) {
+    init();
+
+    solveAllOnBackground();
+    if (futures.front().wait_for(sleep_amount / 2) != std::future_status::timeout) { ASSERT_TRUE(false); }
+
+    notifyGlobalStop();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+TEST_F(StopTest, test_AllLocalTimeout) {
+    init();
+
+    solveAllOnBackground();
+    if (futures.front().wait_for(sleep_amount / 2) != std::future_status::timeout) { ASSERT_TRUE(false); }
+
+    notifyAll();
+    auto results = waitAll();
+
+    ASSERT_EQ(results, std::to_array({s_Undef, s_Undef}));
+}
+
+} // namespace opensmt


### PR DESCRIPTION
Used dedicated functions at the global and local scopes to notify the solver to stop.
Used the flags in `okContinue()` function
Not used in `ScatterSplitter` though, which uses dedicated mechanisms for timeouts etc.
Added a test that demonstrates how to use the stopping mechanism using threads and even a simple timeout.