### PR TITLE
Refactored string (print) functions in `Logic` and clarified the use of SMT-LIB2 format

### DIFF
--- a/examples/test_itp.cc
+++ b/examples/test_itp.cc
@@ -70,7 +70,7 @@ int main()
 
         std::vector<PTRef> itps;
         itp_context->getSingleInterpolant(itps, mask);
-        std::cerr << ";Interpolant:\n;" << logic.printTerm(itps[0]) << std::endl;
+        std::cerr << ";Interpolant:\n;" << logic.termToSMT2String(itps[0]) << std::endl;
     }
     else if (r == s_Undef)
         printf("unknown\n");

--- a/examples/test_lra_itp.cc
+++ b/examples/test_lra_itp.cc
@@ -78,7 +78,7 @@ int main()
 
         std::vector<PTRef> itps;
         itp_context->getSingleInterpolant(itps, mask);
-        std::cerr << ";Interpolant:\n;" << logic.printTerm(itps[0]) << std::endl;
+        std::cerr << ";Interpolant:\n;" << logic.termToSMT2String(itps[0]) << std::endl;
     }
     else if (r == s_Undef)
         printf("unknown\n");

--- a/examples/test_lra_value.cc
+++ b/examples/test_lra_value.cc
@@ -71,20 +71,20 @@ int main()
         printf("sat\n");
         auto m = mainSolver.getModel();
         PTRef v1 = m->evaluate(x1);
-        auto name = logic.printTerm(x1);
-        auto value = logic.printTerm(v1);
+        auto name = logic.termToSMT2String(x1);
+        auto value = logic.termToSMT2String(v1);
         std::cout << name << ": " << value << '\n';
         PTRef v2 = m->evaluate(x2);
-        name = logic.printTerm(x2);
-        value = logic.printTerm(v2);
+        name = logic.termToSMT2String(x2);
+        value = logic.termToSMT2String(v2);
         std::cout << name << ": " << value << '\n';
         PTRef v3 = m->evaluate(x3);
-        name = logic.printTerm(x3);
-        value = logic.printTerm(v3);
+        name = logic.termToSMT2String(x3);
+        value = logic.termToSMT2String(v3);
         std::cout << name << ": " << value << '\n';
         PTRef v4 = m->evaluate(x4);
-        name = logic.printTerm(x4);
-        value = logic.printTerm(v4);
+        name = logic.termToSMT2String(x4);
+        value = logic.termToSMT2String(v4);
         std::cout << name << ": " << value << '\n';
     }
     else if (r == s_False)
@@ -111,7 +111,7 @@ int main()
 
         std::vector<PTRef> itps;
         itp_context->getSingleInterpolant(itps, mask);
-        std::cerr << ";Interpolant:\n;" << logic.printTerm(itps[0]) << std::endl;
+        std::cerr << ";Interpolant:\n;" << logic.termToSMT2String(itps[0]) << std::endl;
     }
     else if (r == s_Undef)
         printf("unknown\n");

--- a/src/api/Interpret.cc
+++ b/src/api/Interpret.cc
@@ -725,7 +725,7 @@ void Interpret::getValue(std::vector<ASTNode*> const & terms)
         PTRef tr = parseTerm(term, tmp);
         if (tr != PTRef_Undef) {
             values.push_back({termNode, model->evaluate(tr)});
-            auto pt_str = logic.printTerm(tr);
+            auto pt_str = logic.termToSMT2String(tr);
             comment_formatted("Found the term %s", pt_str.c_str());
         } else
             comment_formatted("Error parsing the term %s", (**(term.children->begin())).getValue());
@@ -735,7 +735,7 @@ void Interpret::getValue(std::vector<ASTNode*> const & terms)
         for (auto const & valPair : values) {
             std::cout << '(';
             printAstTermNode(*valPair.first);
-            auto value = logic.printTerm(valPair.second);
+            auto value = logic.termToSMT2String(valPair.second);
             std::cout << " " << value << ')';
         }
         std::cout << ')' << std::endl;
@@ -859,8 +859,8 @@ std::string Interpret::printDefinitionSmtlib(PTRef tr, PTRef val) {
     std::stringstream ss;
     auto s = logic->protectName(logic->getSymRef(tr));
     SRef sortRef = logic->getSym(tr).rsort();
-    ss << "  (define-fun " << s << " () " << logic->printSort(sortRef) << '\n';
-    ss << "    " << logic->printTerm(val) << ")\n";
+    ss << "  (define-fun " << s << " () " << logic->sortToString(sortRef) << '\n';
+    ss << "    " << logic->termToSMT2String(val) << ")\n";
     return ss.str();
 }
 
@@ -869,11 +869,11 @@ std::string Interpret::printDefinitionSmtlib(TemplateFunction const & templateFu
     ss << "  (define-fun " << templateFun.getName() << " (";
     vec<PTRef> const & args = templateFun.getArgs();
     for (int i = 0; i < args.size(); i++) {
-        auto sortString = logic->printSort(logic->getSortRef(args[i]));
+        auto sortString = logic->sortToString(logic->getSortRef(args[i]));
         ss << "(" << logic->protectName(logic->getSymRef(args[i])) << " " << sortString << ")" << (i == args.size()-1 ? "" : " ");
     }
-    ss << ")" << " " << logic->printSort(templateFun.getRetSort()) << "\n";
-    ss << "    " << logic->printTerm(templateFun.getBody()) << ")\n";
+    ss << ")" << " " << logic->sortToString(templateFun.getRetSort()) << "\n";
+    ss << "    " << logic->termToSMT2String(templateFun.getBody()) << ")\n";
     return ss.str();
 }
 
