### PR TITLE
Extended `ScopedVector` of `clear` and of accessing particular scopes

### DIFF
--- a/src/common/ScopedVector.h
+++ b/src/common/ScopedVector.h
@@ -51,6 +51,28 @@ public:
     [[nodiscard]] T * data() { return elements.data(); }
 
     [[nodiscard]] std::size_t scopeCount() const { return limits.size() + 1; }
+
+    [[nodiscard]] std::size_t topScopeEmpty() const { return topScopeSize() == 0; }
+    [[nodiscard]] std::size_t topScopeSize() const { return size() - sizeBeforeTopScope(); }
+
+    [[nodiscard]] auto topScopeBegin() const { return begin() + sizeBeforeTopScope(); }
+    [[nodiscard]] auto topScopeEnd() const { return end(); }
+
+    [[nodiscard]] auto topScopeBegin() { return begin() + sizeBeforeTopScope(); }
+    [[nodiscard]] auto topScopeEnd() { return end(); }
+
+    [[nodiscard]] T const * topScopeData() const { return data() + sizeBeforeTopScope(); }
+    [[nodiscard]] T * topScopeData() { return data() + sizeBeforeTopScope(); }
+
+    // Views to just the top scope
+    inline auto topScope() const;
+    inline auto topScope();
+
+protected:
+    template<typename>
+    class TopScopeView;
+
+    inline std::size_t sizeBeforeTopScope() const;
 };
 
 template<typename T>
@@ -75,6 +97,44 @@ template<typename T>
 void ScopedVector<T>::clear() {
     elements.clear();
     limits.clear();
+}
+
+template<typename T>
+std::size_t ScopedVector<T>::sizeBeforeTopScope() const {
+    if (limits.empty()) { return 0; }
+    return limits.back();
+}
+
+template<typename T>
+template<typename VectorT>
+class ScopedVector<T>::TopScopeView {
+public:
+    explicit TopScopeView(VectorT & scopedVector_) : scopedVector{scopedVector_} {}
+
+    bool empty() const noexcept { return scopedVector.topScopeEmpty(); }
+    std::size_t size() const noexcept { return scopedVector.topScopeSize(); }
+
+    auto begin() const noexcept { return scopedVector.topScopeBegin(); }
+    auto end() const noexcept { return scopedVector.topScopeEnd(); }
+
+    auto begin() noexcept { return scopedVector.topScopeBegin(); }
+    auto end() noexcept { return scopedVector.topScopeEnd(); }
+
+    T const * data() const noexcept { return scopedVector.topScopeData(); }
+    T * data() noexcept { return scopedVector.topScopeData(); }
+
+protected:
+    VectorT & scopedVector;
+};
+
+template<typename T>
+auto ScopedVector<T>::topScope() const {
+    return TopScopeView<ScopedVector const>{*this};
+}
+
+template<typename T>
+auto ScopedVector<T>::topScope() {
+    return TopScopeView<ScopedVector>{*this};
 }
 } // namespace opensmt
 

--- a/src/common/ScopedVector.h
+++ b/src/common/ScopedVector.h
@@ -9,6 +9,8 @@
 #define OPENSMT_SCOPEDVECTOR_H
 
 #include <cassert>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace opensmt {
@@ -52,6 +54,7 @@ public:
 
     [[nodiscard]] std::size_t scopeCount() const { return limits.size() + 1; }
 
+    // Slightly more efficient than scope*
     [[nodiscard]] std::size_t topScopeEmpty() const { return topScopeSize() == 0; }
     [[nodiscard]] std::size_t topScopeSize() const { return size() - sizeBeforeTopScope(); }
 
@@ -64,15 +67,32 @@ public:
     [[nodiscard]] T const * topScopeData() const { return data() + sizeBeforeTopScope(); }
     [[nodiscard]] T * topScopeData() { return data() + sizeBeforeTopScope(); }
 
