### PR TITLE
Split `simplifyFormulas` to sub-functions

### DIFF
--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -141,23 +141,11 @@ bool MainSolver::tryAddTermNameFor(PTRef fla, std::string const & name) {
 sstat MainSolver::preprocessAssertions() {
     status = s_Undef;
     for (std::size_t i = firstNotPreprocessedFrame; i < frames.frameCount(); ++i) {
-        auto & frame = frames[i];
-        FrameId const frameId = frame.getId();
-        PreprocessingContext context{.frameCount = i, .perPartition = trackPartitions()};
-        preprocessor.prepareForProcessingFrame(i);
-        firstNotPreprocessedFrame = i + 1;
-
-        if (not context.perPartition) {
-            PTRef frameFormula = preprocessFormulasConjoined(frame.formulas, context);
-            status = giveToSolver(frameFormula, frameId);
-        } else {
-            vec<PTRef> processedFormulas = preprocessFormulasPerPartition(frame.formulas, context);
-            for (PTRef fla : processedFormulas) {
-                status = giveToSolver(fla, frameId);
-                if (status == s_False) { break; }
-            }
+        assert(status != s_False);
+        if (not tryPreprocessFrame(i)) {
+            assert(status == s_False);
+            break;
         }
-        if (status == s_False) { break; }
     }
 
     if (status == s_False) {
@@ -166,6 +154,31 @@ sstat MainSolver::preprocessAssertions() {
     }
 
     return status;
+}
+
+bool MainSolver::tryPreprocessFrame(std::size_t i) {
+    auto & frame = frames[i];
+    FrameId const frameId = frame.getId();
+    PreprocessingContext context{.frameCount = i, .perPartition = trackPartitions()};
+    preprocessor.prepareForProcessingFrame(i);
+    firstNotPreprocessedFrame = i + 1;
+
+    assert(status != s_False);
+
+    if (not context.perPartition) {
+        PTRef frameFormula = preprocessFormulasConjoined(frame.formulas, context);
+        status = giveToSolver(frameFormula, frameId);
+        return status != s_False;
+    }
+
+    vec<PTRef> processedFormulas = preprocessFormulasPerPartition(frame.formulas, context);
+    for (PTRef fla : processedFormulas) {
+        status = giveToSolver(fla, frameId);
+        if (status == s_False) { return false; }
+    }
+
+    assert(status != s_False);
+    return true;
 }
 
 PTRef MainSolver::preprocessFormulasConjoined(vec<PTRef> const & flas, PreprocessingContext const & context) {

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -138,63 +138,124 @@ bool MainSolver::tryAddTermNameFor(PTRef fla, std::string const & name) {
     return termNames.tryInsert(name, fla);
 }
 
-sstat MainSolver::simplifyFormulas() {
+sstat MainSolver::preprocessAssertions() {
     status = s_Undef;
-    for (std::size_t i = firstNotSimplifiedFrame; i < frames.frameCount() && status != s_False; i++) {
+    for (std::size_t i = firstNotSimplifiedFrame; i < frames.frameCount(); ++i) {
+        auto & frame = frames[i];
+        FrameId const frameId = frame.getId();
         PreprocessingContext context{.frameCount = i, .perPartition = trackPartitions()};
         preprocessor.prepareForProcessingFrame(i);
         firstNotSimplifiedFrame = i + 1;
-        if (context.perPartition) {
-            vec<PTRef> frameFormulas;
-            for (PTRef fla : frames[i].formulas) {
-                PTRef processed = theory->preprocessAfterSubstitutions(fla, context);
-                pmanager.transferPartitionMembership(fla, processed);
-                frameFormulas.push(processed);
-                preprocessor.addPreprocessedFormula(processed);
-            }
-            if (frameFormulas.size() == 0 or std::all_of(frameFormulas.begin(), frameFormulas.end(),
-                                                         [&](PTRef fla) { return fla == logic.getTerm_true(); })) {
-                continue;
-            }
-            theory->afterPreprocessing(preprocessor.getPreprocessedFormulas());
-            for (PTRef fla : frameFormulas) {
-                if (fla == logic.getTerm_true()) { continue; }
-                assert(pmanager.getPartitionIndex(fla) != -1);
-                // Optimize the dag for cnfization
-                if (logic.isBooleanOperator(fla)) {
-                    PTRef old = fla;
-                    fla = rewriteMaxArity(fla);
-                    pmanager.transferPartitionMembership(old, fla);
-                }
-                assert(pmanager.getPartitionIndex(fla) != -1);
-                pmanager.propagatePartitionMask(fla);
-                status = giveToSolver(fla, frames[i].getId());
+
+        if (not context.perPartition) {
+            PTRef frameFormula = preprocessFormulasConjoined(frame.formulas, context);
+            status = giveToSolver(frameFormula, frameId);
+        } else {
+            vec<PTRef> processedFormulas = preprocessFormulasPerPartition(frame.formulas, context);
+            for (PTRef fla : processedFormulas) {
+                status = giveToSolver(fla, frameId);
                 if (status == s_False) { break; }
             }
-        } else {
-            PTRef frameFormula = logic.mkAnd(frames[i].formulas);
-            if (context.frameCount > 0) { frameFormula = applyLearntSubstitutions(frameFormula); }
-            frameFormula = theory->preprocessBeforeSubstitutions(frameFormula, context);
-            frameFormula = substitutionPass(frameFormula, context);
-            frameFormula = theory->preprocessAfterSubstitutions(frameFormula, context);
-
-            if (logic.isFalse(frameFormula)) {
-                giveToSolver(logic.getTerm_false(), frames[i].getId());
-                status = s_False;
-                break;
-            }
-            preprocessor.addPreprocessedFormula(frameFormula);
-            theory->afterPreprocessing(preprocessor.getPreprocessedFormulas());
-            // Optimize the dag for cnfization
-            if (logic.isBooleanOperator(frameFormula)) { frameFormula = rewriteMaxArity(frameFormula); }
-            status = giveToSolver(frameFormula, frames[i].getId());
         }
+        if (status == s_False) { break; }
     }
+
     if (status == s_False) {
         assert(firstNotSimplifiedFrame > 0);
         rememberUnsatFrame(firstNotSimplifiedFrame - 1);
     }
+
     return status;
+}
+
+PTRef MainSolver::preprocessFormulasConjoined(vec<PTRef> const & flas, PreprocessingContext const & context) {
+    assert(not context.perPartition);
+
+    if (flas.size() == 0) { return logic.getTerm_true(); }
+
+    PTRef fla = logic.mkAnd(flas);
+    return preprocessFormula(fla, context);
+}
+
+vec<PTRef> MainSolver::preprocessFormulasPerPartition(vec<PTRef> const & flas, PreprocessingContext const & context) {
+    assert(context.perPartition);
+
+    if (flas.size() == 0) { return {}; }
+
+    vec<PTRef> processedFormulas;
+    for (PTRef fla : flas) {
+        PTRef processed = preprocessFormulaBeforeGlobalPhase(fla, context);
+        processedFormulas.push(processed);
+    }
+
+    assert(processedFormulas.size() == flas.size());
+    if (std::all_of(processedFormulas.begin(), processedFormulas.end(),
+                    [&](PTRef fla) { return fla == logic.getTerm_true(); })) {
+        return {};
+    }
+
+    preprocessFormulaGlobalPhase(context);
+
+    for (PTRef & fla : processedFormulas) {
+        if (fla == logic.getTerm_true()) { continue; }
+        fla = preprocessFormulaAfterGlobalPhase(fla, context);
+    }
+
+    return processedFormulas;
+}
+
+PTRef MainSolver::preprocessFormula(PTRef fla, PreprocessingContext const & context) {
+    PTRef processed = preprocessFormulaBeforeGlobalPhase(fla, context);
+    preprocessFormulaGlobalPhase(context);
+    processed = preprocessFormulaAfterGlobalPhase(processed, context);
+    return processed;
+}
+
+PTRef MainSolver::preprocessFormulaBeforeGlobalPhase(PTRef fla, PreprocessingContext const & context) {
+    bool const perPartition = context.perPartition;
+    PTRef processed = fla;
+
+    if (not perPartition) {
+        if (context.frameCount > 0) { processed = applyLearntSubstitutions(processed); }
+        processed = theory->preprocessBeforeSubstitutions(processed, context);
+        processed = substitutionPass(processed, context);
+    }
+
+    processed = theory->preprocessAfterSubstitutions(processed, context);
+
+    if (perPartition) {
+        pmanager.transferPartitionMembership(fla, processed);
+    } else if (logic.isFalse(processed)) {
+        return logic.getTerm_false();
+    }
+
+    preprocessor.addPreprocessedFormula(processed);
+
+    return processed;
+}
+
+void MainSolver::preprocessFormulaGlobalPhase(PreprocessingContext const &) {
+    theory->afterPreprocessing(preprocessor.getPreprocessedFormulas());
+}
+
+PTRef MainSolver::preprocessFormulaAfterGlobalPhase(PTRef fla, PreprocessingContext const & context) {
+    bool const perPartition = context.perPartition;
+    PTRef processed = fla;
+
+    assert(not perPartition or pmanager.getPartitionIndex(processed) != -1);
+
+    // Optimize the dag for cnfization
+    if (logic.isBooleanOperator(processed)) {
+        processed = rewriteMaxArity(processed);
+        if (perPartition) { pmanager.transferPartitionMembership(fla, processed); }
+    }
+
+    if (perPartition) {
+        assert(pmanager.getPartitionIndex(processed) != -1);
+        pmanager.propagatePartitionMask(processed);
+    }
+
+    return processed;
 }
 
 vec<PTRef> MainSolver::getCurrentAssertions() const {
@@ -316,11 +377,15 @@ sstat MainSolver::giveToSolver(PTRef root, FrameId push_id) {
         std::vector<vec<Lit>> clauses;
         void operator()(vec<Lit> && c) override { clauses.push_back(std::move(c)); }
     };
+
+    if (root == logic.getTerm_true()) { return s_Undef; }
+
     ClauseCallBack callBack;
     ts.setClauseCallBack(&callBack);
     ts.Cnfizer::cnfize(root, push_id);
     bool const keepPartitionsSeparate = trackPartitions();
-    Lit frameLit = push_id == 0 ? Lit{} : term_mapper->getOrCreateLit(frameTerms[push_id]);
+    [[maybe_unused]] Lit frameLit;
+    if (push_id != 0) { frameLit = term_mapper->getOrCreateLit(frameTerms[push_id]); }
     int partitionIndex = keepPartitionsSeparate ? pmanager.getPartitionIndex(root) : -1;
     for (auto & clause : callBack.clauses) {
         if (push_id != 0) { clause.push(frameLit); }
@@ -347,7 +412,7 @@ sstat MainSolver::check() {
         StopWatch sw(query_timer);
     }
     if (isLastFrameUnsat()) { return s_False; }
-    sstat rval = simplifyFormulas();
+    sstat rval = preprocessAssertions();
 
     if (config.dump_query()) printCurrentAssertionsAsQuery();
 

--- a/src/api/MainSolver.cc
+++ b/src/api/MainSolver.cc
@@ -93,7 +93,7 @@ bool MainSolver::pop() {
     frames.pop();
     preprocessor.pop();
     termNames.popScope();
-    firstNotSimplifiedFrame = std::min(firstNotSimplifiedFrame, frames.frameCount());
+    firstNotPreprocessedFrame = std::min(firstNotPreprocessedFrame, frames.frameCount());
     if (not isLastFrameUnsat()) { getSMTSolver().restoreOK(); }
     return true;
 }
@@ -115,15 +115,15 @@ void MainSolver::insertFormula(PTRef fla) {
         // formulas,
         //     thus we need the old value of count. TODO: Find a good interface for this so it cannot be broken this
         //     easily
-        unsigned int partition_index = insertedFormulasCount++;
+        unsigned int partition_index = addedAssertionsCount++;
         pmanager.assignTopLevelPartitionIndex(partition_index, fla);
         assert(pmanager.getPartitionIndex(fla) != -1);
     } else {
-        ++insertedFormulasCount;
+        ++addedAssertionsCount;
     }
 
     frames.add(fla);
-    firstNotSimplifiedFrame = std::min(firstNotSimplifiedFrame, frames.frameCount() - 1);
+    firstNotPreprocessedFrame = std::min(firstNotPreprocessedFrame, frames.frameCount() - 1);
 }
 
 bool MainSolver::tryAddNamedAssertion(PTRef fla, std::string const & name) {
@@ -140,12 +140,12 @@ bool MainSolver::tryAddTermNameFor(PTRef fla, std::string const & name) {
 
 sstat MainSolver::preprocessAssertions() {
     status = s_Undef;
-    for (std::size_t i = firstNotSimplifiedFrame; i < frames.frameCount(); ++i) {
+    for (std::size_t i = firstNotPreprocessedFrame; i < frames.frameCount(); ++i) {
         auto & frame = frames[i];
         FrameId const frameId = frame.getId();
         PreprocessingContext context{.frameCount = i, .perPartition = trackPartitions()};
         preprocessor.prepareForProcessingFrame(i);
-        firstNotSimplifiedFrame = i + 1;
+        firstNotPreprocessedFrame = i + 1;
 
         if (not context.perPartition) {
             PTRef frameFormula = preprocessFormulasConjoined(frame.formulas, context);
@@ -161,8 +161,8 @@ sstat MainSolver::preprocessAssertions() {
     }
 
     if (status == s_False) {
-        assert(firstNotSimplifiedFrame > 0);
-        rememberUnsatFrame(firstNotSimplifiedFrame - 1);
+        assert(firstNotPreprocessedFrame > 0);
+        rememberUnsatFrame(firstNotPreprocessedFrame - 1);
     }
 
     return status;

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -104,7 +104,9 @@ public:
     sstat solve();
     // Simplify formulas until all are simplified or the instance is detected unsat
     // Skip assertion levels that have already been simplified
-    sstat simplifyFormulas();
+    sstat simplifyFormulas() { return preprocessAssertions(); }
+    // Alias for `simplifyFormulas`, reserved for future use
+    sstat preprocessAssertions();
 
     [[nodiscard]] sstat getStatus() const { return status; }
 
@@ -288,6 +290,15 @@ protected:
     }
 
     inline bool trackPartitions() const;
+
+    // Usually applied to frame formulas
+    virtual PTRef preprocessFormulasConjoined(vec<PTRef> const &, PreprocessingContext const &);
+    virtual vec<PTRef> preprocessFormulasPerPartition(vec<PTRef> const &, PreprocessingContext const &);
+
+    virtual PTRef preprocessFormula(PTRef, PreprocessingContext const &);
+    virtual PTRef preprocessFormulaBeforeGlobalPhase(PTRef, PreprocessingContext const &);
+    virtual void preprocessFormulaGlobalPhase(PreprocessingContext const &);
+    virtual PTRef preprocessFormulaAfterGlobalPhase(PTRef, PreprocessingContext const &);
 
     PTRef rewriteMaxArity(PTRef root);
 

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -89,9 +89,10 @@ public:
     void insertFormula(PTRef fla);
     // Alias for `insertFormula`, reserved for future use
     void addAssertion(PTRef fla) { return insertFormula(fla); }
-    std::size_t getInsertedFormulasCount() const { return insertedFormulasCount; }
+    // Returns the number of successful calls to `insertFormula` (i.e., not the current no. formulas)
+    std::size_t getInsertedFormulasCount() const { return addedAssertionsCount; }
     // Alias for `getInsertedFormulasCount`, reserved for future use
-    std::size_t getAssertionsCount() const { return getInsertedFormulasCount(); }
+    std::size_t getAddedAssertionsCount() const { return getInsertedFormulasCount(); }
 
     // Uses tryAddTermName and inserts the formula only on success
     bool tryAddNamedAssertion(PTRef, std::string const & name);
@@ -333,8 +334,8 @@ private:
     int check_called = 0;    // A counter on how many times check was called.
 
     vec<PTRef> frameTerms;
-    std::size_t firstNotSimplifiedFrame = 0;
-    unsigned int insertedFormulasCount = 0;
+    std::size_t firstNotPreprocessedFrame = 0;
+    std::size_t addedAssertionsCount = 0;
 };
 
 bool MainSolver::trackPartitions() const {

--- a/src/api/MainSolver.h
+++ b/src/api/MainSolver.h
@@ -292,6 +292,8 @@ protected:
 
     inline bool trackPartitions() const;
 
+    virtual bool tryPreprocessFrame(std::size_t);
+
     // Usually applied to frame formulas
     virtual PTRef preprocessFormulasConjoined(vec<PTRef> const &, PreprocessingContext const &);
     virtual vec<PTRef> preprocessFormulasPerPartition(vec<PTRef> const &, PreprocessingContext const &);


### PR DESCRIPTION
This is just a refactoring. The behavior or performance should not change.

This makes the preprocessing more maintainable, allows overriding particular parts, and also allows preprocessing single formulas without necessarily giving them to the SMT solver with `giveToSolver`.

Also added `preprocessAssertions` as an alias to `simplifyFormulas`.