@@ -994,7 +994,7 @@ bool Interpret::defineFun(const ASTNode& n)
         return false;
     }
     else if (logic->getSortRef(tr) != ret_sort) {
-        notify_formatted(true, "define-fun term and return sort do not match: %s and %s\n", logic->printSort(logic->getSortRef(tr)).c_str(), logic->printSort(ret_sort).c_str());
+        notify_formatted(true, "define-fun term and return sort do not match: %s and %s\n", logic->sortToString(logic->getSortRef(tr)).c_str(), logic->sortToString(ret_sort).c_str());
         return false;
     }
 
@@ -1372,7 +1372,7 @@ void Interpret::getInterpolants(const ASTNode& n)
     }
 
     for (int j = 0; j < itps.size(); j++) {
-        auto itp = logic->pp(itps[j]);
+        auto itp = logic->termToSMT2String(itps[j]);
         notify_formatted(false, "%s%s%s",
                          (j == 0 ? "(" : " "), itp.c_str(), (j == itps.size() - 1 ? ")" : ""));
     }

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -105,7 +105,7 @@ std::size_t MainSolver::getAssertionLevel() const {
 
 void MainSolver::insertFormula(PTRef fla) {
     if (logic.getSortRef(fla) != logic.getSort_bool()) {
-        throw ApiException("Top-level assertion sort must be Bool, got " + logic.printSort(logic.getSortRef(fla)));
+        throw ApiException("Top-level assertion sort must be Bool, got " + logic.sortToString(logic.getSortRef(fla)));
     }
     // TODO: Move this to preprocessing of the formulas
     fla = IteHandler(logic, getPartitionManager().getNofPartitions()).rewrite(fla);

--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define TRACE(x) std::cerr << x << std::endl;
 #define TRACE_FLA_VEC(v)                                                                                               \
     for (unsigned i = 0; i < v.size_(); ++i)                                                                           \
-        std::cerr << i << ": " << logic.printTerm(v[i]) << '\n';                                                       \
+        std::cerr << i << ": " << logic.termToSMT2String(v[i]) << '\n';                                                \
     std::cerr << std::endl;
 #else
 #define TRACE(x)
@@ -48,7 +48,7 @@ Cnfizer::Cnfizer(Logic & logic, TermMapper & tmap) : logic(logic), tmap(tmap) {}
 void Cnfizer::cnfize(PTRef formula, FrameId frame_id) {
     currentFrameId = frame_id;
     assert(formula != PTRef_Undef and logic.getSortRef(formula) == logic.getSort_bool());
-    TRACE("cnfizerAndGiveToSolver: " << logic.printTerm(formula))
+    TRACE("cnfizerAndGiveToSolver: " << logic.termToSMT2String(formula))
 
     vec<PTRef> top_level_formulae = topLevelConjuncts(logic, formula);
     assert(top_level_formulae.size() != 0);
@@ -60,7 +60,7 @@ void Cnfizer::cnfize(PTRef formula, FrameId frame_id) {
         assert(
             not logic.isAnd(topLevelConjunct)); // Conjunction should have been split when retrieving top-level formulae
         if (alreadyProcessed.contains(topLevelConjunct, frame_id)) { continue; }
-        TRACE("Adding clause " << logic.printTerm(f))
+        TRACE("Adding clause " << logic.termToSMT2String(f))
         // Give it to the solver if already in CNF
         if (isClause(topLevelConjunct)) {
             TRACE(" => Already a clause")
@@ -98,7 +98,7 @@ void Cnfizer::deMorganize(PTRef formula) {
     retrieveConjuncts(term[0], conjuncts);
     for (PTRef tr : conjuncts) {
         clause.push(~this->getOrCreateLiteralFor(tr));
-        TRACE("(not " << logic.printTerm(tr) << ")")
+        TRACE("(not " << logic.termToSMT2String(tr) << ")")
     }
     addClause(std::move(clause));
 }

--- a/src/common/VerificationUtils.cc
+++ b/src/common/VerificationUtils.cc
@@ -14,9 +14,9 @@ namespace opensmt {
 bool VerificationUtils::verifyInterpolantInternal(PTRef Apartition, PTRef Bpartition, PTRef itp) {
     SMTConfig validationConfig;
     MainSolver validationSolver(logic, validationConfig, "validator");
-    //    std::cout << "A part:   " << logic.printTerm(Apartition) << '\n';
-    //    std::cout << "B part:   " << logic.printTerm(Bpartition) << '\n';
-    //    std::cout << "Interpol: " << logic.printTerm(itp) << std::endl;
+    //    std::cout << "A part:   " << logic.termToSMT2String(Apartition) << '\n';
+    //    std::cout << "B part:   " << logic.termToSMT2String(Bpartition) << '\n';
+    //    std::cout << "Interpol: " << logic.termToSMT2String(itp) << std::endl;
     validationSolver.push();
     validationSolver.insertFormula(logic.mkNot(logic.mkImpl(Apartition, itp)));
     auto res = validationSolver.check();

--- a/src/logics/ArithLogic.cc
+++ b/src/logics/ArithLogic.cc
@@ -1128,7 +1128,7 @@ PTRef ArithLogic::removeAuxVars(PTRef tr) {
 
 // Handle the printing of real constants that are negative and the
 // rational constants
-std::string ArithLogic::printTerm_(PTRef tr, bool withRefs) const {
+std::string ArithLogic::termToSMT2StringImpl(PTRef tr, bool withRefs) const {
     if (isNumConst(tr)) {
         bool is_neg = false;
         char * tmp_str;
@@ -1181,7 +1181,7 @@ std::string ArithLogic::printTerm_(PTRef tr, bool withRefs) const {
             return rat_str;
         }
     }
-    return Logic::printTerm_(tr, withRefs);
+    return Logic::termToSMT2StringImpl(tr, withRefs);
 }
 
 /**

--- a/src/logics/ArithLogic.h
+++ b/src/logics/ArithLogic.h
@@ -351,8 +351,6 @@ public:
 
     PTRef removeAuxVars(PTRef) override;
 
-    std::string printTerm_(PTRef tr, bool withRefs) const override;
-
     // Helper methods
 
     // Given an inequality 'c <= t', return the constant c; checked version
@@ -377,6 +375,8 @@ protected:
     pair<Number, PTRef> sumToNormalizedPair(PTRef sum);
     pair<Number, PTRef> sumToNormalizedIntPair(PTRef sum);
     pair<Number, PTRef> sumToNormalizedRealPair(PTRef sum);
+
+    std::string termToSMT2StringImpl(PTRef tr, bool withRefs) const override;
 
     bool hasNegativeLeadingVariable(PTRef poly) const;
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -61,7 +61,7 @@ public:
 
     SRef getSortRef(PTRef tr) const;
     SRef getSortRef(SymRef sr) const;
-    std::string printSort(SRef s) const;
+    std::string sortToString(SRef s) const;
     std::size_t getSortSize(SRef s) const;
     SRef declareUninterpretedSort(std::string const &);
 
@@ -346,12 +346,14 @@ public:
     std::string disambiguateName(std::string const & protectedName, SRef retSort, bool isNullary,
                                  bool isInterpreted) const;
     std::string protectName(SymRef sr) const { return protectName(getSymName(sr), getSym(sr).isInterpreted()); };
-    virtual std::string printTerm_(PTRef tr, bool withRefs) const;
-    std::string printTerm(PTRef tr) const { return printTerm_(tr, false); }
-    std::string printTerm(PTRef tr, bool withRefs) const { return printTerm_(tr, withRefs); }
+    // Converts the term into a string in SMT-LIB2 format
+    std::string termToSMT2String(PTRef tr) const { return termToSMT2StringImpl(tr, false); }
+#ifndef NDEBUG
+    std::string termToSMT2String(PTRef tr, bool withRefs) const { return termToSMT2StringImpl(tr, withRefs); }
+#endif
     std::string pp(PTRef tr) const; // A pretty printer
 
-    std::string printSym(SymRef sr) const;
+    std::string symToString(SymRef sr) const;
     virtual void termSort(vec<PTRef> & v) const; // { sort(v, LessThan_PTRef()); }
 
     void purify(PTRef r, PTRef & p,
@@ -407,6 +409,8 @@ protected:
 
     virtual PTRef mkBinaryEq(PTRef lhs, PTRef rhs);
     void newUninterpretedSortHandler(SRef);
+
+    virtual std::string termToSMT2StringImpl(PTRef tr, bool withRefs) const;
 
     static char const * e_argnum_mismatch;
     static char const * e_bad_constant;

--- a/src/proof/InterpolationContext.cc
+++ b/src/proof/InterpolationContext.cc
@@ -584,7 +584,7 @@ PTRef SingleInterpolationComputationContext::produceSingleInterpolant() {
         std::cerr << "; Number of interpreted functions: " << nif << '\n';
     }
 
-    if (verbose() > 1) { std::cout << "; Interpolant:\n" << logic.printTerm(rootInterpolant) << '\n'; }
+    if (verbose() > 1) { std::cout << "; Interpolant:\n" << logic.termToSMT2String(rootInterpolant) << '\n'; }
     return rootInterpolant;
 }
 
@@ -895,9 +895,9 @@ bool InterpolationContext::getPathInterpolants(vec<PTRef> & interpolants, std::v
                 VerificationUtils(logic).impliesInternal(logic.mkAnd(previous_itp, movedPartitions), next_itp);
             if (not propertySatisfied) {
                 std::cerr << "; Path interpolation does not hold for:\n"
-                          << "First interpolant: " << logic.printTerm(previous_itp) << '\n'
-                          << "Moved partitions: " << logic.printTerm(movedPartitions) << '\n'
-                          << "Second interpolant: " << logic.printTerm(next_itp) << '\n';
+                          << "First interpolant: " << logic.termToSMT2String(previous_itp) << '\n'
+                          << "Moved partitions: " << logic.termToSMT2String(movedPartitions) << '\n'
+                          << "Second interpolant: " << logic.termToSMT2String(next_itp) << '\n';
             }
         }
     }
@@ -940,19 +940,21 @@ PTRef InterpolationContext::simplifyInterpolant(PTRef itp) const {
         itp = simplifyUnderAssignment_Aggressive(itp, logic);
     } else {
         if (simplificationLevel > 0) {
-            if (verbose() > 1) { std::cout << "Itp before rewriting max arity: \n" << logic.printTerm(itp) << "\n\n"; }
+            if (verbose() > 1) {
+                std::cout << "Itp before rewriting max arity: \n" << logic.termToSMT2String(itp) << "\n\n";
+            }
             itp = rewriteMaxArityClassic(logic, itp);
         }
         if (simplificationLevel == 2) {
             if (verbose() > 1) {
-                std::cout << "Itp before aggressive simplifying: \n" << logic.printTerm(itp) << "\n\n";
+                std::cout << "Itp before aggressive simplifying: \n" << logic.termToSMT2String(itp) << "\n\n";
             }
             itp = simplifyUnderAssignment(logic, itp);
         }
 
         if (simplificationLevel == 3) {
             if (verbose() > 1) {
-                std::cout << "Itp before aggressive simplifying: \n" << logic.printTerm(itp) << "\n\n";
+                std::cout << "Itp before aggressive simplifying: \n" << logic.termToSMT2String(itp) << "\n\n";
             }
             itp = simplifyUnderAssignment_Aggressive(itp, logic);
         }

--- a/src/smtsolvers/CoreSMTSolver.cc
+++ b/src/smtsolvers/CoreSMTSolver.cc
@@ -790,7 +790,7 @@ void CoreSMTSolver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
 #ifdef REPORT_DL1_THLITS
     if (out_learnt.size() == 1)
     {
-        char* ulit = theory_handler.getLogic().printTerm(theory_handler.varToTerm(var(out_learnt[0])));
+        char* ulit = theory_handler.getLogic().termToSMT2String(theory_handler.varToTerm(var(out_learnt[0])));
         cerr << "; Found a unit literal " << (sign(out_learnt[0]) ? "not " : "") << ulit << endl;
         free(ulit);
     }

--- a/src/smtsolvers/CoreSMTSolver.h
+++ b/src/smtsolvers/CoreSMTSolver.h
@@ -830,7 +830,7 @@ inline void CoreSMTSolver::printClause(const C& c)
         args.push(tr);
     }
     PTRef tr = logic.mkOr(std::move(args));
-    auto clause = logic.printTerm(tr);
+    auto clause = logic.termToSMT2String(tr);
     fprintf(stderr, "; %s", clause.c_str());
 }
 
@@ -860,7 +860,7 @@ inline std::string CoreSMTSolver::printCnfClauses()
 	this->populateClauses(cnf_clauses, clauses);
 
 	Logic& logic = theory_handler.getLogic();
-	return logic.printTerm(logic.mkAnd(std::move(cnf_clauses)));
+	return logic.termToSMT2String(logic.mkAnd(std::move(cnf_clauses)));
 }
 
 inline std::string CoreSMTSolver::printCnfLearnts()
@@ -870,7 +870,7 @@ inline std::string CoreSMTSolver::printCnfLearnts()
 	//this->populateClauses(cnf_clauses, trail);
 
 	Logic& logic = theory_handler.getLogic();
-	return logic.printTerm(logic.mkAnd(std::move(cnf_clauses)));
+	return logic.termToSMT2String(logic.mkAnd(std::move(cnf_clauses)));
 }
 
 

--- a/src/smtsolvers/Debug.cc
+++ b/src/smtsolvers/Debug.cc
@@ -101,7 +101,7 @@ void CoreSMTSolver::printTrail( )
   {
     printLit(trail[i]);
     std::cerr << ' ' << (sign(trail[i]) ? "not " : "")
-        << theory_handler.getLogic().printTerm(theory_handler.varToTerm(var(trail[i]))) << '\n';
+        << theory_handler.getLogic().termToSMT2String(theory_handler.varToTerm(var(trail[i]))) << '\n';
   }
 }
 

--- a/src/sorts/SStore.h
+++ b/src/sorts/SStore.h
@@ -64,12 +64,12 @@ public:
     std::string getSortSymName(SSymRef ssr) const { return ssa[ssr].name; }
     std::string getSortSymName(SRef sr) const { return getSortSymName(getSortSym(sr)); }
     unsigned int getSortSymSize(SSymRef ssr) const { return ssa[ssr].arity; }
-    std::string printSort(SRef sr) const {
+    std::string sortToString(SRef sr) const {
         std::string name = getSortSymName(sr);
         if (sa[sr].getSize() > 0) {
             name = "(" + name + " ";
             for (unsigned i = 0; i < sa[sr].getSize(); i++) {
-                name += printSort(sa[sr][i]) + (i == sa[sr].getSize() - 1 ? "" : " ");
+                name += sortToString(sa[sr][i]) + (i == sa[sr].getSize() - 1 ? "" : " ");
             }
             name += ")";
         }

--- a/src/tsolvers/THandler.cc
+++ b/src/tsolvers/THandler.cc
@@ -191,7 +191,7 @@ Lit THandler::getDeduction() {
         //assert(e.sgn != l_Undef);
 #ifdef PEDANTIC_DEBUG
         if (!tmap.hasLit(e.tr))
-            cerr << "Missing (optimized) deduced literal ignored: " << getLogic().printTerm(e.tr) << '\n';
+            cerr << "Missing (optimized) deduced literal ignored: " << getLogic().termToSMT2String(e.tr) << '\n';
 #endif
         if (!tmap.hasLit(e.tr)) continue;
         break;
@@ -267,7 +267,7 @@ char* THandler::printAsrtClause(vec<Lit>& r) {
     for (int i = 0; i < r.size(); i++) {
         Var v = var(r[i]);
         bool sgn = sign(r[i]);
-        os << (sgn ? "not " : "") << getLogic().printTerm(tmap.varToPTRef(v)) << " ";
+        os << (sgn ? "not " : "") << getLogic().termToSMT2String(tmap.varToPTRef(v)) << " ";
     }
     return strdup(os.str().c_str());
 }
@@ -300,7 +300,7 @@ std::string THandler::printAssertion(Lit assertion) {
     PTRef pt_r = tmap.varToPTRef(v);
     if (sign(assertion))
         os << "!";
-    os << getLogic().term_store.printTerm(pt_r, true) << "[var " << v << "] " << '\n';
+    os << getLogic().term_store.termToSMT2String(pt_r, true) << "[var " << v << "] " << '\n';
     return os.str();
 }
 
@@ -316,7 +316,7 @@ std::string THandler::printAssertion(Lit assertion) {
 //        if ( val == l_False )
 //            os << "!";
 //
-//        os << getLogic().term_store.printTerm(explanation[i].tr);
+//        os << getLogic().term_store.termToSMT2String(explanation[i].tr);
 //        os << "[var " << v << "]";
 //    }
 //    os << '\n';
@@ -339,7 +339,7 @@ PTRef   THandler::varToTerm          ( Var v ) const { return tmap.varToPTRef(v)
 Pterm&  THandler::varToPterm         ( Var v)        { return getLogic().getPterm(tmap.varToPTRef(v)); } // Return the term corresponding to a variable
 Lit     THandler::PTRefToLit         ( PTRef tr)     { return tmap.getLit(tr); }
 
-std::string THandler::getVarName(Var v) const { return getLogic().printTerm(tmap.varToPTRef(v)); }
+std::string THandler::getVarName(Var v) const { return getLogic().termToSMT2String(tmap.varToPTRef(v)); }
 
 Var     THandler::ptrefToVar         ( PTRef r ) { return tmap.getVar(r); }
 

--- a/src/tsolvers/bvsolver/BitBlaster.cc
+++ b/src/tsolvers/bvsolver/BitBlaster.cc
@@ -249,7 +249,7 @@ BitBlaster::bbTerm(PTRef tr)
     //
     // Exit if term is not handled
     //
-    std::cerr << "term not handled (yet ?): " << logic.printTerm(tr) << "\n";
+    std::cerr << "term not handled (yet ?): " << logic.termToSMT2String(tr) << "\n";
     return BVRef_Undef;
 }
 

--- a/src/tsolvers/egraph/EgraphDebug.cc
+++ b/src/tsolvers/egraph/EgraphDebug.cc
@@ -48,14 +48,14 @@ std::string Egraph::printEqClass(PTRef tr) const {
     std::stringstream out;
     const ERef er = enode_store.getERef(tr);
     ERef c_er = er;
-    out << "In the same eq class with " << logic.printTerm(tr) << " are:\n[ ";
+    out << "In the same eq class with " << logic.termToSMT2String(tr) << " are:\n[ ";
 
     while (true) {
         Enode const & en = getEnode(c_er);
         ERef next_er = en.getEqNext();
         if (next_er == er) break;
         Enode const & en_o = getEnode(next_er);
-        out << logic.printTerm(en_o.getTerm()) << ' ';
+        out << logic.termToSMT2String(en_o.getTerm()) << ' ';
     }
     out << "]";
     return out.str();
@@ -86,7 +86,7 @@ std::string Egraph::printDistinctions(PTRef x) const
     }
 
     std::stringstream out;
-    out << "In different eq class with " << logic.printTerm(x) << " are:\n[ ";
+    out << "In different eq class with " << logic.termToSMT2String(x) << " are:\n[ ";
 
     const ERef er = enode_store[enode_store.getERef(x)].getRoot();
 
@@ -101,7 +101,7 @@ std::string Egraph::printDistinctions(PTRef x) const
         const Elist& el = forbid_allocator[c_elr];
         ELRef next_elr = el.link;
         const Elist& el_o = forbid_allocator[next_elr];
-        out << logic.printTerm(enode_store[el_o.e].getTerm()) << ' ';
+        out << logic.termToSMT2String(enode_store[el_o.e].getTerm()) << ' ';
         if (next_elr == elr) break;
         c_elr = next_elr;
     }
@@ -125,23 +125,23 @@ const std::string Egraph::printDistinctionList( ELRef x, ELAllocator& ela, bool 
               << "| ELRef: " << x.x << '\n'
               << "| id: " << ela[x].getId() << '\n'
               << "| dirty: " << ela[x].isDirty() << '\n'
-              << "| reason: " << (ela[x].reason.pta.sgn == l_True ? "" : "not " ) << logic.printTerm(ela[x].reason.pta.tr) << '\n';
+              << "| reason: " << (ela[x].reason.pta.sgn == l_True ? "" : "not " ) << logic.termToSMT2String(ela[x].reason.pta.tr) << '\n';
 
             if (ela[x].reloced())
                 os << "| reloced to: " << ela[x].rel_e.x << '\n';
             else {
                 os << "| different from enode " << ela[x].e.x << '\n';
-                os << "|   term " << logic.printTerm(enode_store[ela[x].e].getTerm()) << '\n';
+                os << "|   term " << logic.termToSMT2String(enode_store[ela[x].e].getTerm()) << '\n';
             }
             os << "| link: " << ela[x].link.x << '\n';
         } else {
             os << "+-----------------------------------------------------------+" << '\n'
                << "| Forbid list node                                          |" << '\n'
                << "+-----------------------------------------------------------+" << '\n'
-               << "| reason: " << (ela[x].reason.pta.sgn == l_True ? "" : "not " ) << logic.printTerm(ela[x].reason.pta.tr) << '\n';
+               << "| reason: " << (ela[x].reason.pta.sgn == l_True ? "" : "not " ) << logic.termToSMT2String(ela[x].reason.pta.tr) << '\n';
 
             os << "| different from enode " << ela[x].e.x << '\n';
-            os << "|   term " << logic.printTerm(enode_store[ela[x].e].getTerm()) << '\n';
+            os << "|   term " << logic.termToSMT2String(enode_store[ela[x].e].getTerm()) << '\n';
         }
         os << "+-----------------------------------------------------------+" << '\n';
 
@@ -176,7 +176,7 @@ void Egraph::checkRefConsistency() {
 std::string Egraph::toString(ERef er) const {
     if (er == ERef_Undef) { return "undef"; }
     const Enode & node = getEnode(er);
-    return logic.printTerm(node.getTerm());
+    return logic.termToSMT2String(node.getTerm());
 }
 
 }

--- a/src/tsolvers/egraph/EgraphSolver.cc
+++ b/src/tsolvers/egraph/EgraphSolver.cc
@@ -525,10 +525,10 @@ bool Egraph::assertNEq ( PTRef x, PTRef y, const Expl &r ) {
 #ifdef GC_DEBUG
     checkRefConsistency();
     assert(r.sgn != l_Undef);
-    cerr << "Asserting distinction of " << logic.printTerm(x)
-         << " and " << logic.printTerm(y)
+    cerr << "Asserting distinction of " << logic.termToSMT2String(x)
+         << " and " << logic.termToSMT2String(y)
          << " enforced by " << (r.sgn == l_True ? "" : "not ")
-         << logic.printTerm(r.tr) << endl;
+         << logic.termToSMT2String(r.tr) << endl;
 #endif
     checkFaGarbage();
 #ifdef GC_DEBUG
@@ -1200,11 +1200,11 @@ void Egraph::relocAll(ELAllocator& to) {
                  << "  link: " << forbid_allocator[er].link.x << endl
                  << "  ERef: " << forbid_allocator[er].e.x
                  << "  Reason: " <<
-                    logic.printTerm(forbid_allocator[er].reason.tr)
+                    logic.termToSMT2String(forbid_allocator[er].reason.tr)
                  << endl;
             if (enode_store[forbid_allocator[er].e].isTerm()) {
                 cerr << "  Term: "
-                     << logic.printTerm(enode_store[forbid_allocator[er].e].getTerm()) << endl;
+                     << logic.termToSMT2String(enode_store[forbid_allocator[er].e].getTerm()) << endl;
             }
 #endif
             forbid_allocator.reloc(er, to);

--- a/src/tsolvers/egraph/UFInterpolator.h
+++ b/src/tsolvers/egraph/UFInterpolator.h
@@ -103,7 +103,7 @@ public:
     CNode* getConflictEnd()   const { assert(conf2 != PTRef_Undef); return cnodes_store.at(conf2); }
 
     inline void setConf(PTRef c1, PTRef c2) {
-//      cout << "SetConf: " << logic.printTerm(c1) << " = " << logic.printTerm(c2) << endl;
+//      cout << "SetConf: " << logic.termToSMT2String(c1) << " = " << logic.termToSMT2String(c2) << endl;
         assert(conf1 == PTRef_Undef);
         assert(conf2 == PTRef_Undef);
         assert(c1 != PTRef_Undef);

--- a/src/tsolvers/lasolver/FarkasInterpolator.cc
+++ b/src/tsolvers/lasolver/FarkasInterpolator.cc
@@ -329,9 +329,9 @@ namespace {
             auto const & coeff = *it_coeff;
             if (coeff.isZero()) { continue; } // when some basis is found, some coordinates could be zero; ignore those
             auto const & ineq = *it_ineq;
-            trace(std::cout << "Original explanation: " << logic.printTerm(ineq.explanation)
+            trace(std::cout << "Original explanation: " << logic.termToSMT2String(ineq.explanation)
                             << "; negated: " << ineq.negated << '\n');
-            trace(std::cout << "LAExpr as PTrEf: " << logic.printTerm(ineq.expr.toPTRef()) << '\n');
+            trace(std::cout << "LAExpr as PTrEf: " << logic.termToSMT2String(ineq.expr.toPTRef()) << '\n');
             trace(std::cout << "LAExpr as stored: ");
             trace(ineq.expr.print(std::cout); std::cout << std::endl);
             if (ineq.negated) {
@@ -426,7 +426,7 @@ PTRef FarkasInterpolator::getDecomposedInterpolant(icolor_t color) {
     for (int i = 0; i < explanations.size(); ++i) {
         assert(explanation_coeffs[i] > 0);
         candidates.emplace_back(explanations[i], explanation_coeffs[i]);
-        trace(std::cout << "Explanation " << logic.printTerm(explanations[i].tr) << " with coeff "
+        trace(std::cout << "Explanation " << logic.termToSMT2String(explanations[i].tr) << " with coeff "
                         << explanation_coeffs[i] << " is negated: " << (explanations[i].sgn == l_False) << '\n');
         bool isA = this->isInPartitionOfColor(icolor_t::I_A, explanations[i].tr);
         bool isB = this->isInPartitionOfColor(icolor_t::I_B, explanations[i].tr);

--- a/src/tsolvers/lasolver/LASolver.cc
+++ b/src/tsolvers/lasolver/LASolver.cc
@@ -545,7 +545,7 @@ bool LASolver::setStatus( LASolverStatus s )
 void LASolver::getSimpleDeductions(LABoundRef br)
 {
 //    printf("Deducing from bound %s\n", boundStore.printBound(br));
-//    printf("The full bound list for %s:\n%s\n", logic.printTerm(lva[v].getPTRef()), boundStore.printBounds(v));
+//    printf("The full bound list for %s:\n%s\n", logic.termToSMT2String(lva[v].getPTRef()), boundStore.printBounds(v));
 
     auto const & bound = boundStore[br];
     LVRef v = bound.getLVRef();

--- a/src/unsatcores/UnsatCore.cc
+++ b/src/unsatcores/UnsatCore.cc
@@ -54,7 +54,7 @@ std::vector<std::string> NamedUnsatCore::makeHiddenTermNames() const {
 }
 
 void FullUnsatCore::printTerm(std::ostream & os, PTRef term) const {
-    os << logic.printTerm(term);
+    os << logic.termToSMT2String(term);
 }
 
 } // namespace opensmt

--- a/test/unit/test_LIALogicMkTerms.cc
+++ b/test/unit/test_LIALogicMkTerms.cc
@@ -165,8 +165,8 @@ TEST_F(LIALogicMkTermsTest, test_EqualityNormalization) {
     PTRef two = logic.mkIntConst(2);
     PTRef eq1 = logic.mkEq(x, y);
     PTRef eq2 = logic.mkEq(logic.mkTimes(x, two), logic.mkTimes(y, two));
-//    std::cout << logic.printTerm(eq1) << std::endl;
-//    std::cout << logic.printTerm(eq2) << std::endl;
+//    std::cout << logic.termToSMT2String(eq1) << std::endl;
+//    std::cout << logic.termToSMT2String(eq2) << std::endl;
     EXPECT_EQ(eq1, eq2);
 }
 

--- a/test/unit/test_LRALogicMkTerms.cc
+++ b/test/unit/test_LRALogicMkTerms.cc
@@ -260,8 +260,8 @@ TEST_F(LRALogicMkTermsTest, test_EqualityNormalization) {
     PTRef two = logic.mkRealConst(2);
     PTRef eq1 = logic.mkEq(x, y);
     PTRef eq2 = logic.mkEq(logic.mkTimes(x, two), logic.mkTimes(y, two));
-//    std::cout << logic.printTerm(eq1) << std::endl;
-//    std::cout << logic.printTerm(eq2) << std::endl;
+//    std::cout << logic.termToSMT2String(eq1) << std::endl;
+//    std::cout << logic.termToSMT2String(eq2) << std::endl;
     EXPECT_EQ(eq1, eq2);
 }
 

--- a/test/unit/test_Model.cc
+++ b/test/unit/test_Model.cc
@@ -358,8 +358,8 @@ TEST_F(ModelIntegrationTest, testSubstitutions) {
     ASSERT_EQ(res, s_True);
 //    auto xval = mainSolver.getValue(x);
 //    auto yval = mainSolver.getValue(y);
-//    std::cout << logic.printTerm(xval.tr) << " : " << xval.val << '\n';
-//    std::cout << logic.printTerm(yval.tr) << " : " << yval.val << std::endl;
+//    std::cout << logic.termToSMT2String(xval.tr) << " : " << xval.val << '\n';
+//    std::cout << logic.termToSMT2String(yval.tr) << " : " << yval.val << std::endl;
     auto model = mainSolver.getModel();
     EXPECT_EQ(model->evaluate(fla), logic.getTerm_true());
 }
@@ -408,9 +408,9 @@ TEST_F(ModelIntegrationTest, testIteWithSubstitution_SubtermsHaveValue) {
     auto res = mainSolver.check();
     ASSERT_EQ(res, s_True);
     auto model = mainSolver.getModel();
-//    std::cout << logic.printTerm(x) << " := " << logic.printTerm(model->evaluate(x)) << '\n';
-//    std::cout << logic.printTerm(y) << " := " << logic.printTerm(model->evaluate(y)) << '\n';
-//    std::cout << logic.printTerm(c) << " := " << logic.printTerm(model->evaluate(c)) << '\n';
+//    std::cout << logic.termToSMT2String(x) << " := " << logic.termToSMT2String(model->evaluate(x)) << '\n';
+//    std::cout << logic.termToSMT2String(y) << " := " << logic.termToSMT2String(model->evaluate(y)) << '\n';
+//    std::cout << logic.termToSMT2String(c) << " := " << logic.termToSMT2String(model->evaluate(c)) << '\n';
     EXPECT_EQ(model->evaluate(fla), logic.getTerm_true());
     EXPECT_EQ(model->evaluate(c), logic.getTerm_false());
 }

--- a/test/unit/test_Rewriting.cc
+++ b/test/unit/test_Rewriting.cc
@@ -44,7 +44,7 @@ TEST(Rewriting_test, test_RewriteClassicWithSimplification)
     // l1 is (and b (or (and c d) (and a (and b (not a)))))
     // which is equivalent to (and b c d)
     PTRef res = rewriteMaxArityClassic(logic, l1);
-//    std::cout << logic.printTerm(res) << std::endl;
+//    std::cout << logic.termToSMT2String(res) << std::endl;
     vec<PTRef> args {b,c,d};
     ASSERT_EQ(res, logic.mkAnd(args));
 }
@@ -60,7 +60,7 @@ TEST(Rewriting_test, test_RewriteClassicUnderNegation)
     // (not (and a (and b c)))
     // is equivalent to (not (and a b c))
     PTRef res = rewriteMaxArityClassic(logic, negative);
-//    std::cout << logic.printTerm(res) << std::endl;
+//    std::cout << logic.termToSMT2String(res) << std::endl;
     ASSERT_EQ(res, logic.mkNot(logic.mkAnd({a,b,c})));
 }
 
@@ -84,7 +84,7 @@ TEST(Rewriting_test, test_RewriteDivMod) {
     PTRef mod = logic.mkMod(x,two);
     PTRef fla = logic.mkAnd(logic.mkEq(div, two), logic.mkEq(mod, logic.getTerm_IntZero()));
     PTRef rewritten = rewriteDivMod(logic, fla);
-//    std::cout << logic.printTerm(rewritten) << std::endl;
+//    std::cout << logic.termToSMT2String(rewritten) << std::endl;
     SMTConfig config;
     MainSolver solver(logic, config, "test");
     solver.insertFormula(rewritten);

--- a/test/unit/test_Sorts.cc
+++ b/test/unit/test_Sorts.cc
@@ -22,7 +22,7 @@ TEST_F(SortTest, test_indexedSort) {
     SRef barSort = logic.getSort(logic.declareSortSymbol({"Bar", 0}), {});
     SRef indexedSort = logic.getSort(logic.getSortSymIndexed(), {fooSort, barSort});
     ASSERT_NE(indexedSort, SRef_Undef);
-    std::cout << logic.printSort(indexedSort) << std::endl;
+    std::cout << logic.sortToString(indexedSort) << std::endl;
 
     PTRef foo = logic.mkConst(fooSort, "foo");
     PTRef bar = logic.mkConst(barSort, "bar");
@@ -31,13 +31,13 @@ TEST_F(SortTest, test_indexedSort) {
 
     SRef indexedSort2 = logic.getSort(logic.getSortSymIndexed(), {barSort, fooSort});
     ASSERT_NE(indexedSort2, indexedSort);
-    std::cout << logic.printSort(indexedSort2) << std::endl;
+    std::cout << logic.sortToString(indexedSort2) << std::endl;
 
     SRef quuxSort = logic.getSort(logic.declareSortSymbol({"Quux", 0}), {});
     SRef frobbozSort = logic.getSort(logic.declareSortSymbol({"Frobboz", 0}), {});
     SRef indexedSort3 = logic.getSort(logic.getSortSymIndexed(), {quuxSort, frobbozSort});
     ASSERT_NE(indexedSort, indexedSort3);
-    std::cout << logic.printSort(indexedSort3) << std::endl;
+    std::cout << logic.sortToString(indexedSort3) << std::endl;
 }
 
 TEST_F(SortTest, test_parametricSort) {
@@ -67,10 +67,10 @@ TEST_F(SortTest, test_parametricSort) {
     rval = logic.peekSortSymbol(symbolU2, symbolRefU);
     ASSERT_TRUE(rval);
     SRef sortU_V = logic.getSort(symbolRefU, {sortV});
-    std::cout << logic.printSort(sortU_V) << std::endl;
+    std::cout << logic.sortToString(sortU_V) << std::endl;
     SRef sortU_W = logic.getSort(symbolRefU, {sortW});
-    std::cout << logic.printSort(sortU_V) << std::endl;
-    std::cout << logic.printSort(sortU_W) << std::endl;
+    std::cout << logic.sortToString(sortU_V) << std::endl;
+    std::cout << logic.sortToString(sortU_W) << std::endl;
 
     ASSERT_NE(sortU_V, SRef_Undef);
     ASSERT_NE(sortU_W, SRef_Undef);

--- a/test/unit/test_Splitting.cc
+++ b/test/unit/test_Splitting.cc
@@ -18,7 +18,7 @@ TEST_F(SplitTest, test_TermPrinting) {
     SymRef sr = logic.declareFun("f", U, {U, U});
     PTRef a = logic.mkVar(U, "a");
     PTRef f_a = logic.mkUninterpFun(sr, {a, a});
-    std::string str = logic.printTerm(f_a);
+    std::string str = logic.termToSMT2String(f_a);
     std::string reference = "(f a a)";
     std::cout << str << std::endl;
     ASSERT_EQ(str.compare(reference), 0);

--- a/test/unit/test_UFInterpolation.cc
+++ b/test/unit/test_UFInterpolation.cc
@@ -445,7 +445,7 @@ TEST_F(UFInterpolationTest, test_LocalColorInformationInsufficient){
     ipartitions_t mask;
     setbit(mask, 1);
     itpCtx->getSingleInterpolant(interpolants, mask);
-//    std::cout << logic.printTerm(interpolants[0]) << std::endl;
+//    std::cout << logic.termToSMT2String(interpolants[0]) << std::endl;
     EXPECT_TRUE(verifyInterpolant(A, B, interpolants[0]));
 }
 


### PR DESCRIPTION
Clarified that the former `printTerm` refers to the SMT-LIB2 format in the first place.
In addition, I avoided to use the name `print*` and prefer `*ToString` instead, because the result is `std::string`.

I kept `Logic::pp` because it is used at several parts, and is not necessarily a bad thing to have - one does not always want an output in SMT-LIB format.

Resolves #789 