+    [[nodiscard]] std::size_t scopeEmpty(std::size_t idx) const { return scopeSize(idx) == 0; }
+    [[nodiscard]] std::size_t scopeSize(std::size_t idx) const;
+
+    // Only const accessors for potentially non-top scopes
+    [[nodiscard]] auto scopeBegin(std::size_t idx) const { return begin() + sizeBeforeScope(idx); }
+    [[nodiscard]] auto scopeEnd(std::size_t idx) const;
+
+    [[nodiscard]] T const * scopeData(std::size_t idx) const { return data() + sizeBeforeScope(idx); }
+
     // Views to just the top scope
     inline auto topScope() const;
     inline auto topScope();
 
+    // Views to just a scope
+    inline auto scope(std::size_t idx) const;
+
 protected:
     template<typename>
     class TopScopeView;
+    template<typename>
+    class ScopeView;
+
+    inline void checkScopeIdx(std::size_t idx) const;
 
     inline std::size_t sizeBeforeTopScope() const;
+    inline std::size_t sizeBeforeScope(std::size_t idx) const;
 };
 
 template<typename T>
@@ -100,9 +120,34 @@ void ScopedVector<T>::clear() {
 }
 
 template<typename T>
+void ScopedVector<T>::checkScopeIdx(std::size_t idx) const {
+    if (idx < scopeCount()) { return; }
+    throw std::out_of_range{"Scope index out of range: " + std::to_string(idx)};
+}
+
+template<typename T>
 std::size_t ScopedVector<T>::sizeBeforeTopScope() const {
     if (limits.empty()) { return 0; }
     return limits.back();
+}
+
+template<typename T>
+std::size_t ScopedVector<T>::sizeBeforeScope(std::size_t idx) const {
+    checkScopeIdx(idx);
+    if (idx == 0) { return 0; }
+    return limits[idx - 1];
+}
+
+template<typename T>
+std::size_t ScopedVector<T>::scopeSize(std::size_t idx) const {
+    if (idx == scopeCount() - 1) { return topScopeSize(); }
+    return sizeBeforeScope(idx + 1) - sizeBeforeScope(idx);
+}
+
+template<typename T>
+auto ScopedVector<T>::scopeEnd(std::size_t idx) const {
+    if (idx == scopeCount() - 1) { return topScopeEnd(); }
+    return begin() + sizeBeforeScope(idx + 1);
 }
 
 template<typename T>
@@ -128,6 +173,25 @@ protected:
 };
 
 template<typename T>
+template<typename VectorT>
+class ScopedVector<T>::ScopeView {
+public:
+    explicit ScopeView(VectorT & scopedVector_, std::size_t idx_) : scopedVector{scopedVector_}, idx{idx_} {}
+
+    bool empty() const noexcept { return scopedVector.scopeEmpty(idx); }
+    std::size_t size() const noexcept { return scopedVector.scopeSize(idx); }
+
+    auto begin() const noexcept { return scopedVector.scopeBegin(idx); }
+    auto end() const noexcept { return scopedVector.scopeEnd(idx); }
+
+    T const * data() const noexcept { return scopedVector.scopeData(idx); }
+
+protected:
+    VectorT & scopedVector;
+    std::size_t idx;
+};
+
+template<typename T>
 auto ScopedVector<T>::topScope() const {
     return TopScopeView<ScopedVector const>{*this};
 }
@@ -135,6 +199,11 @@ auto ScopedVector<T>::topScope() const {
 template<typename T>
 auto ScopedVector<T>::topScope() {
     return TopScopeView<ScopedVector>{*this};
+}
+
+template<typename T>
+auto ScopedVector<T>::scope(std::size_t idx) const {
+    return ScopeView<ScopedVector const>{*this, idx};
 }
 } // namespace opensmt
 

