### PR TITLE
Fixed unit tests for stopping solvers and made them not depend on concrete runtime

### DIFF
--- a/src/api/GlobalStop.cc
+++ b/src/api/GlobalStop.cc
@@ -15,6 +15,10 @@ void notifyGlobalStop() {
     globalStopFlag = true;
 }
 
+void resetGlobalStop() {
+    globalStopFlag = false;
+}
+
 bool globallyStopped() {
     return globalStopFlag;
 }

--- a/src/api/GlobalStop.h
+++ b/src/api/GlobalStop.h
@@ -9,6 +9,7 @@ namespace opensmt {
 
 // Notify all solvers in the application to stop
 void notifyGlobalStop();
+void resetGlobalStop();
 // Check if a global stop flag for all solvers has been triggered
 bool globallyStopped();
 


### PR DESCRIPTION
Also added previously missing `resetGlobalStop()`. I do not implement this at the local scope - it would also have to maintain the consistency of the solver if it was about to be used further.