### PR TITLE
Updated MacOS CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
     build-macos:
         macos:
             xcode: 15.4.0
-        resource_class: macos.m1.medium.gen1
+        resource_class: m4pro.medium
         steps:
             - run:
                 name: Packages


### PR DESCRIPTION
Mac M1 and M2 resource classes (we used `macos.m1.medium.gen1`) are soon to be deprecated:
https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/