--- a/src/common/ScopedVector.h
+++ b/src/common/ScopedVector.h
@@ -18,29 +18,39 @@ class ScopedVector {
     std::vector<unsigned> limits;
 
 public:
+    using value_type = T;
+    using reference = T &;
+    using const_reference = T const &;
+    using pointer = T *;
+    using const_pointer = T const *;
+
+    using size_type = std::size_t;
+
     using iterator = typename decltype(elements)::iterator;
     using const_iterator = typename decltype(elements)::const_iterator;
 
     void push(T const & element) { return elements.push_back(element); }
 
     void pushScope() { limits.push_back(elements.size()); }
-
-    void popScope();
-
+    inline void popScope();
     template<typename TFun>
-    void popScope(TFun callback);
+    inline void popScope(TFun callback);
+
+    inline void clear();
 
     [[nodiscard]] bool empty() const { return elements.empty(); }
     [[nodiscard]] std::size_t size() const { return elements.size(); }
-
-    [[nodiscard]] T * data() { return elements.data(); }
-    [[nodiscard]] T const * data() const { return elements.data(); }
 
     [[nodiscard]] auto begin() const { return elements.begin(); }
     [[nodiscard]] auto end() const { return elements.end(); }
 
     [[nodiscard]] auto begin() { return elements.begin(); }
     [[nodiscard]] auto end() { return elements.end(); }
+
+    [[nodiscard]] T const * data() const { return elements.data(); }
+    [[nodiscard]] T * data() { return elements.data(); }
+
+    [[nodiscard]] std::size_t scopeCount() const { return limits.size() + 1; }
 };
 
 template<typename T>
@@ -59,6 +69,12 @@ void ScopedVector<T>::popScope(TFun callback) {
         callback(elements.back());
         elements.pop_back();
     }
