### PR TITLE
Options that invoke `get-*` commands after each `check-sat` gracefully

### DIFF
--- a/src/bin/opensmt.cc
+++ b/src/bin/opensmt.cc
@@ -223,7 +223,9 @@ void printHelp()
           "  --dry-run [-d]                  executes dry run\n"
           "  --random-seed [-r] <seed>       sets random seed to specific number\n"
           "  --produce-models [-m]           enable producing models\n"
+          "  --get-models                    get-model after each check-sat gracefully\n"
           "  --produce-unsat-cores           enable producing unsat cores\n"
+          "  --get-unsat-cores               get-unsat-core after each check-sat gracefully\n"
           "  --minimal-unsat-cores           produced unsat cores must be irreducible\n"
           "  --print-cores-full              produced unsat cores are agnostic to the smt2 attribute ':named'\n"
           "  --produce-interpolants [-i]     enables interpolant computation\n"
@@ -235,7 +237,9 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
 {
     enum class LongOpt {
         version,
+        getModel,
         produceUcore,
+        getUcore,
         minUcore,
         fullUcore
     };
@@ -251,7 +255,9 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
             {"dry-run", no_argument, nullptr, 'd'},
             {"random-seed", required_argument, nullptr, 'r'},
             {"produce-models", no_argument, nullptr, 'm'},
+            {"get-models", no_argument, &selectedLongOpt, int(LongOpt::getModel)},
             {"produce-unsat-cores", no_argument, &selectedLongOpt, int(LongOpt::produceUcore)},
+            {"get-unsat-cores", no_argument, &selectedLongOpt, int(LongOpt::getUcore)},
             {"minimal-unsat-cores", no_argument, &selectedLongOpt, int(LongOpt::minUcore)},
             {"print-cores-full", no_argument, &selectedLongOpt, int(LongOpt::fullUcore)},
             {"produce-interpolants", no_argument, nullptr, 'i'},
@@ -271,8 +277,14 @@ SMTConfig parseCMDLineArgs( int argc, char * argv[ ] )
                     case LongOpt::version:
                         printVersion();
                         exit(0);
+                    case LongOpt::getModel:
+                        res.setOption(SMTConfig::o_get_models, SMTOption(true), msg);
+                        break;
                     case LongOpt::produceUcore:
                         res.setOption(SMTConfig::o_produce_unsat_cores, SMTOption(true), msg);
+                        break;
+                    case LongOpt::getUcore:
+                        res.setOption(SMTConfig::o_get_unsat_cores, SMTOption(true), msg);
                         break;
                     case LongOpt::minUcore:
                         res.setOption(SMTConfig::o_minimal_unsat_cores, SMTOption(true), msg);

--- a/src/options/SMTConfig.cc
+++ b/src/options/SMTConfig.cc
@@ -446,7 +446,9 @@ namespace opensmt {
   }
 
   const char* SMTConfig::o_produce_models = ":produce-models";
+  const char* SMTConfig::o_get_models = ":get-models";
   const char* SMTConfig::o_produce_unsat_cores = ":produce-unsat-cores";
+  const char* SMTConfig::o_get_unsat_cores = ":get-unsat-cores";
   const char* SMTConfig::o_minimal_unsat_cores = ":minimal-unsat-cores";
   const char* SMTConfig::o_print_cores_full = ":print-cores-full";
   const char* SMTConfig::o_verbosity      = ":verbosity";

--- a/src/options/SMTConfig.h
+++ b/src/options/SMTConfig.h
@@ -305,7 +305,9 @@ namespace opensmt {
     static const char* o_sat_split_randomize_lookahead;
     static const char* o_sat_split_randomize_lookahead_buf;
     static const char* o_produce_models;
+    static const char* o_get_models;
     static const char* o_produce_unsat_cores;
+    static const char* o_get_unsat_cores;
     // Produce the unsat cores as locally minimal (i.e. subset-minimal)
     static const char* o_minimal_unsat_cores;
     // Make unsat cores agnostic to the smt2 attribute ':named'
@@ -507,11 +509,21 @@ namespace opensmt {
       { return optionTable.has(o_incremental) ?
           optionTable[o_incremental]->getValue().numval == 1: true; }
     int produce_models() const {
+        // get_models => produce_models
+        if (getting_models()) { return true; }
         return optionTable.has(o_produce_models) ?
                 optionTable[o_produce_models]->getValue().numval :
                 1; }
+    bool getting_models() const {
+        return optionTable.has(o_get_models) && optionTable[o_get_models]->getValue().numval > 0;
+    }
     bool produce_unsat_cores() const {
+        // get_unsat_cores => produce_unsat_cores
+        if (getting_unsat_cores()) { return true; }
         return optionTable.has(o_produce_unsat_cores) && optionTable[o_produce_unsat_cores]->getValue().numval > 0;
+    }
+    bool getting_unsat_cores() const {
+        return optionTable.has(o_get_unsat_cores) && optionTable[o_get_unsat_cores]->getValue().numval > 0;
     }
     bool minimal_unsat_cores() const {
         return optionTable.has(o_minimal_unsat_cores) && optionTable[o_minimal_unsat_cores]->getValue().numval > 0;


### PR DESCRIPTION
As a follow-up to #861, adding also user-friendly options for models and unsat cores that automatically ensure that the corresponding `:produce-*` option is set, and that after each `check-sat` command with the desired status, the corresponding `get-*` command is invoked, while ignoring these commands if given in the script because they have already been invoked after the `check-sat` command.

Resolves #845 