### PR TITLE
Updated CircleCI MacOS XCode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
 
     build-macos:
         macos:
-            xcode: 15.4.0
+            xcode: 16.4.0
         resource_class: macos.m1.medium.gen1
         steps:
             - run:


### PR DESCRIPTION
The primary purpose is to support more C++20 features in the pipeline (e.g. `std::jthread`).