+}
+
+template<typename T>
+void ScopedVector<T>::clear() {
+    elements.clear();
+    limits.clear();
 }
 } // namespace opensmt
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -251,3 +251,11 @@ target_sources(StopTest
 
 target_link_libraries(StopTest OpenSMT gtest gtest_main)
 gtest_add_tests(TARGET StopTest)
+
+add_executable(ScopedVectorTest)
+target_sources(ScopedVectorTest
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_ScopedVector.cc"
+        )
+
+target_link_libraries(ScopedVectorTest OpenSMT gtest gtest_main)
+gtest_add_tests(TARGET ScopedVectorTest)

--- a/test/unit/test_ScopedVector.cc
+++ b/test/unit/test_ScopedVector.cc
@@ -1,0 +1,143 @@
+/*
+* Copyright (c) 2025, Tomas Kolarik <tomaqa@gmail.com>
+*
+*  SPDX-License-Identifier: MIT
+*
+*/
+
+#include <gtest/gtest.h>
+#include <common/ScopedVector.h>
+
+namespace opensmt {
+
+class Test : public ::testing::Test {
+public:
+    Test() {}
+
+    bool compare(std::vector<int> const & v) const {
+        return compareTp(svector, v);
+    }
+
+protected:
+    bool compareTp(auto const & sv, std::vector<int> const & v) const {
+        if (sv.size() != v.size()) { return false; }
+        auto vIt = v.begin();
+        for (auto & sve : sv) {
+            auto & ve = *vIt++;
+            if (sve != ve) { return false; }
+        }
+
+        auto * vptr = v.data();
+        auto * svptr = sv.data();
+        for (size_t i = 0; i < sv.size(); ++i) {
+            auto & sve = *svptr++;
+            auto & ve = *vptr++;
+            if (sve != ve) { return false; }
+        }
+
+        return true;
+    }
+
+    ScopedVector<int> svector;
+};
+
+// Starting with an empty scoped vector,
+// check if its contents are as expected when pushing/popping elements or scopes
+
+TEST_F(Test, test_ScopeVector1) {
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+    svector.push(1);
+    ASSERT_TRUE(compare({1}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+    svector.push(2);
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+
+    svector.pushScope();
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(3);
+    ASSERT_TRUE(compare({1, 2, 3}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(4);
+    ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.pushScope();
+    ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_EQ(svector.scopeCount(), 3);
+    svector.popScope();
+    ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.pushScope();
+    ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_EQ(svector.scopeCount(), 3);
+    svector.push(5);
+    ASSERT_TRUE(compare({1, 2, 3, 4, 5}));
+    ASSERT_EQ(svector.scopeCount(), 3);
+    svector.popScope();
+    ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.popScope();
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+    svector.pushScope();
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(6);
+    ASSERT_TRUE(compare({1, 2, 6}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.popScope();
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+
+    svector.clear();
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+}
+
+TEST_F(Test, test_ScopeVector2) {
+    svector.pushScope();
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(1);
+    ASSERT_TRUE(compare({1}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(2);
+    ASSERT_TRUE(compare({1, 2}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.popScope();
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+
+    svector.clear();
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+}
+
+TEST_F(Test, test_ScopeVector3) {
+    svector.push(11);
+    ASSERT_TRUE(compare({11}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+    svector.push(22);
+    ASSERT_TRUE(compare({11, 22}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+
+    svector.pushScope();
+    ASSERT_TRUE(compare({11, 22}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+    svector.push(33);
+    ASSERT_TRUE(compare({11, 22, 33}));
+    ASSERT_EQ(svector.scopeCount(), 2);
+
+    svector.clear();
+    ASSERT_TRUE(compare({}));
+    ASSERT_EQ(svector.scopeCount(), 1);
+}
+
+}

--- a/test/unit/test_ScopedVector.cc
+++ b/test/unit/test_ScopedVector.cc
@@ -18,6 +18,10 @@ public:
         return compareTp(svector, v);
     }
 
+    bool compareTopScope(std::vector<int> const & v) const {
+        return compareTp(svector.topScope(), v);
+    }
+
 protected:
     bool compareTp(auto const & sv, std::vector<int> const & v) const {
         if (sv.size() != v.size()) { return false; }
@@ -46,97 +50,123 @@ protected:
 
 TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(1);
     ASSERT_TRUE(compare({1}));
+    ASSERT_TRUE(compareTopScope({1}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(3);
     ASSERT_TRUE(compare({1, 2, 3}));
+    ASSERT_TRUE(compareTopScope({3}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(4);
     ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.push(5);
     ASSERT_TRUE(compare({1, 2, 3, 4, 5}));
+    ASSERT_TRUE(compareTopScope({5}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
+    ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(6);
     ASSERT_TRUE(compare({1, 2, 6}));
+    ASSERT_TRUE(compareTopScope({6}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 
 TEST_F(Test, test_ScopeVector2) {
     svector.pushScope();
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(1);
     ASSERT_TRUE(compare({1}));
+    ASSERT_TRUE(compareTopScope({1}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
+    ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 
 TEST_F(Test, test_ScopeVector3) {
     svector.push(11);
     ASSERT_TRUE(compare({11}));
+    ASSERT_TRUE(compareTopScope({11}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(22);
     ASSERT_TRUE(compare({11, 22}));
+    ASSERT_TRUE(compareTopScope({11, 22}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.pushScope();
     ASSERT_TRUE(compare({11, 22}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(33);
     ASSERT_TRUE(compare({11, 22, 33}));
+    ASSERT_TRUE(compareTopScope({33}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
+    ASSERT_TRUE(compareTopScope({}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 

--- a/test/unit/test_ScopedVector.cc
+++ b/test/unit/test_ScopedVector.cc
@@ -57,16 +57,29 @@ TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compareTopScope({}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({0}));
+    ASSERT_FALSE(compareTopScope({0}));
+    ASSERT_FALSE(compareScope(0, {0}));
+
     svector.push(1);
     ASSERT_TRUE(compare({1}));
     ASSERT_TRUE(compareTopScope({1}));
     ASSERT_TRUE(compareScope(0, {1}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({}));
+    ASSERT_FALSE(compareTopScope({}));
+    ASSERT_FALSE(compareScope(0, {}));
+
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({1}));
+    ASSERT_FALSE(compareTopScope({1}));
+    ASSERT_FALSE(compareScope(0, {1}));
+
+    //--------------------------------------------------
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
@@ -74,18 +87,34 @@ TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compareScope(1, {}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({}));
+    ASSERT_FALSE(compareTopScope({1, 2}));
+    ASSERT_FALSE(compareScope(1, {1, 2}));
+    ASSERT_FALSE(compareScope(0, {}));
+
     svector.push(3);
     ASSERT_TRUE(compare({1, 2, 3}));
     ASSERT_TRUE(compareTopScope({3}));
     ASSERT_TRUE(compareScope(1, {3}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2}));
+    ASSERT_FALSE(compareTopScope({1, 2}));
+    ASSERT_FALSE(compareScope(1, {1, 2}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
     svector.push(4);
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2, 3}));
+    ASSERT_FALSE(compareTopScope({1, 2, 3}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
+    //--------------------------------------------------
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
@@ -94,12 +123,24 @@ TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
+    ASSERT_FALSE(compare({1, 2, 3}));
+    ASSERT_FALSE(compareTopScope({1, 2, 3}));
+    ASSERT_FALSE(compareScope(2, {3, 4}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2, 3}));
+    ASSERT_FALSE(compareTopScope({1, 2, 3}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
+    //--------------------------------------------------
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
@@ -108,6 +149,12 @@ TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
+    ASSERT_FALSE(compare({1, 2, 3}));
+    ASSERT_FALSE(compareTopScope({1, 2, 3}));
+    ASSERT_FALSE(compareScope(2, {3, 4}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
     svector.push(5);
     ASSERT_TRUE(compare({1, 2, 3, 4, 5}));
     ASSERT_TRUE(compareTopScope({5}));
@@ -115,42 +162,78 @@ TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
+    ASSERT_FALSE(compare({1, 2, 3, 4}));
+    ASSERT_FALSE(compareTopScope({3, 4, 5}));
+    ASSERT_FALSE(compareScope(2, {3, 4, 5}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3, 4}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3, 4}));
+
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
     ASSERT_TRUE(compareScope(1, {3, 4}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2, 3}));
+    ASSERT_FALSE(compareTopScope({1, 2, 3}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 3}));
+    ASSERT_FALSE(compareScope(0, {1, 2, 3}));
+
+    //--------------------------------------------------
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({1, 2, 3, 4}));
+    ASSERT_FALSE(compareTopScope({3, 4}));
+    ASSERT_FALSE(compareScope(0, {3, 4}));
+
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({}));
     ASSERT_TRUE(compareScope(1, {}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2, 3, 4}));
+    ASSERT_FALSE(compareTopScope({3, 4}));
+    ASSERT_FALSE(compareScope(1, {3, 4}));
+    ASSERT_FALSE(compareScope(0, {3, 4}));
+
     svector.push(6);
     ASSERT_TRUE(compare({1, 2, 6}));
     ASSERT_TRUE(compareTopScope({6}));
     ASSERT_TRUE(compareScope(1, {6}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
+    ASSERT_FALSE(compare({1, 2}));
+    ASSERT_FALSE(compareTopScope({1, 2, 6}));
+    ASSERT_FALSE(compareScope(1, {1, 2, 6}));
+    ASSERT_FALSE(compareScope(0, {6}));
+
+    //--------------------------------------------------
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
     ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({1, 2, 6}));
+    ASSERT_FALSE(compareTopScope({6}));
+    ASSERT_FALSE(compareScope(0, {6}));
+
+    //--------------------------------------------------
 
     svector.clear();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
+    ASSERT_FALSE(compare({1, 2}));
+    ASSERT_FALSE(compareTopScope({1, 2}));
+    ASSERT_FALSE(compareScope(0, {1, 2}));
+
 }
 
 TEST_F(Test, test_ScopeVector2) {
@@ -160,12 +243,14 @@ TEST_F(Test, test_ScopeVector2) {
     ASSERT_TRUE(compareScope(1, {}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
+
     svector.push(1);
     ASSERT_TRUE(compare({1}));
     ASSERT_TRUE(compareTopScope({1}));
     ASSERT_TRUE(compareScope(1, {1}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
+
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
@@ -173,17 +258,22 @@ TEST_F(Test, test_ScopeVector2) {
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
+    //--------------------------------------------------
+
     svector.popScope();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
+    //--------------------------------------------------
+
     svector.clear();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
     ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
+
 }
 
 TEST_F(Test, test_ScopeVector3) {
@@ -192,11 +282,14 @@ TEST_F(Test, test_ScopeVector3) {
     ASSERT_TRUE(compareTopScope({11}));
     ASSERT_TRUE(compareScope(0, {11}));
     ASSERT_EQ(svector.scopeCount(), 1);
+
     svector.push(22);
     ASSERT_TRUE(compare({11, 22}));
     ASSERT_TRUE(compareTopScope({11, 22}));
     ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 1);
+
+    //--------------------------------------------------
 
     svector.pushScope();
     ASSERT_TRUE(compare({11, 22}));
@@ -204,12 +297,15 @@ TEST_F(Test, test_ScopeVector3) {
     ASSERT_TRUE(compareScope(1, {}));
     ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 2);
+
     svector.push(33);
     ASSERT_TRUE(compare({11, 22, 33}));
     ASSERT_TRUE(compareTopScope({33}));
     ASSERT_TRUE(compareScope(1, {33}));
     ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 2);
+
+    //--------------------------------------------------
 
     svector.clear();
     ASSERT_TRUE(compare({}));

--- a/test/unit/test_ScopedVector.cc
+++ b/test/unit/test_ScopedVector.cc
@@ -22,6 +22,10 @@ public:
         return compareTp(svector.topScope(), v);
     }
 
+    bool compareScope(std::size_t idx, std::vector<int> const & v) const {
+        return compareTp(svector.scope(idx), v);
+    }
+
 protected:
     bool compareTp(auto const & sv, std::vector<int> const & v) const {
         if (sv.size() != v.size()) { return false; }
@@ -51,72 +55,101 @@ protected:
 TEST_F(Test, test_ScopeVector1) {
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(1);
     ASSERT_TRUE(compare({1}));
     ASSERT_TRUE(compareTopScope({1}));
+    ASSERT_TRUE(compareScope(0, {1}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(1, {}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(3);
     ASSERT_TRUE(compare({1, 2, 3}));
     ASSERT_TRUE(compareTopScope({3}));
+    ASSERT_TRUE(compareScope(1, {3}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(4);
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(2, {}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(2, {}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.push(5);
     ASSERT_TRUE(compare({1, 2, 3, 4, 5}));
     ASSERT_TRUE(compareTopScope({5}));
+    ASSERT_TRUE(compareScope(2, {5}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 3);
     svector.popScope();
     ASSERT_TRUE(compare({1, 2, 3, 4}));
     ASSERT_TRUE(compareTopScope({3, 4}));
+    ASSERT_TRUE(compareScope(1, {3, 4}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.pushScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(1, {}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(6);
     ASSERT_TRUE(compare({1, 2, 6}));
     ASSERT_TRUE(compareTopScope({6}));
+    ASSERT_TRUE(compareScope(1, {6}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
+    ASSERT_TRUE(compareScope(0, {1, 2}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 
@@ -124,24 +157,32 @@ TEST_F(Test, test_ScopeVector2) {
     svector.pushScope();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(1, {}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(1);
     ASSERT_TRUE(compare({1}));
     ASSERT_TRUE(compareTopScope({1}));
+    ASSERT_TRUE(compareScope(1, {1}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(2);
     ASSERT_TRUE(compare({1, 2}));
     ASSERT_TRUE(compareTopScope({1, 2}));
+    ASSERT_TRUE(compareScope(1, {1, 2}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.popScope();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 
@@ -149,24 +190,31 @@ TEST_F(Test, test_ScopeVector3) {
     svector.push(11);
     ASSERT_TRUE(compare({11}));
     ASSERT_TRUE(compareTopScope({11}));
+    ASSERT_TRUE(compareScope(0, {11}));
     ASSERT_EQ(svector.scopeCount(), 1);
     svector.push(22);
     ASSERT_TRUE(compare({11, 22}));
     ASSERT_TRUE(compareTopScope({11, 22}));
+    ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 1);
 
     svector.pushScope();
     ASSERT_TRUE(compare({11, 22}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(1, {}));
+    ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 2);
     svector.push(33);
     ASSERT_TRUE(compare({11, 22, 33}));
     ASSERT_TRUE(compareTopScope({33}));
+    ASSERT_TRUE(compareScope(1, {33}));
+    ASSERT_TRUE(compareScope(0, {11, 22}));
     ASSERT_EQ(svector.scopeCount(), 2);
 
     svector.clear();
     ASSERT_TRUE(compare({}));
     ASSERT_TRUE(compareTopScope({}));
+    ASSERT_TRUE(compareScope(0, {}));
     ASSERT_EQ(svector.scopeCount(), 1);
 }
 


### PR DESCRIPTION
Extended `ScopedVector` to allow more operations and look more std. container-like.

Importantly, I added functions that allow accessing particular scopes, not only the entire vector, and not even necessarily the top scope. This allows traversing the elements in batches in a lazy fashion, as for example done with frames in the preprocessing pipeline.

Btw., `AssertionStack` could probably also be rebased on top of a `ScopedVector`, but it would not be that straightforward.