### PR TITLE
Changed `Logic::isBoolAtom` to `isBoolVar` and added `isLiteral`

### DIFF
--- a/src/cnfizers/Cnfizer.cc
+++ b/src/cnfizers/Cnfizer.cc
@@ -211,8 +211,7 @@ void Cnfizer::Cache::insert(PTRef term, FrameId frame) {
     cache.insert({term, frame});
 }
 
-// TODO: Fix isAtom!!! (everything that is not a boolean connective should be considered as atom
 bool Cnfizer::isLiteral(PTRef ptr) const {
-    return (logic.isNot(ptr) and logic.isAtom(logic.getPterm(ptr)[0])) or logic.isAtom(ptr);
+    return logic.isLiteral(ptr);
 }
 } // namespace opensmt

--- a/src/logics/Logic.cc
+++ b/src/logics/Logic.cc
@@ -880,6 +880,14 @@ bool Logic::isAtom(PTRef r) const {
     return false;
 }
 
+bool Logic::isLiteral(PTRef tr) const {
+    if (isAtom(tr)) { return true; }
+    if (not isNot(tr)) { return false; }
+    auto & term = getPterm(tr);
+    assert(term.size() == 1);
+    return isAtom(term[0]);
+}
+
 //
 // The substitutions for the term riddance from osmt1
 //
@@ -928,7 +936,7 @@ pair<lbool, Logic::SubstMap> Logic::retrieveSubstitutions(vec<PtAsgn> const & fa
                     if (!substs.has(var)) { substs.insert(var, PtAsgn(trm, l_True)); }
                 }
             }
-        } else if (isBoolAtom(tr)) {
+        } else if (isBoolVar(tr)) {
             PTRef term = sgn == l_True ? getTerm_true() : getTerm_false();
             if (substs.has(tr)) {
                 if (substs[tr].tr == getTerm_true() || substs[tr].tr == getTerm_false()) {
@@ -1021,7 +1029,7 @@ bool Logic::getNewFacts(PTRef root, MapWithKeys<PTRef, lbool, PTRefHash> & facts
                 PTRef c;
                 lbool c_sign;
                 purify(pta.tr, c, c_sign);
-                if (isBoolAtom(c)) { facts.insert(c, c_sign ^ (pta.sgn == l_False)); }
+                if (isBoolVar(c)) { facts.insert(c, c_sign ^ (pta.sgn == l_False)); }
             }
         }
     }
@@ -1464,7 +1472,7 @@ bool Logic::isVar(PTRef tr) const {
     return isVar(getPterm(tr).symb());
 }
 
-bool Logic::isBoolAtom(PTRef tr) const {
+bool Logic::isBoolVar(PTRef tr) const {
     return hasSortBool(tr) && isVar(tr);
 }
 

--- a/src/logics/Logic.h
+++ b/src/logics/Logic.h
@@ -280,10 +280,12 @@ public:
 
     bool isVar(SymRef sr) const; //{ return sym_store[sr].nargs() == 0 && !isConstant(sr); }
     bool isVar(PTRef tr) const;  // { return isVar(getPterm(tr).symb()); }
+    bool isBoolVar(PTRef tr) const;
     bool isVarOrIte(SymRef sr) const { return isVar(sr) or isIte(sr); }
     bool isVarOrIte(PTRef tr) const { return isVarOrIte(getPterm(tr).symb()); }
     virtual bool isAtom(PTRef tr) const;
-    bool isBoolAtom(PTRef tr) const; // { return hasSortBool(tr) && isVar(tr); }
+    // An atom or its negation
+    bool isLiteral(PTRef tr) const;
     // Check if term is an uninterpreted predicate.
     bool isInterpreted(SymRef sr) const { return sym_store.isInterpreted(sr); }
     virtual bool isUP(PTRef) const;

--- a/src/tsolvers/egraph/EnodeStore.cc
+++ b/src/tsolvers/egraph/EnodeStore.cc
@@ -140,7 +140,7 @@ vec<PTRefERefPair> EnodeStore::constructTerm(PTRef tr) {
 
     if (logic.hasSortBool(tr)) {
         // Add the negated term
-        assert(logic.isBooleanOperator(tr) || logic.isBoolAtom(tr) || logic.isTrue(tr) || logic.isFalse(tr) || logic.isEquality(tr) || logic.isUP(tr) || logic.isDisequality(tr));
+        assert(logic.isBooleanOperator(tr) || logic.isBoolVar(tr) || logic.isTrue(tr) || logic.isFalse(tr) || logic.isEquality(tr) || logic.isUP(tr) || logic.isDisequality(tr));
         assert(not logic.isNot(tr));
         PTRef tr_neg = logic.mkNot(tr);
         if (needsEnode(tr_neg)) {


### PR DESCRIPTION
`isBoolAtom` is actually more restricted than that, because it does not allow constants, so it is rather `isBoolVar`.

`isLiteral` checks if the term is a `Atom` or its negation.
Also replaced `Cnfizer::isLiteral` by `Logic::isLiteral`.