### PR TITLE
Running regression tests in CI also in release modes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,17 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
             environment:
                 CMAKE_BUILD_TYPE: Release
+                MODEL_VALIDATION: Dolmen
+                PARALLEL: OFF
                 FLAGS: -Wall -Wextra -Werror
                 OSMT_INSTALL: ~/osmt-install
-                PARALLEL: OFF
         steps:
             - checkout
             - run:
                 name: Release build gcc
-                command: ./ci/run_ci_commands.sh
+                command: |
+                    eval $(opam env)
+                    ./ci/run_ci_commands.sh
 
     build-recent-clang-debug:
         docker:
@@ -83,6 +86,7 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
             environment:
                 CMAKE_BUILD_TYPE: Release
+                MODEL_VALIDATION: Dolmen
                 PARALLEL: ON
                 FLAGS: -Wall -Wextra -Werror
                 OSMT_INSTALL: ~/osmt-install
@@ -93,7 +97,9 @@ jobs:
                 command: sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
             - run:
                 name: Release build llvm
-                command: ./ci/run_ci_commands.sh
+                command: |
+                    eval $(opam env)
+                    ./ci/run_ci_commands.sh
 
     build-fedora-debug:
         docker:
@@ -125,14 +131,17 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
               environment:
                 CMAKE_BUILD_TYPE: Release
+                MODEL_VALIDATION: Dolmen
+                PARALLEL: OFF
                 FLAGS: -Wall -Wextra -Werror
                 OSMT_INSTALL: ~/osmt-install
-                PARALLEL: OFF
         steps:
             - checkout
             - run:
                 name: Release build gcc in Fedora
-                command: ./ci/run_ci_commands.sh
+                command: |
+                    eval $(opam env)
+                    ./ci/run_ci_commands.sh
 
     build-fedora-release-static:
         docker:
@@ -142,9 +151,9 @@ jobs:
                 password: $DOCKERHUB_PASSWORD
               environment:
                 CMAKE_BUILD_TYPE: Release
+                PARALLEL: ON
                 FLAGS: -Wall -Wextra -Werror
                 OSMT_INSTALL: ~/osmt-install
-                PARALLEL: ON
         steps:
             - checkout
             - run:
@@ -171,12 +180,12 @@ jobs:
                 command: echo 'export PATH=/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin:$PATH' >> $BASH_ENV
             - run:
                 name: Release build OS X
-                command: ./ci/run_ci_commands.sh
                 environment:
                     CMAKE_BUILD_TYPE: Release
+                    PARALLEL: ON
                     FLAGS: -Wall -Wextra -Werror
                     OSMT_INSTALL: ~/osmt-install
-                    PARALLEL: ON
+                command: ./ci/run_ci_commands.sh
 
 workflows:
   build-test:

--- a/ci/run_ci_commands.sh
+++ b/ci/run_ci_commands.sh
@@ -21,18 +21,18 @@ cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 make -j4
 make test
 make install
-if [[ ${CMAKE_BUILD_TYPE} == Debug ]]; then
-    cd ../test/regression/base && ./run-test-notiming.sh ../../../build/opensmt
-    cd ../unsatcores && ./run-test-notiming.sh ../../../build/opensmt
-    cd ../interpolation && ./run-tests.sh ../../../build/opensmt
-    if [[ "${PARALLEL}" == "ON" ]]; then
-      cd ../splitting && ./bin/run-tests.sh ../../../build/opensmt-splitter
-    fi
-    cd ../pipe && ./run-tests.sh ../../../build/opensmt
+cd ../test/regression/base && ./run-test-notiming.sh ../../../build/opensmt
+cd ../unsatcores && ./run-test-notiming.sh ../../../build/opensmt
+cd ../interpolation && ./run-tests.sh ../../../build/opensmt
+if [[ "${PARALLEL}" == "ON" ]]; then
+    cd ../splitting && ./bin/run-tests.sh ../../../build/opensmt-splitter
+fi
+cd ../pipe && ./run-tests.sh ../../../build/opensmt
+if [[ -n ${MODEL_VALIDATION} ]]; then
     cd ../models
-    if [[ x"${MODEL_VALIDATION}" == x"Dolmen" || -f ./data/ENV-MODERN ]]; then
+    if [[ ${MODEL_VALIDATION} == Dolmen || -f ./data/ENV-MODERN ]]; then
         ./bin/run-tests-dolmen.sh ../../../build/opensmt
-    elif [[ x"${MODEL_VALIDATION}" == x"pySMT" || -f ./data/ENV-SMTCOMP ]]; then
+    elif [[ ${MODEL_VALIDATION} == pySMT || -f ./data/ENV-SMTCOMP ]]; then
         ./bin/run-tests-smtcomp.sh ../../../build/opensmt
     else
         echo "Error: the model regression environment is not set."


### PR DESCRIPTION
Resolves #762

MacOS is excluded from model validation tests. Since it does not come with a Docker image, I found it difficult to properly set up the environment for Dolmen or pySMT.